### PR TITLE
Fix double free in pp_tls_create on invalid pkey

### DIFF
--- a/Sources/PartoutCrypto/OpenSSL_C/tls.c
+++ b/Sources/PartoutCrypto/OpenSSL_C/tls.c
@@ -93,6 +93,8 @@ pp_tls pp_tls_create(const pp_tls_options *opt, pp_tls_error_code *error) {
         }
         X509_free(cert);
         BIO_free(cert_bio);
+        cert = NULL;
+        cert_bio = NULL;
 
         if (opt->key_pem) {
             pkey_bio = create_BIO_from_PEM(opt->key_pem);


### PR DESCRIPTION
When supplied with a valid certificate but an invalid private key, a double free occurs where `goto failure` causes the already freed `cert`/`cert_bio` to be freed again and crash (on macOS at least).

This issue can cause PassepartoutTunnel to enter a crash loop when given a config with a malformed private key (first crash in the loop from this bug with subsequent crashes from missing preference data that the first run failed to ever save).
