### PR TITLE
Inject pp_log into C code

### DIFF
--- a/Sources/PartoutCore/Logging/PPLog.swift
+++ b/Sources/PartoutCore/Logging/PPLog.swift
@@ -42,3 +42,16 @@ public func pp_log(
     }
     logger.appendLog(level, message: ctxMessage)
 }
+
+/// Logs to the global context from C code.
+@_cdecl("pp_clog")
+func pp_clog(
+    _ cCategory: UnsafePointer<CChar>,
+    _ cLevel: Int,
+    _ cMessage: UnsafePointer<CChar>
+) {
+    let category = LoggerCategory(rawValue: String(cString: cCategory))
+    let level = DebugLog.Level(rawValue: cLevel) ?? .info
+    let message = String(cString: cMessage)
+    pp_log_g(category, level, message)
+}

--- a/Sources/PartoutCore_C/common.c
+++ b/Sources/PartoutCore_C/common.c
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include <stdarg.h>
+#include "portable/common.h"
+
+pp_log_category PPLogCategoryCore = "core";
+
+void pp_clog_v(pp_log_category category,
+               pp_log_level level,
+               const char *_Nonnull fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    // Add 1 to include the null terminator
+    const size_t msg_len = 1 + vsnprintf(NULL, 0, fmt, args);
+    char *msg = pp_alloc(msg_len);
+    vsnprintf(msg, msg_len, fmt, args);
+    va_end(args);
+    pp_clog(category, level, msg);
+    pp_free(msg);
+}

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -12,6 +12,27 @@
 #include <stdlib.h>
 #include <string.h>
 
+// Logging counterpart of Swift pp_log
+
+typedef enum {
+    PPLogLevelDebug,
+    PPLogLevelInfo,
+    PPLogLevelNotice,
+    PPLogLevelError,
+    PPLogLevelFault
+} pp_log_level;
+
+typedef const char *_Nonnull pp_log_category;
+extern pp_log_category PPLogCategoryCore;
+
+extern void pp_clog(pp_log_category category,
+                    pp_log_level level,
+                    const char *_Nonnull message);
+
+void pp_clog_v(pp_log_category category,
+               pp_log_level level,
+               const char *_Nonnull fmt, ...);
+
 // Use inline rather than #define to make available to Swift
 
 static inline
@@ -23,7 +44,7 @@ static inline
 void *_Nonnull pp_alloc(size_t size) {
     void *memory = calloc(1, size);
     if (!memory) {
-        fputs("pp_alloc: malloc() call failed", stderr);
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "pp_alloc: malloc() call failed");
         abort();
     }
     return memory;
@@ -52,7 +73,7 @@ char *_Nonnull pp_dup(const char *_Nonnull str) {
     char *ptr = strdup(str);
 #endif
     if (!ptr) {
-        fputs("pp_dup: strdup() call failed", stderr);
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "pp_dup: strdup() call failed");
         abort();
     }
     return ptr;

--- a/Sources/PartoutCore_C/lib.c
+++ b/Sources/PartoutCore_C/lib.c
@@ -30,7 +30,7 @@ pp_lib pp_lib_create(const char *path) {
     snprintf(path_ext, path_len, "%s.dll", path);
     HMODULE handle = LoadLibraryExA(path_ext, NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!handle) {
-        fprintf(stderr, "LoadLibraryExA(): %lu\n", GetLastError());
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "LoadLibraryExA(): %lu", GetLastError());
         goto failure;
     }
 #else
@@ -41,7 +41,7 @@ pp_lib pp_lib_create(const char *path) {
 #endif
     void *handle = dlopen(path_ext, RTLD_NOW);
     if (!handle) {
-        fprintf(stderr, "dlopen(): %s\n", dlerror());
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "dlopen(): %s", dlerror());
         goto failure;
     }
 #endif
