### PR TITLE
WireGuard/Cross: Skip handshake on path update while active

### DIFF
--- a/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuard/Cross/Internal/WireGuardAdapter.swift
@@ -276,7 +276,7 @@ actor WireGuardAdapter {
         switch state {
         case .started(let handle, let settingsGenerator):
             if isReachable {
-                let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
+                let wgConfig = try await settingsGenerator.endpointUapiConfiguration(logHandler: logHandler)
 
                 backend.setConfig(handle, settings: wgConfig)
                 backend.disableSomeRoamingForBrokenMobileSemantics(handle)


### PR DESCRIPTION
Cross is handling path updates fine, but sending the full UAPI configuration triggers a new handshake even if the tunnel is already active. On path updates, update the endpoints instead, like legacy does by sending endpointUapiConfiguration() to the backend instead of uapiConfiguration(). This was a slip-up when porting WireGuardAdapter.