### PR TITLE
Add initial codegen with Kotlin output

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -528,3 +528,29 @@ enum FoundationCompatibility {
         }
     }
 }
+
+// MARK: - Codegen
+
+package.dependencies.append(
+    .package(url: "https://github.com/swiftlang/swift-syntax", from: "602.0.0")
+)
+package.products.append(
+    .library(
+        name: "PartoutCodegen",
+        targets: ["PartoutCodegen"]
+    )
+)
+package.targets.append(contentsOf: [
+    .target(
+        name: "PartoutCodegen",
+        dependencies: [
+            "Partout",
+            .product(name: "SwiftParser", package: "swift-syntax"),
+            .product(name: "SwiftSyntax", package: "swift-syntax")
+        ]
+    ),
+    .executableTarget(
+        name: "partout-codegen",
+        dependencies: ["PartoutCodegen"]
+    )
+])

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ $ scripts/build.sh -config Release -l -crypto openssl
 Sample output:
 
 ```
-bin/<platform-arch>/partout.h       # The Partout ABI
 bin/darwin-arm64/libpartout.a       # macOS
 bin/linux-aarch64/libpartout.a      # Linux
 bin/windows-arm64/libpartout.lib    # Windows
@@ -96,6 +95,18 @@ Building for Android requires access to external SDKs:
 - `$SWIFT_ANDROID_SDK` to point to your Swift for Android SDK installation (e.g. in `~/.swiftpm/swift-sdks`)
 
 The CMake configuration is done with the `android.toolchain.cmake` toolchain. The script runs on macOS, but can be adapted for other platforms with slight tweaks to `scripts/build.sh`.
+
+#### Codegen
+
+A custom code generator is supplied to translate Swift data entities for interop with other programming languages.
+
+```
+swift run partout-codegen
+```
+
+The program is crafted around the Partout entities and does not pretend to be a full-fledged Swift transpiler. It's a poor-man [protobuf][protobuf] that however retains Swift as the source of truth, and makes several assumptions to keep the scanner logic essential.
+
+`partout-codegen` uses [swift-syntax][credits-swift-syntax] to build an intermediate representation (IR) of the Swift data entities, then proceeds to generate the output code in a different language. Currently, the codegen only supports [Kotlin][kotlin] for Android.
 
 ## Demo
 
@@ -115,7 +126,7 @@ Open `Demo.xcodeproj` and run the `PartoutDemo` target.
 
 Copyright (c) 2026 Davide De Rosa. All rights reserved.
 
-The library is licensed under the [GPLv3][license]. The `MiniFoundation` targets are MIT-licensed.
+The library is licensed under the [GPLv3][license]. The `MiniFoundation` and `partout-codegen` targets are MIT-licensed.
 
 ### Contributing
 
@@ -128,6 +139,7 @@ Libraries:
 - [GenericJSON][credits-genericjson]
 - [MbedTLS][credits-mbedtls]
 - [OpenSSL][credits-openssl]
+- [SwiftSyntax][credits-swift-syntax]
 - [url.c][credits-url.c]
 - [Wintun][credits-wintun]
 - [WireGuard (Go)][credits-wireguard-go]
@@ -158,6 +170,8 @@ Website: [partout.io][about-website]
 [swift]: https://swift.org/
 [swift-android-sdk]: https://github.com/swift-android-sdk/swift-android-sdk
 [network-extension]: https://developer.apple.com/documentation/networkextension/
+[protobuf]: https://protobuf.dev/
+[kotlin]: https://kotlinlang.org/
 [wintun]: https://git.zx2c4.com/wintun/about/
 [blog]: https://davidederosa.com/cross-platform-swift/
 [license]: LICENSE
@@ -169,6 +183,7 @@ Website: [partout.io][about-website]
 [credits-genericjson]: https://github.com/iwill/generic-json-swift
 [credits-mbedtls]: https://github.com/Mbed-TLS/mbedtls
 [credits-openssl]: https://github.com/openssl/openssl
+[credits-swift-syntax]: https://github.com/swiftlang/swift-syntax
 [credits-tmthecoder]: https://github.com/tmthecoder
 [credits-tmthecoder-xor]: https://github.com/partout-io/tunnelkit/pull/255
 [credits-url.c]: https://github.com/cozis/url.c

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -91,6 +91,8 @@ if(USE_COMPAT)
         -DMINIF_COMPAT
     )
     set(EXCLUDED_PATTERNS
+        partout-codegen.*
+        PartoutCodegen.*
         PartoutOS\/Apple.*
     )
 endif()

--- a/Sources/PartoutCodegen/Codegen+Encoders.swift
+++ b/Sources/PartoutCodegen/Codegen+Encoders.swift
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+extension Codegen {
+    public enum Output: String, CaseIterable {
+        case swift
+        case kotlin
+        case cxx
+    }
+
+    public static func forSwift() -> Codegen {
+        Codegen(encoder: SwiftEncoder())
+    }
+
+    public static func forKotlin(
+        packageName: String,
+        preamble: String? = nil,
+        sealed: KotlinSealedMetadata? = nil,
+        replacement: ((String) -> String)? = nil,
+        skipsProperty: ((_ name: String, _ fqModelName: String) -> Bool)? = nil
+    ) -> Codegen {
+        Codegen(encoder: KotlinEncoder(
+            packageName: packageName,
+            preamble: preamble,
+            sealed: sealed,
+            replacement: replacement,
+            skipsProperty: skipsProperty
+        ))
+    }
+}

--- a/Sources/PartoutCodegen/Codegen.swift
+++ b/Sources/PartoutCodegen/Codegen.swift
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import SwiftParser
+
+public final class Codegen {
+    private let encoder: IREncoder
+
+    init(encoder: IREncoder) {
+        self.encoder = encoder
+    }
+
+    public func generate(from paths: [String], entities: [String]) throws -> String {
+        let ctx = try scanDirectories(paths: paths)
+        var lines: [String] = []
+        var undefinedEntities = Set(entities)
+        if let preamble = encoder.encodePreamble() {
+            lines.append(preamble)
+            lines.append("")
+        }
+        for model in ctx.models {
+            let fq = model.fqTypeName
+            guard entities.contains(fq) else { continue }
+            guard !ctx.aliases.contains(where: { $0.name == model.name }) else { continue }
+            lines.append(encoder.encode(model, ctx: ctx))
+            lines.append("")
+            undefinedEntities.remove(model.fqTypeName)
+        }
+        for alias in ctx.aliases {
+            lines.append(encoder.encode(alias, ctx: ctx))
+            lines.append("")
+            undefinedEntities.remove(alias.fqTypeName)
+        }
+        // Make sure that all entities exist in the output
+        assert(undefinedEntities.isEmpty)
+        return lines.joined(separator: "\n")
+    }
+}
+
+private extension Codegen {
+    func scanDirectories(paths: [String]) throws -> IRContext {
+        let fm: FileManager = .default
+        var result = IRContext()
+        for path in paths {
+            let url = URL(fileURLWithPath: path)
+            let files = try fm.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: nil
+            )
+            for file in files where file.pathExtension == "swift" {
+                let partial = try scanFile(path: file.path)
+                result.merge(partial)
+            }
+        }
+        return result
+    }
+
+    func scanFile(path: String) throws -> IRContext {
+        let url = URL(fileURLWithPath: path)
+        let source = try Parser.parse(source: String(contentsOf: url))
+        let scanner = ModelScanner(viewMode: .all)
+        scanner.walk(source)
+        return scanner.results
+    }
+}

--- a/Sources/PartoutCodegen/CxxEncoder.swift
+++ b/Sources/PartoutCodegen/CxxEncoder.swift
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT

--- a/Sources/PartoutCodegen/IR.swift
+++ b/Sources/PartoutCodegen/IR.swift
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+struct IRModel {
+    enum Kind: String {
+        case `struct`
+        case `enum`
+    }
+    let name: String
+    let kind: Kind
+    let properties: [IRProperty]
+    let parents: [IRScope]
+}
+
+struct IRAlias {
+    let name: String
+    let kind: IRType
+    let parents: [IRScope]
+}
+
+struct IRProperty {
+    let name: String
+    let type: IRType
+    let scope: [IRScope]
+}
+
+indirect enum IRType {
+    case string
+    case int
+    case double
+    case bool
+    case uuid
+    case url
+    case data
+    case date
+    case json
+    case optional(IRType)
+    case array(IRType)
+    case dictionary(key: IRType, value: IRType)
+    case set(IRType)
+    case enumType(String)
+    case unresolved(String)
+    case custom(search: (IRContext) -> String?, fallback: String)
+}
+
+enum IRScope {
+    case `extension`(String)
+    case `struct`(String)
+    case `enum`(String)
+    var stringValue: String {
+        switch self {
+        case .extension(let s):
+            return s
+        case .struct(let s):
+            return s
+        case .enum(let s):
+            return s
+        }
+    }
+}
+
+// MARK: - Encoder
+
+struct IRContext {
+    var models: [IRModel] = []
+    var aliases: [IRAlias] = []
+    func merging(_ other: IRContext) -> IRContext {
+        var copy = self
+        copy.models += other.models
+        copy.aliases += other.aliases
+        return copy
+    }
+    mutating func merge(_ other: IRContext) {
+        self = merging(other)
+    }
+}
+
+protocol IREncoder {
+    func encodePreamble() -> String?
+    func encode(_ model: IRModel, ctx: IRContext) -> String
+    func encode(_ alias: IRAlias, ctx: IRContext) -> String
+    func encode(_ type: IRType, ctx: IRContext) -> String
+}
+
+extension IREncoder {
+    func encodePreamble() -> String? { nil }
+}
+
+// MARK: - Extensions
+
+protocol IRWithParents {
+    var typeName: String { get }
+    var parents: [IRScope] { get }
+}
+
+extension IRWithParents {
+    var fqType: [String] {
+        parents.map(\.stringValue) + [typeName]
+    }
+
+    var fqTypeName: String {
+        fqType.joined(separator: ".")
+    }
+}
+
+extension IRModel: IRWithParents {
+    var typeName: String {
+        name
+    }
+}
+
+extension IRAlias: IRWithParents {
+    var typeName: String {
+        name
+    }
+}
+
+// MARK: - Descriptions
+
+extension IRModel.Kind: CustomDebugStringConvertible {
+    var debugDescription: String {
+        rawValue
+    }
+}
+
+extension IRProperty: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "\(name): \(type)"
+    }
+}

--- a/Sources/PartoutCodegen/KotlinEncoder.swift
+++ b/Sources/PartoutCodegen/KotlinEncoder.swift
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+public struct KotlinSealedMetadata {
+    let classes: [KotlinSealedClass]
+    let baseClass: (_ fqTypeName: String) -> String?
+    public init(classes: [KotlinSealedClass], baseClass: @escaping (_: String) -> String?) {
+        self.classes = classes
+        self.baseClass = baseClass
+    }
+}
+
+public struct KotlinSealedClass {
+    let name: String
+    let discriminator: String
+    public init(name: String, discriminator: String) {
+        self.name = name
+        self.discriminator = discriminator
+    }
+}
+
+final class KotlinEncoder: IREncoder {
+    private let packageName: String
+    private let preamble: String?
+    private let sealed: KotlinSealedMetadata?
+    private let replacement: ((String) -> String?)?
+    private let skipsProperty: ((_ name: String, _ fqModelName: String) -> Bool)?
+
+    init(
+        packageName: String,
+        preamble: String?,
+        sealed: KotlinSealedMetadata?,
+        replacement: ((String) -> String?)?,
+        skipsProperty: ((_ name: String, _ fqTypeName: String) -> Bool)?
+    ) {
+        self.packageName = packageName
+        self.preamble = preamble
+        self.sealed = sealed
+        self.replacement = replacement
+        self.skipsProperty = skipsProperty
+    }
+
+    func encodePreamble() -> String? {
+        var desc = """
+package \(packageName)
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+"""
+        if let preamble {
+            desc.append(preamble)
+            desc.append("\n")
+        }
+        if let sealed {
+            desc.append("""
+import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonElement
+
+""")
+            sealed.classes.forEach {
+                desc += """
+
+@Serializable
+@JsonClassDiscriminator("\($0.discriminator)")
+sealed class \($0.name)
+"""
+            }
+        }
+        return desc
+    }
+
+    func encode(_ model: IRModel, ctx: IRContext) -> String {
+        var desc: [String] = []
+        let fqTypeName = normalizedTypeName(model.fqTypeName)
+        desc.append("@Serializable")
+        desc.append("@SerialName(\"\(fqTypeName)\")")
+        switch model.kind {
+        case .enum:
+            desc.append("enum class \(fqTypeName) {")
+            model.properties.forEach {
+                desc.append("    \($0.name),")
+            }
+            desc.append("}")
+        case .struct:
+            let filteredProps = model.properties.filter {
+                !skipsProperty(withName: $0.name, fqModelName: fqTypeName)
+            }
+            if !filteredProps.isEmpty {
+                desc.append("data class \(fqTypeName)(")
+            } else {
+                desc.append("class \(fqTypeName)(")
+            }
+            filteredProps.forEach {
+                let typeName = encode($0.type, ctx: ctx)
+                desc.append("    val \($0.name.normalizedIdentifier): \(normalizedTypeName(typeName)),")
+            }
+            if let sealed, let baseClass = sealed.baseClass(fqTypeName) {
+                desc.append(") : \(baseClass)()")
+            } else {
+                desc.append(")")
+            }
+        }
+        return desc.joined(separator: "\n")
+    }
+
+    func encode(_ alias: IRAlias, ctx: IRContext) -> String {
+        "typealias \(normalizedTypeName(alias.fqTypeName)) = \(encode(alias.kind, ctx: ctx))"
+    }
+
+    func encode(_ type: IRType, ctx: IRContext) -> String {
+        switch type {
+        case .string:
+            "String"
+        case .int:
+            "Int"
+        case .double:
+            "Double"
+        case .bool:
+            "Boolean"
+        case .uuid:
+            "UUID"
+        case .url:
+            "String"
+        case .data:
+            "ByteArray"
+        case .date:
+            "String"
+        case .json:
+            "JsonElement"
+        case .optional(let wrapped):
+            "\(encode(wrapped, ctx: ctx))? = null"
+        case .array(let element):
+            "List<\(encode(element, ctx: ctx))>"
+        case .dictionary(let key, let value):
+            "Map<\(encode(key, ctx: ctx)), \(encode(value, ctx: ctx))>"
+        case .set(let element):
+            "Set<\(encode(element, ctx: ctx))>"
+        case .enumType(let name):
+            normalizedTypeName(name)
+        case .unresolved(let name):
+            normalizedTypeName(name)
+        case .custom(let search, let fallback):
+            normalizedTypeName(search(ctx) ?? fallback)
+        }
+    }
+}
+
+private extension String {
+    var normalizedIdentifier: String {
+        switch self {
+        case "interface": "`\(self)`"
+        default: self
+        }
+    }
+
+}
+
+private extension KotlinEncoder {
+    func normalizedTypeName(_ typeName: String) -> String {
+        switch typeName {
+        case "Int8", "Int16", "Int32", "Int64":
+            return "Int"
+        case "Profile.ID":
+            return "String"
+        case "SecureData":
+            return "ByteArray"
+        case "TimeInterval":
+            return "Double"
+        case "UInt8", "UInt16", "UInt32", "UInt64":
+            return "UInt"
+        case "UniqueID":
+            return "String"
+        default:
+            if let replacement, let newName = replacement(typeName) {
+                return newName
+            }
+            return typeName.replacingOccurrences(of: ".", with: "_")
+        }
+    }
+
+    func skipsProperty(withName name: String, fqModelName: String) -> Bool {
+        skipsProperty?(name, fqModelName) ?? false
+    }
+}

--- a/Sources/PartoutCodegen/ModelScanner.swift
+++ b/Sources/PartoutCodegen/ModelScanner.swift
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+import SwiftSyntax
+
+final class ModelScanner: SyntaxVisitor {
+    private(set) var results = IRContext()
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        doVisit(node, parents: [])
+        return .skipChildren
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        doVisit(node, parents: [])
+        return .skipChildren
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        doVisit(node, parents: [])
+        return .skipChildren
+    }
+}
+
+private extension ModelScanner {
+    func doVisit(_ node: ExtensionDeclSyntax, parents: [IRScope]) {
+        let name = node.extendedType.trimmedDescription
+        if let alias = findAlias(in: node.inheritanceClause, memberBlock: node.memberBlock, name: name, parents: parents) {
+            results.aliases.append(alias)
+            return
+        }
+        let newParents = parents + [.extension(name)]
+        for member in node.memberBlock.members {
+            if let structDecl = member.decl.as(StructDeclSyntax.self) {
+                doVisit(structDecl, parents: newParents)
+            } else if let enumDecl = member.decl.as(EnumDeclSyntax.self) {
+                doVisit(enumDecl, parents: newParents)
+            }
+        }
+    }
+
+    func doVisit(_ node: StructDeclSyntax, parents: [IRScope]) {
+        let name = node.name.text
+        // Express raw as typealias, not struct
+        if let alias = findAlias(
+            in: node.inheritanceClause,
+            memberBlock: node.memberBlock,
+            name: name,
+            parents: parents
+        ) {
+            results.aliases.append(alias)
+            return
+        }
+        let newParents = parents + [.struct(name)]
+        let props = node.memberBlock.parseProperties(parents: newParents)
+        results.models.append(IRModel(
+            name: name,
+            kind: .struct,
+            properties: props,
+            parents: parents
+        ))
+        for member in node.memberBlock.members {
+            if let structDecl = member.decl.as(StructDeclSyntax.self) {
+                doVisit(structDecl, parents: newParents)
+            } else if let enumDecl = member.decl.as(EnumDeclSyntax.self) {
+                doVisit(enumDecl, parents: newParents)
+            }
+        }
+    }
+
+    func doVisit(_ node: EnumDeclSyntax, parents: [IRScope]) {
+        let name = node.name.text
+        let props = node.parseCases(parents: parents)
+        results.models.append(IRModel(
+            name: name,
+            kind: .enum,
+            properties: props,
+            parents: parents
+        ))
+        let newParents = parents + [.enum(name)]
+        for member in node.memberBlock.members {
+            if let structDecl = member.decl.as(StructDeclSyntax.self) {
+                doVisit(structDecl, parents: newParents)
+            } else if let enumDecl = member.decl.as(EnumDeclSyntax.self) {
+                doVisit(enumDecl, parents: newParents)
+            }
+        }
+    }
+
+    func findAlias(
+        in clause: InheritanceClauseSyntax?,
+        memberBlock: MemberBlockSyntax,
+        name: String,
+        parents: [IRScope]
+    ) -> IRAlias? {
+        guard let clause, clause.conformsTo("RawRepresentable") else {
+            return nil
+        }
+        let props = memberBlock.parseProperties(parents: parents, includingComputed: true)
+        guard let rawValue = props.first(where: { $0.name == "rawValue" }) else { return nil }
+        return IRAlias(name: name, kind: rawValue.type, parents: parents)
+    }
+}
+
+// MARK: - Syntax
+
+private extension EnumDeclSyntax {
+    func parseCases(parents: [IRScope]) -> [IRProperty] {
+        var cases: [IRProperty] = []
+        for member in memberBlock.members {
+            guard let enumCase = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
+            for element in enumCase.elements {
+                cases.append(IRProperty(
+                    name: element.name.text,
+                    type: .enumType(name.text),
+                    scope: parents
+                ))
+            }
+        }
+        return cases
+    }
+}
+
+private extension MemberBlockSyntax {
+    func parseProperties(parents: [IRScope], includingComputed: Bool = false) -> [IRProperty] {
+        var props: [IRProperty] = []
+        for member in members {
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self) else { continue }
+            guard !varDecl.modifiers.contains(where: {
+                ["static", "class"].contains($0.name.text)
+            }) else { continue }
+            for binding in varDecl.bindings {
+                guard includingComputed || binding.accessorBlock == nil else { continue }
+                guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else { continue }
+                let name = pattern.identifier.text
+                guard let typeSyntax = binding.typeAnnotation?.type else { continue }
+                let irType = typeSyntax.irType(parents: parents)
+                props.append(IRProperty(
+                    name: name,
+                    type: irType,
+                    scope: parents
+                ))
+            }
+        }
+        return props
+    }
+}
+
+private extension TypeSyntax {
+    func irType(parents: [IRScope]) -> IRType {
+        if let opt = self.as(OptionalTypeSyntax.self) {
+            return .optional(opt.wrappedType.irType(parents: parents))
+        } else if let arr = self.as(ArrayTypeSyntax.self) {
+            return .array(arr.element.irType(parents: parents))
+        } else if let dict = self.as(DictionaryTypeSyntax.self) {
+            return .dictionary(
+                key: dict.key.irType(parents: parents),
+                value: dict.value.irType(parents: parents)
+            )
+        } else if let simple = self.as(IdentifierTypeSyntax.self) {
+            let name = simple.trimmedDescription
+            if name.hasPrefix("Set") {
+                if let args = simple.genericArgumentClause?.arguments {
+                    if let firstArg = args.first?.argument.as(TypeSyntax.self) {
+                        return .set(firstArg.irType(parents: parents))
+                    }
+                }
+            }
+            switch name {
+            case "String": return .string
+            case "Int": return .int
+            case "Bool": return .bool
+            case "UUID": return .uuid
+            case "URL": return .url
+            case "Data": return .data
+            case "Date": return .date
+            case "Double", "TimeInterval": return .double
+            case "JSON": return .json
+            default:
+                return .custom(withName: name, scope: parents)
+            }
+        } else if let member = self.as(MemberTypeSyntax.self) {
+            return .custom(withName: member.trimmedDescription, scope: parents)
+        } else {
+            return .custom(withName: trimmedDescription, scope: parents)
+        }
+    }
+}
+
+private extension InheritanceClauseSyntax {
+    func conformsTo(_ proto: String) -> Bool {
+        inheritedTypes.contains {
+            $0.type.trimmedDescription == proto
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension IRType {
+    static func custom(withName typeName: String, scope: [IRScope]) -> IRType {
+        .custom(search: { ctx in
+            if let alias = ctx.aliases.first(where: { $0.name == typeName }) {
+                return alias.fqTypeName
+            }
+            let matches = ctx.models.filter {
+                $0.name == typeName
+            }
+            guard let found = matches.first else {
+//                print("IRModel: Unable to find for \(typeName)")
+                return nil
+            }
+            guard matches.count == 1 else {
+                fatalError("IRModel: Multiple matches for \(typeName): \(matches)")
+            }
+//            print("IRModel: Found for \(typeName): \(found.name)")
+            return found.fqTypeName
+        }, fallback: typeName)
+    }
+}

--- a/Sources/PartoutCodegen/PartoutCodegen.swift
+++ b/Sources/PartoutCodegen/PartoutCodegen.swift
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+public enum PartoutCodegen {
+    public static let paths: [String] = [
+        "PartoutCore/IP",
+        "PartoutCore/Modules",
+        "PartoutCore/Profile",
+        "PartoutOpenVPN",
+        "PartoutWireGuard"
+    ]
+
+    public static let entities: [String] = [
+        "Address",
+//        "Address.Family",
+        "Endpoint",
+        "EndpointProtocol",
+        "ExtendedEndpoint",
+        "IPSettings",
+        "IPSocketType",
+        "ModuleType",
+//        "Profile.ID",
+        "ProfileBehavior",
+        "Route",
+//        "SecureData",
+        "SocketType",
+        "Subnet",
+//        "TunnelRemoteInfo",
+        //
+        "DNSModule",
+        "DNSModule.ProtocolType",
+        "DNSProtocol",
+        "HTTPProxyModule",
+        "IPModule",
+        "OnDemandModule",
+        "OnDemandModule.OtherNetwork",
+        "OnDemandModule.Policy",
+        //
+        "OpenVPNModule",
+        "OpenVPN.Cipher",
+        "OpenVPN.CompressionAlgorithm",
+        "OpenVPN.CompressionFraming",
+        "OpenVPN.Configuration",
+        "OpenVPN.Credentials",
+        "OpenVPN.Credentials.OTPMethod",
+        "OpenVPN.CryptoContainer",
+        "OpenVPN.Digest",
+        "OpenVPN.ObfuscationMethod",
+        "OpenVPN.PullMask",
+        "OpenVPN.RoutingPolicy",
+        "OpenVPN.StaticKey",
+        "OpenVPN.StaticKey.Direction",
+        "OpenVPN.TLSWrap",
+        "OpenVPN.TLSWrap.Strategy",
+        //
+        "WireGuardModule",
+        "WireGuard.Configuration",
+        "WireGuard.Key",
+        "WireGuard.LocalInterface",
+        "WireGuard.RemoteInterface"
+    ]
+}

--- a/Sources/PartoutCodegen/SwiftEncoder.swift
+++ b/Sources/PartoutCodegen/SwiftEncoder.swift
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+// This is only a showcase to get the hang of the
+// encoding process. It may break from time to time.
+final class SwiftEncoder: IREncoder {
+    func encode(_ model: IRModel, ctx: IRContext) -> String {
+        var desc: [String] = []
+        let fqTypeName = model.fqTypeName.normalizedTypeName
+        switch model.kind {
+        case .enum:
+            desc.append("enum \(fqTypeName) {")
+            model.properties.forEach {
+                desc.append("    case \($0.name)")
+            }
+        case .struct:
+            desc.append("struct \(fqTypeName) {")
+            model.properties.forEach {
+                let typeName = encode($0.type, ctx: ctx)
+                desc.append("    let \($0.name): \(typeName.normalizedTypeName)")
+            }
+        }
+        desc.append("}")
+        return desc.joined(separator: "\n")
+    }
+
+    func encode(_ alias: IRAlias, ctx: IRContext) -> String {
+        "typealias \(alias.fqTypeName.normalizedTypeName) = \(encode(alias.kind, ctx: ctx))"
+    }
+
+    func encode(_ type: IRType, ctx: IRContext) -> String {
+        switch type {
+        case .string:
+            "String"
+        case .int:
+            "Int"
+        case .double:
+            "Double"
+        case .bool:
+            "Bool"
+        case .uuid:
+            "UUID"
+        case .url:
+            "URL"
+        case .data:
+            "Data"
+        case .date:
+            "Date"
+        case .json:
+            "JSON"
+        case .optional(let wrapped):
+            "\(encode(wrapped, ctx: ctx))?"
+        case .array(let element):
+            "[\(encode(element, ctx: ctx))]"
+        case .dictionary(let key, let value):
+            "[\(encode(key, ctx: ctx)): \(encode(value, ctx: ctx))]"
+        case .set(let element):
+            "Set<\(encode(element, ctx: ctx))>"
+        case .enumType(let name):
+            name.normalizedTypeName
+        case .unresolved(let name):
+            name.normalizedTypeName
+        case .custom(let search, let fallback):
+            (search(ctx) ?? fallback).normalizedTypeName
+        }
+    }
+}
+
+private extension String {
+    var normalizedTypeName: String {
+        switch self {
+        case "Profile.ID": "String"
+        default: replacingOccurrences(of: ".", with: "_")
+        }
+    }
+}

--- a/Sources/partout-codegen/main.swift
+++ b/Sources/partout-codegen/main.swift
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import PartoutCodegen
+import SwiftParser
+
+do {
+    let args = CommandLine.arguments
+    guard args.count > 1 else {
+        let known = Codegen.Output.allCases
+            .map(\.rawValue)
+            .joined(separator: "|")
+        fatalError("Missing encoder name (\(known))")
+    }
+    let encoderName = args[1]
+
+    let codegen: Codegen
+    switch Codegen.Output(rawValue: encoderName) {
+    case .swift:
+        codegen = .forSwift()
+    case .kotlin:
+        codegen = .forKotlin(
+            packageName: "io.partout.abi"
+        )
+    case .cxx:
+        fatalError("C++ encoder not implemented")
+    default:
+        fatalError("Unknown encoder '\(encoderName)'")
+    }
+    let output = try codegen.generate(
+        from: PartoutCodegen.paths.map { "Sources/\($0)" },
+        entities: PartoutCodegen.entities
+    )
+    print(output)
+} catch {
+    print(error)
+}


### PR DESCRIPTION
Create a code generator based on SwiftSyntax that maps Partout data entities (Codable/JSON) to non-Swift languages for cross-platform interop, starting with Kotlin. This is preferred over quicktype and protobuf because it's a way to retain Swift as the source of truth. The downside is that we have to maintain a custom transpiler, but several assumptions are made to keep the codegen simple and maintainable (certainly not reusable):

The codegen code is split into a library target for reuse (`PartoutCodegen`) and an executable (`partout-codegen`) that depends on the library. The executable prints all the Partout entities.

The reason behind the codegen is to represent the data model across the Swift boundary, e.g., in a C ABI based on `@_cdecl`. Say an Android app wants to connect to a Partout `Profile`, it must be able to serialize the `Profile` entity in Kotlin before passing it to a `@_cdecl` call, which in turn would deserialize it again to a Swift `Profile`.

The same approach applies to internal classes requiring interactions with non-Swift APIs, like `VirtualTunnelController` and `pp_tun_ctrl_set_tunnel`, where the C function must forward a `TunnelRemoteInfo` structure to a non-Swift app. The input to the C callback must be serialized, and the non-Swift callback implementation requires a proper data model for `TunnelRemoteInfo` to deserialize and handle it. This is (partially) done in `jni/PartoutVpnWrapper.kt`.

The codegen:

- Takes a list of source directories and entities to transpile (structs must reside in such directories)
- Takes an output type (`swift` or `kotlin`)
- Prints the provided entities represented in the output type

For example:

```swift
extension WireGuard {
    struct LocalInterface: BuildableType, Hashable, Codable, Sendable {
        public let privateKey: Key
        public let addresses: [Subnet]
        public let dns: DNSModule?
        public let mtu: UInt16?
    }
}
```

Becomes:

```kotlin
@Serializable
@SerialName("WireGuard_LocalInterface")
data class WireGuard_LocalInterface(
    val privateKey: WireGuard_Key,
    val addresses: List<Subnet>,
    val dns: DNSModule? = null,
    val mtu: UInt? = null,
)
```

Still to be done:

- Enums with associated values
- Date encoding (Apple vs ISO8601)
- Modules (sealed)
- TunnelRemoteInfo
- Profile