@@ -72,7 +72,7 @@ void *pp_lib_load(const pp_lib lib, const char *symbol) {
     void *ptr = dlsym(lib->handle, symbol);
 #endif
     if (!ptr) {
-        fprintf(stderr, "%s not found in library\n", symbol);
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s not found in library", symbol);
         return NULL;
     }
     return ptr;

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -11,7 +11,7 @@
 #define OS_INVALID_SOCKET INVALID_SOCKET
 #define os_close_socket closesocket
 #define SOCKET_PRINT_ERROR(msg) \
-    fprintf(stderr, "%s failed with error %d\n", msg, WSAGetLastError())
+    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed with error %d", msg, WSAGetLastError())
 #else
 #include <unistd.h>
 #include <sys/types.h>
@@ -22,7 +22,7 @@
 #define OS_INVALID_SOCKET -1
 #define os_close_socket close
 #define SOCKET_PRINT_ERROR(msg) \
-    fprintf(stderr, "%s failed: %s\n", msg, strerror(errno))
+    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed: %s", msg, strerror(errno))
 #endif
 
 #include <stdio.h>

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -22,7 +22,7 @@ pp_tun pp_tun_create(const char *_Nonnull uuid, const void *_Nullable any_impl) 
     pp_tun impl = (pp_tun)any_impl;
     pp_assert(impl && impl->fd > 0);
 
-    printf("tun_android: Created tun device %d\n", impl->fd);
+    pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_android: Created tun device %d", impl->fd);
     return impl;
 }
 

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -34,7 +34,7 @@ pp_tun pp_tun_create(const char *_Nonnull uuid, const void *_Nullable impl) {
      * consistent across distros for coming from the kernel. */
     fd = open(dev_path, O_RDWR);
     if (fd < 0) {
-        perror("open(tun)");
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "open(tun)");
         goto failure;
     }
 
