### PR TITLE
OpenVPN: Clean up on connection start failure

### DIFF
--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -96,9 +96,6 @@ extension NETunnelStrategy: TunnelObservableStrategy {
         try await saveAtomically(manager) {
             $0.isOnDemandEnabled = false
         }
-        // XXX: Mitigate races where the on-demand flag, despite saveToPreferences(),
-        // is not disabled yet, thus causing the tunnel to reconnect
-        try await Task.sleep(for: .milliseconds(200))
         manager.connection.stopVPNTunnel()
         await manager.connection.waitForDisconnection()
     }


### PR DESCRIPTION
The session is not properly shut down when the failure happens before the connection even establishes. The subsequent connection attempt was always stuck at "Link interface already set".