### PR TITLE
OpenVPN/Cross: Fix crash on verify peer

### DIFF
--- a/Sources/PartoutCrypto/OpenSSL_C/tls.c
+++ b/Sources/PartoutCrypto/OpenSSL_C/tls.c
@@ -39,10 +39,14 @@ BIO *create_BIO_from_PEM(const char *_Nonnull pem) {
 
 static
 int pp_tls_verify_peer(int ok, X509_STORE_CTX *_Nonnull ctx) {
-    if (!ok) {
+    if (ok == 0) {
         pp_clog_v(PPLogCategoryCore, PPLogLevelError,
                   "pp_tls_verify_peer: error %d", X509_STORE_CTX_get_error(ctx));
         SSL *ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+        if (!ssl) {
+            pp_clog(PPLogCategoryCore, PPLogLevelFault, "pp_tls_verify_peer: NULL ssl");
+            abort();
+        }
         pp_tls tls = SSL_get_ex_data(ssl, PPTLSExDataIdx);
         if (!tls) {
             pp_clog(PPLogCategoryCore, PPLogLevelFault, "pp_tls_verify_peer: NULL tls");


### PR DESCRIPTION
Extra data index was not initialized.