### PR TITLE
WireGuard/Cross: Extend reachability condition

### DIFF
--- a/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
@@ -57,7 +57,8 @@ extension NEObservablePath {
                         pp_log(self.ctx, .os, .debug, "Cancelled NEObservablePath.isReachableStream")
                         break
                     }
-                    let reachable = path.status == .satisfied
+                    let reachable = path.status.isSatisfiable
+                    // Strip dups, is this ideal?
                     guard reachable != previous else {
                         continue
                     }
@@ -66,6 +67,19 @@ extension NEObservablePath {
                 }
                 continuation.finish()
             }
+        }
+    }
+}
+
+private extension NWPath.Status {
+    var isSatisfiable: Bool {
+        switch self {
+        case .requiresConnection, .satisfied:
+            return true
+        case .unsatisfied:
+            return false
+        @unknown default:
+            return true
         }
     }
 }

--- a/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
@@ -98,10 +98,8 @@ actor WireGuardAdapter {
         self.dnsTimeout = dnsTimeout
         backend = WireGuardBackend()
         self.reachability = reachability
-        reachabilityTask = nil
         self.logHandler = logHandler
 
-        setupReachabilityTask()
         setupLogHandler()
     }
 
@@ -140,6 +138,7 @@ actor WireGuardAdapter {
         guard case .stopped = state else {
             throw WireGuardAdapterError.invalidState
         }
+        setupReachabilityTask()
         do {
             let settingsGenerator = makeSettingsGenerator(with: tunnelConfiguration)
             let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
@@ -223,6 +222,7 @@ actor WireGuardAdapter {
     // MARK: - Private methods
 
     private func setupReachabilityTask() {
+        reachabilityTask?.cancel()
         reachabilityTask = Task { [weak self] in
             guard let self else { return }
             for await isReachable in reachability.isReachableStream {

--- a/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
@@ -98,8 +98,10 @@ actor WireGuardAdapter {
         self.dnsTimeout = dnsTimeout
         backend = WireGuardBackend()
         self.reachability = reachability
+        reachabilityTask = nil
         self.logHandler = logHandler
 
+        setupReachabilityTask()
         setupLogHandler()
     }
 
@@ -138,7 +140,6 @@ actor WireGuardAdapter {
         guard case .stopped = state else {
             throw WireGuardAdapterError.invalidState
         }
-        setupReachabilityTask()
         do {
             let settingsGenerator = makeSettingsGenerator(with: tunnelConfiguration)
             let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
@@ -222,7 +223,6 @@ actor WireGuardAdapter {
     // MARK: - Private methods
 
     private func setupReachabilityTask() {
-        reachabilityTask?.cancel()
         reachabilityTask = Task { [weak self] in
             guard let self else { return }
             for await isReachable in reachability.isReachableStream {


### PR DESCRIPTION
Path allows connection except when explicitly .unsatisfied, reuse condition from WireGuardKit. Delete unused WireGuardAdapter.update() method (dead code).