### PR TITLE
OpenVPN: Deal with comp-lzo migration

### DIFF
--- a/Sources/OpenVPN/Legacy/Internal/Authenticator.swift
+++ b/Sources/OpenVPN/Legacy/Internal/Authenticator.swift
@@ -85,18 +85,7 @@ final class Authenticator {
                 "V4",
                 "dev-type tun"
             ]
-            if let comp = options.compressionFraming {
-                switch comp {
-                case .compLZO:
-                    opts.append("comp-lzo")
-
-                case .compress:
-                    opts.append("compress")
-
-                default:
-                    break
-                }
-            }
+            opts.append("comp-lzo")
             if let direction = options.tlsWrap?.key.direction?.rawValue {
                 opts.append("keydir \(direction)")
             }


### PR DESCRIPTION
Always include "comp-lzo" in the local options to trigger the server inclusion of "comp-lzo" in the PUSH_REPLY if necessary. In fact, the local options were never meant to include the compression framing used in the .ovpn configuration file.

Fixes #140