### PR TITLE
NE: Mitigate the potential of reconnection on disconnection

### DIFF
--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -96,6 +96,9 @@ extension NETunnelStrategy: TunnelObservableStrategy {
         try await saveAtomically(manager) {
             $0.isOnDemandEnabled = false
         }
+        // XXX: Mitigate races where the on-demand flag, despite saveToPreferences(),
+        // is not disabled yet, thus causing the tunnel to reconnect
+        try await Task.sleep(for: .milliseconds(200))
         manager.connection.stopVPNTunnel()
         await manager.connection.waitForDisconnection()
     }


### PR DESCRIPTION
The on-demand flag may not be disabled in time, therefore, wait 200 milliseconds before stopping the disconnected tunnel. Network Extension bugs.