### PR TITLE
WireGuard/Cross: Recover from lost reachability and DNS failure

### DIFF
--- a/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
@@ -27,7 +27,7 @@ public final class NEObservablePath: ReachabilityObserver {
             guard let self else {
                 return
             }
-            pp_log(ctx, .os, .debug, "Path updated: \(path.debugDescription)")
+            pp_log(ctx, .os, .info, "Path updated: \(path.debugDescription)")
             subject.send(path)
         }
         monitor.start(queue: .global())

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
@@ -40,8 +40,7 @@ extension NEObservablePath {
     }
 
     public var isReachable: Bool {
-        // XXX: WireGuard suggests including .requiresConnection
-        subject.value.status == .satisfied
+        subject.value.isSatisfiable
     }
 
     public var isReachableStream: AsyncStream<Bool> {
@@ -65,15 +64,15 @@ extension NEObservablePath {
     }
 }
 
-private extension NWPath.Status {
+private extension NWPath {
     var isSatisfiable: Bool {
-        switch self {
-        case .requiresConnection, .satisfied:
-            return true
-        case .unsatisfied:
-            return false
-        @unknown default:
-            return true
+        let target: [NWInterface.InterfaceType] = [
+            .cellular, .wifi, .wiredEthernet
+        ]
+        let isAvailable = target.contains {
+            usesInterfaceType($0)
         }
+        guard isAvailable else { return false }
+        return status == .satisfied
     }
 }

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
@@ -51,19 +51,13 @@ extension NEObservablePath {
                     continuation.finish()
                     return
                 }
-                var previous: Bool?
                 for await path in self.stream {
                     guard !Task.isCancelled else {
                         pp_log(self.ctx, .os, .debug, "Cancelled NEObservablePath.isReachableStream")
                         break
                     }
-                    let reachable = path.status.isSatisfiable
-                    // Strip dups, is this ideal?
-                    guard reachable != previous else {
-                        continue
-                    }
+                    let reachable = path.isSatisfiable
                     continuation.yield(reachable)
-                    previous = reachable
                 }
                 continuation.finish()
             }

--- a/Sources/PartoutWireGuard/Cross/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuard/Cross/Internal/TunnelRemoteInfoGenerator.swift
@@ -41,6 +41,9 @@ final class TunnelRemoteInfoGenerator: Sendable {
         let resolutionMap = await tunnelConfiguration.resolvePeers(timeout: dnsTimeout) {
             logHandler($0, $1)
         }
+        guard !resolutionMap.isEmpty else {
+            throw PartoutError(.dnsFailure)
+        }
 
         for peer in tunnelConfiguration.peers {
             let publicKey = try peer.publicKey.rawValue.hexStringFromBase64()

--- a/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
@@ -249,7 +249,13 @@ actor WireGuardAdapter {
 #if os(iOS)
         backend.disableSomeRoamingForBrokenMobileSemantics(handle)
 #endif
-        let socketFds = backend.socketDescriptors(handle)
+        let socketFds = {
+            var rawFds = backend.socketDescriptors(handle)
+            if rawFds.isEmpty {
+                rawFds = fallbackFileDescriptor.map { [$0] } ?? []
+            }
+            return rawFds
+        }()
         pp_log(ctx, .wireguard, .info, "Socket descriptors: \(socketFds)")
         delegate?.adapterShouldConfigureSockets(self, descriptors: socketFds.map(UInt64.init))
         return handle

--- a/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
@@ -187,6 +187,7 @@ actor WireGuardAdapter {
                     try await didUpdateReachable(isReachable: isReachable)
                 } catch {
                     pp_log(ctx, .wireguard, .error, "Unable to update reachability: \(error)")
+                    try? await stop()
                 }
             }
         }

--- a/Sources/PartoutWireGuard/Cross/WireGuardConnection.swift
+++ b/Sources/PartoutWireGuard/Cross/WireGuardConnection.swift
@@ -279,8 +279,7 @@ private extension WireGuardLogLevel {
     var debugLevel: DebugLog.Level {
         switch self {
         case .verbose:
-            return .debug
-
+            return .info
         case .error:
             return .error
         }


### PR DESCRIPTION
- Observe some interfaces in particular (cellular, Wi-Fi, ethernet)
- Use NWPath.usesInterfaceType() for better reliability
- Treat empty resolved endpoints as DNS failure
- Recover from DNS failure by shutting down the connection
- Increase log level for troubleshooting

Revisits #254 deeply.