### PR TITLE
WireGuard/Cross: Fix concurrency crash in DNS resolution

### DIFF
--- a/Sources/PartoutOS/Portable/POSIXBlockingSocket.swift
+++ b/Sources/PartoutOS/Portable/POSIXBlockingSocket.swift
@@ -15,14 +15,16 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
 
     private let writeQueue: DispatchQueue
 
-    private nonisolated(unsafe) let sock: pp_socket
+    nonisolated(unsafe)
+    private let sock: pp_socket
 
     private let endpoint: ExtendedEndpoint?
 
     private let closesOnEmptyRead: Bool
 
     // FIXME: #188, how to avoid silent copy? (enforce reference)
-    private nonisolated(unsafe) var readBuf: [UInt8]
+    nonisolated(unsafe)
+    private var readBuf: [UInt8]
 
     private var isActive = false
 

--- a/Sources/PartoutOS/Portable/VirtualTunnelController.swift
+++ b/Sources/PartoutOS/Portable/VirtualTunnelController.swift
@@ -13,7 +13,8 @@ import PartoutCore
 public final class VirtualTunnelController: TunnelController {
     private let ctx: PartoutLoggerContext
 
-    private nonisolated(unsafe) let ctrl: partout_tun_ctrl?
+    nonisolated(unsafe)
+    private let ctrl: partout_tun_ctrl?
 
     private let maxReadLength: Int
 

--- a/Sources/PartoutOS/Portable/VirtualTunnelInterface.swift
+++ b/Sources/PartoutOS/Portable/VirtualTunnelInterface.swift
@@ -13,7 +13,8 @@ import PartoutCore
 public final class VirtualTunnelInterface: IOInterface, @unchecked Sendable {
     private let ctx: PartoutLoggerContext
 
-    private nonisolated(unsafe) let tun: pp_tun
+    nonisolated(unsafe)
+    private let tun: pp_tun
 
     public let tunImpl: UnsafeMutableRawPointer?
 


### PR DESCRIPTION
Concurrent access to dictionary with side-effect. Could have been causing this crash in Passepartout 3.5.15:

```
Thread 2 Crashed:
0   libswiftCore.dylib            	0x00000001945986cc swift_isUniquelyReferenced_nonNull_native + 0 (SwiftObject.mm:1498)
1   PassepartoutTunnel            	0x000000010474de00 specialized Dictionary._Variant.isUniquelyReferenced() + 8 (/<compiler-generated>:0)
2   PassepartoutTunnel            	0x000000010474de00 specialized Dictionary._Variant.setValue(_:forKey:) + 8 (/<compiler-generated>:0)
3   PassepartoutTunnel            	0x000000010474de00 specialized Dictionary.subscript.setter + 8 (/<compiler-generated>:0)
4   PassepartoutTunnel            	0x000000010474de00 closure #1 in closure #2 in WireGuard.Configuration.resolvePeers(timeout:logHandler:) + 892 (Configuration+Resolve.swift:40)
5   PassepartoutTunnel            	0x00000001044f1ce9 <deduplicated_symbol> + 1
6   PassepartoutTunnel            	0x00000001044efd1d <deduplicated_symbol> + 1
7   PassepartoutTunnel            	0x00000001044ef981 <deduplicated_symbol> + 1
8   libswift_Concurrency.dylib    	0x000000019592fb75 completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*) + 1 (Task.cpp:546)
```