@@ -42,11 +42,11 @@ pp_tun pp_tun_create(const char *_Nonnull uuid, const void *_Nullable impl) {
      * the first available device number */
     ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
     if (ioctl(fd, TUNSETIFF, (void *)&ifr) < 0) {
-        perror("ioctl(TUNSETIFF)");
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctl(TUNSETIFF)");
         goto failure;
     }
 
-    printf("tun_linux: Created tun device %s\n", ifr.ifr_name);
+    pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: Created tun device %s", ifr.ifr_name);
     pp_tun tun = pp_alloc(sizeof(*tun));
     tun->fd = fd;
     tun->dev_name = pp_dup(ifr.ifr_name);

--- a/Sources/PartoutCore_C/zd.c
+++ b/Sources/PartoutCore_C/zd.c
@@ -118,7 +118,7 @@ void pp_zd_resize(pp_zd *zd, size_t new_length) {
     pp_assert(zd);
     if (new_length == zd->length) return;
 
-    // FIXME: #190, Do not reallocate if new length is shorter, track allocated length though
+    // TODO: #178/notes, Do not reallocate if new length is shorter, track allocated length though
     uint8_t *new_bytes = pp_alloc(new_length);
     if (new_length < zd->length) {
         memcpy(new_bytes, zd->bytes, new_length);

--- a/Sources/PartoutOS/AppleNE/Connection/NESocket.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NESocket.swift
@@ -125,6 +125,7 @@ private extension NESocketObserver {
 
 // MARK: - NESocket
 
+// FIXME: #190, Deprecated NEUDPSocket/NETCPSocket use far less CPU %
 private actor NESocket: LinkInterface {
     private let queue: DispatchQueue
 

--- a/Sources/PartoutOpenVPN/Cross/Internal/OpenVPNTCPLink.swift
+++ b/Sources/PartoutOpenVPN/Cross/Internal/OpenVPNTCPLink.swift
@@ -61,7 +61,7 @@ extension OpenVPNTCPLink: LinkInterface {
                 return
             }
 
-            // FIXME: #190, This is very inefficient (TCP)
+            // FIXME: #214, TCP is very slow
             buffer.reserveCapacity(buffer.count + packets.flatCount)
             for p in packets {
                 buffer += p

--- a/Sources/PartoutOpenVPN/Legacy/Internal/LegacyOpenVPNTCPLink.swift
+++ b/Sources/PartoutOpenVPN/Legacy/Internal/LegacyOpenVPNTCPLink.swift
@@ -61,7 +61,7 @@ extension LegacyOpenVPNTCPLink: LinkInterface {
                 return
             }
 
-            // FIXME: #190, This is very inefficient (TCP)
+            // FIXME: #214, TCP is very slow
             buffer.reserveCapacity(buffer.count + packets.flatCount)
             for p in packets {
                 buffer += p

--- a/Sources/PartoutOpenVPN_C/include/openvpn/dp_macros.h
+++ b/Sources/PartoutOpenVPN_C/include/openvpn/dp_macros.h
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "openvpn/logging.h"
 #include "openvpn/packet.h"
 
 #define OPENVPN_DP_ENCRYPT_BEGIN(peerId) \
@@ -34,8 +35,8 @@
     }
 
 #ifdef OPENVPN_DP_DEBUG
-#define OPENVPN_DP_LOG(msg)         fprintf(stderr, "%s\n", msg)
-#define OPENVPN_DP_LOG_F(fmt, ...)  fprintf(stderr, fmt, __VA_ARGS__)
+#define OPENVPN_DP_LOG(msg)         pp_clog_v(PPLogCategoryOpenVPN, PPLogLevelInfo, "%s", msg)
+#define OPENVPN_DP_LOG_F(fmt, ...)  pp_clog_v(PPLogCategoryOpenVPN, PPLogLevelInfo, fmt, __VA_ARGS__)
 #else
 #define OPENVPN_DP_LOG(msg)         (void)0
 #define OPENVPN_DP_LOG_F(fmt, ...)  (void)0

--- a/Sources/PartoutOpenVPN_C/include/openvpn/logging.h
+++ b/Sources/PartoutOpenVPN_C/include/openvpn/logging.h
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include "portable/common.h"
+
+extern pp_log_category PPLogCategoryOpenVPN;

--- a/Sources/PartoutOpenVPN_C/logging.c
+++ b/Sources/PartoutOpenVPN_C/logging.c
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include "openvpn/logging.h"
+
+pp_log_category PPLogCategoryOpenVPN = "openvpn";

--- a/Sources/PartoutWireGuard_C/include/wireguard/logging.h
+++ b/Sources/PartoutWireGuard_C/include/wireguard/logging.h
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include "portable/common.h"
+
+extern pp_log_category PPLogCategoryWireGuard;

--- a/Sources/PartoutWireGuard_C/logging.c
+++ b/Sources/PartoutWireGuard_C/logging.c
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include "wireguard/logging.h"
+
+pp_log_category PPLogCategoryWireGuard = "wireguard";

--- a/Sources/PartoutWireGuard_C/wireguard.c
+++ b/Sources/PartoutWireGuard_C/wireguard.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include "portable/lib.h"
+#include "wireguard/logging.h"
 #include "wireguard/wireguard.h"
 
 /* The WireGuard API is declared as local function pointers, so
@@ -86,8 +87,7 @@ int load_symbols() {
 
 int pp_wg_init() {
     if (load_symbols() != 0) return -1;
-    // FIXME: #205, fprintf
-    fprintf(stderr, "wg-go version: %s\n", pp_wg_version());
+    pp_clog_v(PPLogCategoryWireGuard, PPLogLevelInfo, "wg-go version: %s", pp_wg_version());
     return 0;
 }
 


### PR DESCRIPTION
- Add internal pp_clog wrapper for C code
- Add C counterparts of pp_log arguments
- Replace puts()
- Replace perror()
- Add simple pp_clog varargs variant
- Replace printf() with pp_clog_v()
- Update FIXMEs

Fixes #205