### PR TITLE
WireGuard: Retain workaround for buggy Apple IPv6

### DIFF
--- a/Sources/PartoutWireGuard/Cross/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuard/Cross/Internal/TunnelRemoteInfoGenerator.swift
@@ -114,7 +114,13 @@ final class TunnelRemoteInfoGenerator: Sendable {
             case .ip(_, let family):
                 switch family {
                 case .v4: ipv4.append(subnet)
-                case .v6: ipv6.append(subnet)
+                case .v6:
+                    /* Big fat ugly hack for broken iOS networking stack: the smallest prefix that will have
+                     * any effect on iOS is a /120, so we clamp everything above to /120. This is potentially
+                     * very bad, if various network parameters were actually relying on that subnet being
+                     * intentionally small. TODO: talk about this with upstream iOS devs.
+                     */
+                    ipv6.append(Subnet(subnet.address, min(120, subnet.prefixLength)))
                 }
             default:
                 break


### PR DESCRIPTION
Copy as is from WireGuardKit upstream. Despite the comment, the bug affects all Apple devices, not only iOS.