### PR TITLE
WireGuard: Fix regressions from official stack

### DIFF
--- a/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
@@ -66,13 +66,13 @@ extension NEObservablePath {
 
 private extension NWPath {
     var isSatisfiable: Bool {
-        let target: [NWInterface.InterfaceType] = [
-            .cellular, .wifi, .wiredEthernet
-        ]
-        let isAvailable = target.contains {
-            usesInterfaceType($0)
+        switch status {
+        case .requiresConnection, .satisfied:
+            return true
+        case .unsatisfied:
+            return false
+        @unknown default:
+            return true
         }
-        guard isAvailable else { return false }
-        return status == .satisfied
     }
 }

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+import Dispatch
 import Network
 
 /// An observer that publishes updates from a `NWPathMonitor`.
@@ -9,6 +10,8 @@ public final class NEObservablePath: ReachabilityObserver {
     private let ctx: PartoutLoggerContext
 
     private let monitor: NWPathMonitor
+
+    private let monitorQueue: DispatchQueue
 
     private nonisolated let subject: CurrentValueStream<NWPath>
 
@@ -18,19 +21,20 @@ public final class NEObservablePath: ReachabilityObserver {
     public init(_ ctx: PartoutLoggerContext) {
         self.ctx = ctx
         monitor = NWPathMonitor()
+        monitorQueue = DispatchQueue(label: "NEObservablePath")
         subject = CurrentValueStream(monitor.currentPath)
     }
 
     public func startObserving() {
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
-            let didChangeSatisfiability = path.isSatisfiable != wasSatisfiable
+            let didChangeSatisfiability = path.isSatisfiable != self.wasSatisfiable
             let level: DebugLog.Level = didChangeSatisfiability ? .info : .debug
-            pp_log(ctx, .os, level, "Path updated: \(path.debugDescription)")
-            wasSatisfiable = path.isSatisfiable
-            subject.send(path)
+            pp_log(self.ctx, .os, level, "Path updated: \(path.debugDescription)")
+            self.wasSatisfiable = path.isSatisfiable
+            self.subject.send(path)
         }
-        monitor.start(queue: .global())
+        monitor.start(queue: monitorQueue)
     }
 }
 
@@ -45,12 +49,13 @@ extension NEObservablePath {
 
     public var isReachableStream: AsyncStream<Bool> {
         AsyncStream { [weak self] continuation in
-            Task { [weak self] in
+            let relayTask = Task { [weak self] in
                 guard let self else {
                     continuation.finish()
                     return
                 }
-                for await path in self.stream {
+                let pathStream = self.stream
+                for await path in pathStream {
                     guard !Task.isCancelled else {
                         pp_log(self.ctx, .os, .debug, "Cancelled NEObservablePath.isReachableStream")
                         break
@@ -59,6 +64,9 @@ extension NEObservablePath {
                     continuation.yield(reachable)
                 }
                 continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                relayTask.cancel()
             }
         }
     }

--- a/Sources/PartoutWireGuardConnection/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/Configuration+Resolve.swift
@@ -8,9 +8,9 @@
 /// - Returns: The list of resolved endpoints.
 extension WireGuard.Configuration {
     actor ResolvedMap {
-        private var map: [Address: [Endpoint]] = [:]
+        private var map: [Endpoint: Endpoint] = [:]
 
-        func setEndpoints(_ endpoints: [Endpoint], for address: Address) {
+        func setEndpoints(_ endpoints: [Endpoint], for sourceEndpoint: Endpoint) {
             assert(!endpoints.isEmpty, "Assigning empty resolved endpoints")
             let targetEndpoint: Endpoint? = {
                 // All resolved IPv4 addresses
@@ -27,10 +27,10 @@ extension WireGuard.Configuration {
                 return firstEndpoint
             }()
             guard let targetEndpoint else { return }
-            map = [address: [targetEndpoint]]
+            map[sourceEndpoint] = targetEndpoint
         }
 
-        func toMap() -> [Address: [Endpoint]] {
+        func toMap() -> [Endpoint: Endpoint] {
             map
         }
     }
@@ -38,12 +38,12 @@ extension WireGuard.Configuration {
     func resolvePeers(
         timeout: Int,
         logHandler: @escaping WireGuardAdapter.LogHandler
-    ) async -> [Address: [Endpoint]] {
+    ) async -> [Endpoint: Endpoint] {
         let endpoints = peers.compactMap(\.endpoint)
         let resolver = SimpleDNSResolver {
             POSIXDNSStrategy(hostname: $0)
         }
-        return await withTaskGroup(returning: [Address: [Endpoint]].self) { group in
+        return await withTaskGroup(returning: [Endpoint: Endpoint].self) { group in
             let allResolved = ResolvedMap()
             for endpoint in endpoints {
                 group.addTask { @Sendable in
@@ -63,7 +63,7 @@ extension WireGuard.Configuration {
                                 logHandler(.verbose, "DNS64: mapped \(endpoint.address) to \(record.address)")
                             }
                         }
-                        await allResolved.setEndpoints(currentResolved, for: endpoint.address)
+                        await allResolved.setEndpoints(currentResolved, for: endpoint)
                     } catch {
                         logHandler(.error, "Failed to resolve endpoint \(endpoint.address.asSensitiveAddress(.global)): \(error.localizedDescription)")
                     }

--- a/Sources/PartoutWireGuardConnection/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/Configuration+Resolve.swift
@@ -7,6 +7,7 @@
 /// - Throws: an error of type `WireGuardAdapterError`.
 /// - Returns: The list of resolved endpoints.
 extension WireGuard.Configuration {
+    @available(*, deprecated, renamed: "ResolvedMapV2")
     actor ResolvedMap {
         private var map: [Address: [Endpoint]] = [:]
 

--- a/Sources/PartoutWireGuardConnection/Internal/Configuration+ResolveV2.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/Configuration+ResolveV2.swift
@@ -7,10 +7,10 @@
 /// - Throws: an error of type `WireGuardAdapterError`.
 /// - Returns: The list of resolved endpoints.
 extension WireGuard.Configuration {
-    actor ResolvedMap {
-        private var map: [Address: [Endpoint]] = [:]
+    actor ResolvedMapV2 {
+        private var map: [Endpoint: Endpoint] = [:]
 
-        func setEndpoints(_ endpoints: [Endpoint], for address: Address) {
+        func setEndpoints(_ endpoints: [Endpoint], for sourceEndpoint: Endpoint) {
             assert(!endpoints.isEmpty, "Assigning empty resolved endpoints")
             let targetEndpoint: Endpoint? = {
                 // All resolved IPv4 addresses
@@ -27,24 +27,24 @@ extension WireGuard.Configuration {
                 return firstEndpoint
             }()
             guard let targetEndpoint else { return }
-            map = [address: [targetEndpoint]]
+            map[sourceEndpoint] = targetEndpoint
         }
 
-        func toMap() -> [Address: [Endpoint]] {
+        func toMap() -> [Endpoint: Endpoint] {
             map
         }
     }
 
-    func resolvePeers(
+    func resolvePeersV2(
         timeout: Int,
         logHandler: @escaping WireGuardAdapter.LogHandler
-    ) async -> [Address: [Endpoint]] {
+    ) async -> [Endpoint: Endpoint] {
         let endpoints = peers.compactMap(\.endpoint)
         let resolver = SimpleDNSResolver {
             POSIXDNSStrategy(hostname: $0)
         }
-        return await withTaskGroup(returning: [Address: [Endpoint]].self) { group in
-            let allResolved = ResolvedMap()
+        return await withTaskGroup(returning: [Endpoint: Endpoint].self) { group in
+            let allResolved = ResolvedMapV2()
             for endpoint in endpoints {
                 group.addTask { @Sendable in
                     do {
@@ -63,7 +63,7 @@ extension WireGuard.Configuration {
                                 logHandler(.verbose, "DNS64: mapped \(endpoint.address) to \(record.address)")
                             }
                         }
-                        await allResolved.setEndpoints(currentResolved, for: endpoint.address)
+                        await allResolved.setEndpoints(currentResolved, for: endpoint)
                     } catch {
                         logHandler(.error, "Failed to resolve endpoint \(endpoint.address.asSensitiveAddress(.global)): \(error.localizedDescription)")
                     }

--- a/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
@@ -41,13 +41,14 @@ final class TunnelRemoteInfoGenerator: Sendable {
                 continue
             }
             wgSettings.append("public_key=\(publicKey)\n")
-            guard let endpoint = peer.endpoint else { continue }
-            for resolvedEndpoint in resolutionMap[endpoint.address] ?? [] {
-                if case .hostname = resolvedEndpoint.address {
-                    assertionFailure("Endpoint is not resolved")
-                }
-                wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
+            guard let endpoint = peer.endpoint,
+                  let resolvedEndpoint = resolutionMap[endpoint] else {
+                continue
             }
+            if case .hostname = resolvedEndpoint.address {
+                assertionFailure("Endpoint is not resolved")
+            }
+            wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
         }
         return wgSettings
     }
@@ -82,13 +83,14 @@ final class TunnelRemoteInfoGenerator: Sendable {
                 let preSharedKey = try preSharedKeyBase64.hexStringFromBase64()
                 wgSettings.append("preshared_key=\(preSharedKey)\n")
             }
-            guard let endpoint = peer.endpoint else { continue }
-            for resolvedEndpoint in resolutionMap[endpoint.address] ?? [] {
-                if case .hostname = resolvedEndpoint.address {
-                    assertionFailure("Endpoint is not resolved")
-                }
-                wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
+            guard let endpoint = peer.endpoint,
+                  let resolvedEndpoint = resolutionMap[endpoint] else {
+                continue
             }
+            if case .hostname = resolvedEndpoint.address {
+                assertionFailure("Endpoint is not resolved")
+            }
+            wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
             let persistentKeepAlive = peer.keepAlive ?? 0
             wgSettings.append("persistent_keepalive_interval=\(persistentKeepAlive)\n")
             if !peer.allowedIPs.isEmpty {

--- a/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
@@ -45,10 +45,17 @@ final class TunnelRemoteInfoGenerator: Sendable {
                   let resolvedEndpoint = resolutionMap[endpoint] else {
                 continue
             }
-            if case .hostname = resolvedEndpoint.address {
+            let reresolvedEndpoint: Endpoint
+            do {
+                reresolvedEndpoint = try resolvedEndpoint.withReresolvedIP()
+            } catch {
+                pp_log(ctx, .wireguard, .error, "Unable to re-resolve endpoint: \(error)")
+                reresolvedEndpoint = resolvedEndpoint
+            }
+            if case .hostname = reresolvedEndpoint.address {
                 assertionFailure("Endpoint is not resolved")
             }
-            wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
+            wgSettings.append("endpoint=\(reresolvedEndpoint.wgRepresentation)\n")
         }
         return wgSettings
     }
@@ -87,10 +94,17 @@ final class TunnelRemoteInfoGenerator: Sendable {
                   let resolvedEndpoint = resolutionMap[endpoint] else {
                 continue
             }
-            if case .hostname = resolvedEndpoint.address {
+            let reresolvedEndpoint: Endpoint
+            do {
+                reresolvedEndpoint = try resolvedEndpoint.withReresolvedIP()
+            } catch {
+                pp_log(ctx, .wireguard, .error, "Unable to re-resolve endpoint: \(error)")
+                reresolvedEndpoint = resolvedEndpoint
+            }
+            if case .hostname = reresolvedEndpoint.address {
                 assertionFailure("Endpoint is not resolved")
             }
-            wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
+            wgSettings.append("endpoint=\(reresolvedEndpoint.wgRepresentation)\n")
             let persistentKeepAlive = peer.keepAlive ?? 0
             wgSettings.append("persistent_keepalive_interval=\(persistentKeepAlive)\n")
             if !peer.allowedIPs.isEmpty {
@@ -216,5 +230,69 @@ final class TunnelRemoteInfoGenerator: Sendable {
             }
         }
         return (ipv4IncludedRoutes, ipv6IncludedRoutes)
+    }
+}
+
+private extension Endpoint {
+    func withReresolvedIP() throws -> Endpoint {
+#if os(iOS) || os(tvOS)
+        let hostname = address.rawValue
+
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = SOCK_DGRAM
+        hints.ai_protocol = IPPROTO_UDP
+        hints.ai_flags = 0
+
+        var resultPointer: UnsafeMutablePointer<addrinfo>?
+        defer {
+            resultPointer.flatMap {
+                freeaddrinfo($0)
+            }
+        }
+
+        let errorCode = getaddrinfo(hostname, "\(port)", &hints, &resultPointer)
+        if errorCode != 0 {
+            throw PartoutError(.dnsFailure)
+        }
+
+        var next = resultPointer
+        while let addrInfo = next?.pointee {
+            if let endpoint = Self.endpoint(from: addrInfo, port: port) {
+                return endpoint
+            }
+            next = addrInfo.ai_next
+        }
+        throw PartoutError(.dnsFailure)
+#else
+        return self
+#endif
+    }
+
+    private static func endpoint(from addrInfo: addrinfo, port: UInt16) -> Endpoint? {
+        guard let addr = addrInfo.ai_addr else {
+            return nil
+        }
+        var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+#if os(Windows)
+        let hostBufferLength = DWORD(hostBuffer.count)
+#elseif os(Android)
+        let hostBufferLength = Int(hostBuffer.count)
+#else
+        let hostBufferLength = socklen_t(hostBuffer.count)
+#endif
+        let result = getnameinfo(
+            addr,
+            socklen_t(addrInfo.ai_addrlen),
+            &hostBuffer,
+            hostBufferLength,
+            nil,
+            0,
+            NI_NUMERICHOST
+        )
+        guard result == 0 else {
+            return nil
+        }
+        return try? Endpoint(hostBuffer.string, port)
     }
 }

--- a/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
@@ -43,7 +43,9 @@ final class TunnelRemoteInfoGenerator: Sendable {
             wgSettings.append("public_key=\(publicKey)\n")
             guard let endpoint = peer.endpoint else { continue }
             for resolvedEndpoint in resolutionMap[endpoint.address] ?? [] {
-                if case .hostname = resolvedEndpoint.address { assert(false, "Endpoint is not resolved") }
+                if case .hostname = resolvedEndpoint.address {
+                    assertionFailure("Endpoint is not resolved")
+                }
                 wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
             }
         }
@@ -82,7 +84,9 @@ final class TunnelRemoteInfoGenerator: Sendable {
             }
             guard let endpoint = peer.endpoint else { continue }
             for resolvedEndpoint in resolutionMap[endpoint.address] ?? [] {
-                if case .hostname = resolvedEndpoint.address { assert(false, "Endpoint is not resolved") }
+                if case .hostname = resolvedEndpoint.address {
+                    assertionFailure("Endpoint is not resolved")
+                }
                 wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
             }
             let persistentKeepAlive = peer.keepAlive ?? 0

--- a/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
@@ -67,9 +67,9 @@ final class TunnelRemoteInfoGenerator: Sendable {
         var wgSettings = ""
         wgSettings.append("private_key=\(privateKey)\n")
         // TODO: #93, listenPort not implemented
-//        if let listenPort = tunnelConfiguration.interface.listenPort {
-//            wgSettings.append("listen_port=\(listenPort)\n")
-//        }
+        //        if let listenPort = tunnelConfiguration.interface.listenPort {
+        //            wgSettings.append("listen_port=\(listenPort)\n")
+        //        }
         if !tunnelConfiguration.peers.isEmpty {
             wgSettings.append("replace_peers=true\n")
         }
@@ -173,8 +173,10 @@ final class TunnelRemoteInfoGenerator: Sendable {
             requiresVirtualDevice: requiresVirtualDevice
         )
     }
+}
 
-    private func addresses() -> ([Subnet], [Subnet]) {
+private extension TunnelRemoteInfoGenerator {
+    func addresses() -> ([Subnet], [Subnet]) {
         var ipv4: [Subnet] = []
         var ipv6: [Subnet] = []
         for subnet in tunnelConfiguration.interface.addresses {
@@ -200,13 +202,13 @@ final class TunnelRemoteInfoGenerator: Sendable {
         return (ipv4, ipv6)
     }
 
-    private func includedRoutes() -> ([Route], [Route]) {
+    func includedRoutes() -> ([Route], [Route]) {
         var ipv4IncludedRoutes: [Route] = []
         var ipv6IncludedRoutes: [Route] = []
         for subnet in tunnelConfiguration.interface.addresses {
             switch subnet.address {
             case .ip(_, let family):
-                let route = Route(subnet, subnet.address)
+                let route = Route(subnet.maskedSubnet, subnet.address)
                 switch family {
                 case .v4: ipv4IncludedRoutes.append(route)
                 case .v6: ipv6IncludedRoutes.append(route)
@@ -230,6 +232,24 @@ final class TunnelRemoteInfoGenerator: Sendable {
             }
         }
         return (ipv4IncludedRoutes, ipv6IncludedRoutes)
+    }
+}
+
+private extension Subnet {
+    var maskedSubnet: Subnet {
+        let maskedAddress: Address? = switch address.family {
+        case .v4:
+            address.network(with: ipv4Mask)
+        case .v6:
+            address.network(with: prefixLength)
+        case nil:
+            nil
+        }
+        guard let maskedAddress,
+              let maskedSubnet = Subnet(maskedAddress, prefixLength) else {
+            fatalError("Could not derive masked route subnet from interface address")
+        }
+        return maskedSubnet
     }
 }
 

--- a/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGenerator.swift
@@ -10,6 +10,7 @@
 
 internal import _PartoutWireGuard_C
 
+@available(*, deprecated, renamed: "TunnelRemoteInfoGeneratorV2")
 final class TunnelRemoteInfoGenerator: Sendable {
     private let ctx: PartoutLoggerContext
 

--- a/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGeneratorV2.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGeneratorV2.swift
@@ -289,7 +289,7 @@ private extension Endpoint {
 #endif
     }
 
-    private static func endpoint(from addrInfo: addrinfo, port: UInt16) -> Endpoint? {
+    static func endpoint(from addrInfo: addrinfo, port: UInt16) -> Endpoint? {
         guard let addr = addrInfo.ai_addr else {
             return nil
         }

--- a/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGeneratorV2.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/TunnelRemoteInfoGeneratorV2.swift
@@ -10,7 +10,7 @@
 
 internal import _PartoutWireGuard_C
 
-final class TunnelRemoteInfoGenerator: Sendable {
+final class TunnelRemoteInfoGeneratorV2: Sendable {
     private let ctx: PartoutLoggerContext
 
     private let tunnelConfiguration: WireGuard.Configuration
@@ -28,7 +28,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
         var wgSettings = ""
 
         // address: String -> resolvedEndpoints: [Endpoint]
-        let resolutionMap = await tunnelConfiguration.resolvePeers(
+        let resolutionMap = await tunnelConfiguration.resolvePeersV2(
             timeout: dnsTimeout,
             logHandler: logHandler
         )
@@ -41,11 +41,21 @@ final class TunnelRemoteInfoGenerator: Sendable {
                 continue
             }
             wgSettings.append("public_key=\(publicKey)\n")
-            guard let endpoint = peer.endpoint else { continue }
-            for resolvedEndpoint in resolutionMap[endpoint.address] ?? [] {
-                if case .hostname = resolvedEndpoint.address { assert(false, "Endpoint is not resolved") }
-                wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
+            guard let endpoint = peer.endpoint,
+                  let resolvedEndpoint = resolutionMap[endpoint] else {
+                continue
             }
+            let reresolvedEndpoint: Endpoint
+            do {
+                reresolvedEndpoint = try resolvedEndpoint.withReresolvedIP()
+            } catch {
+                pp_log(ctx, .wireguard, .error, "Unable to re-resolve endpoint: \(error)")
+                reresolvedEndpoint = resolvedEndpoint
+            }
+            if case .hostname = reresolvedEndpoint.address {
+                assertionFailure("Endpoint is not resolved")
+            }
+            wgSettings.append("endpoint=\(reresolvedEndpoint.wgRepresentation)\n")
         }
         return wgSettings
     }
@@ -57,15 +67,15 @@ final class TunnelRemoteInfoGenerator: Sendable {
         var wgSettings = ""
         wgSettings.append("private_key=\(privateKey)\n")
         // TODO: #93, listenPort not implemented
-//        if let listenPort = tunnelConfiguration.interface.listenPort {
-//            wgSettings.append("listen_port=\(listenPort)\n")
-//        }
+        //        if let listenPort = tunnelConfiguration.interface.listenPort {
+        //            wgSettings.append("listen_port=\(listenPort)\n")
+        //        }
         if !tunnelConfiguration.peers.isEmpty {
             wgSettings.append("replace_peers=true\n")
         }
 
         // address: String -> resolvedEndpoints: [Endpoint]
-        let resolutionMap = await tunnelConfiguration.resolvePeers(
+        let resolutionMap = await tunnelConfiguration.resolvePeersV2(
             timeout: dnsTimeout,
             logHandler: logHandler
         )
@@ -80,11 +90,21 @@ final class TunnelRemoteInfoGenerator: Sendable {
                 let preSharedKey = try preSharedKeyBase64.hexStringFromBase64()
                 wgSettings.append("preshared_key=\(preSharedKey)\n")
             }
-            guard let endpoint = peer.endpoint else { continue }
-            for resolvedEndpoint in resolutionMap[endpoint.address] ?? [] {
-                if case .hostname = resolvedEndpoint.address { assert(false, "Endpoint is not resolved") }
-                wgSettings.append("endpoint=\(resolvedEndpoint.wgRepresentation)\n")
+            guard let endpoint = peer.endpoint,
+                  let resolvedEndpoint = resolutionMap[endpoint] else {
+                continue
             }
+            let reresolvedEndpoint: Endpoint
+            do {
+                reresolvedEndpoint = try resolvedEndpoint.withReresolvedIP()
+            } catch {
+                pp_log(ctx, .wireguard, .error, "Unable to re-resolve endpoint: \(error)")
+                reresolvedEndpoint = resolvedEndpoint
+            }
+            if case .hostname = reresolvedEndpoint.address {
+                assertionFailure("Endpoint is not resolved")
+            }
+            wgSettings.append("endpoint=\(reresolvedEndpoint.wgRepresentation)\n")
             let persistentKeepAlive = peer.keepAlive ?? 0
             wgSettings.append("persistent_keepalive_interval=\(persistentKeepAlive)\n")
             if !peer.allowedIPs.isEmpty {
@@ -153,8 +173,10 @@ final class TunnelRemoteInfoGenerator: Sendable {
             requiresVirtualDevice: requiresVirtualDevice
         )
     }
+}
 
-    private func addresses() -> ([Subnet], [Subnet]) {
+private extension TunnelRemoteInfoGeneratorV2 {
+    func addresses() -> ([Subnet], [Subnet]) {
         var ipv4: [Subnet] = []
         var ipv6: [Subnet] = []
         for subnet in tunnelConfiguration.interface.addresses {
@@ -180,13 +202,13 @@ final class TunnelRemoteInfoGenerator: Sendable {
         return (ipv4, ipv6)
     }
 
-    private func includedRoutes() -> ([Route], [Route]) {
+    func includedRoutes() -> ([Route], [Route]) {
         var ipv4IncludedRoutes: [Route] = []
         var ipv6IncludedRoutes: [Route] = []
         for subnet in tunnelConfiguration.interface.addresses {
             switch subnet.address {
             case .ip(_, let family):
-                let route = Route(subnet, subnet.address)
+                let route = Route(subnet.maskedSubnet, subnet.address)
                 switch family {
                 case .v4: ipv4IncludedRoutes.append(route)
                 case .v6: ipv6IncludedRoutes.append(route)
@@ -210,5 +232,87 @@ final class TunnelRemoteInfoGenerator: Sendable {
             }
         }
         return (ipv4IncludedRoutes, ipv6IncludedRoutes)
+    }
+}
+
+private extension Subnet {
+    var maskedSubnet: Subnet {
+        let maskedAddress: Address? = switch address.family {
+        case .v4:
+            address.network(with: ipv4Mask)
+        case .v6:
+            address.network(with: prefixLength)
+        case nil:
+            nil
+        }
+        guard let maskedAddress,
+              let maskedSubnet = Subnet(maskedAddress, prefixLength) else {
+            fatalError("Could not derive masked route subnet from interface address")
+        }
+        return maskedSubnet
+    }
+}
+
+private extension Endpoint {
+    func withReresolvedIP() throws -> Endpoint {
+#if os(iOS) || os(tvOS)
+        let hostname = address.rawValue
+
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = SOCK_DGRAM
+        hints.ai_protocol = IPPROTO_UDP
+        hints.ai_flags = 0
+
+        var resultPointer: UnsafeMutablePointer<addrinfo>?
+        defer {
+            resultPointer.flatMap {
+                freeaddrinfo($0)
+            }
+        }
+
+        let errorCode = getaddrinfo(hostname, "\(port)", &hints, &resultPointer)
+        if errorCode != 0 {
+            throw PartoutError(.dnsFailure)
+        }
+
+        var next = resultPointer
+        while let addrInfo = next?.pointee {
+            if let endpoint = Self.endpoint(from: addrInfo, port: port) {
+                return endpoint
+            }
+            next = addrInfo.ai_next
+        }
+        throw PartoutError(.dnsFailure)
+#else
+        return self
+#endif
+    }
+
+    private static func endpoint(from addrInfo: addrinfo, port: UInt16) -> Endpoint? {
+        guard let addr = addrInfo.ai_addr else {
+            return nil
+        }
+        var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+#if os(Windows)
+        let hostBufferLength = DWORD(hostBuffer.count)
+#elseif os(Android)
+        let hostBufferLength = Int(hostBuffer.count)
+#else
+        let hostBufferLength = socklen_t(hostBuffer.count)
+#endif
+        let result = getnameinfo(
+            addr,
+            socklen_t(addrInfo.ai_addrlen),
+            &hostBuffer,
+            hostBufferLength,
+            nil,
+            0,
+            NI_NUMERICHOST
+        )
+        guard result == 0 else {
+            return nil
+        }
+        return try? Endpoint(hostBuffer.string, port)
     }
 }

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardAdapter.swift
@@ -4,6 +4,7 @@
 internal import _PartoutCore_C
 internal import _PartoutWireGuard_C
 
+@available(*, deprecated, renamed: "WireGuardAdapterV2Delegate")
 protocol WireGuardAdapterDelegate: AnyObject, Sendable {
     func adapterShouldReassert(_ adapter: WireGuardAdapter, reasserting: Bool)
 
@@ -15,6 +16,7 @@ protocol WireGuardAdapterDelegate: AnyObject, Sendable {
 }
 
 /// Enum representing internal state of the `WireGuardAdapter`
+@available(*, deprecated, renamed: "WireGuardAdapterV2State")
 private enum WireGuardAdapterState {
     /// The tunnel is stopped
     case stopped
@@ -26,6 +28,7 @@ private enum WireGuardAdapterState {
     case temporaryShutdown(_ settingsGenerator: TunnelRemoteInfoGenerator)
 }
 
+@available(*, deprecated, renamed: "WireGuardAdapterV2")
 actor WireGuardAdapter {
     typealias LogHandler = @Sendable (WireGuardLogLevel, String) -> Void
 

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardAdapterV2.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardAdapterV2.swift
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
+
+internal import _PartoutCore_C
+internal import _PartoutWireGuard_C
+
+protocol WireGuardAdapterV2Delegate: AnyObject, Sendable {
+    func adapterShouldReassert(_ adapter: WireGuardAdapterV2, reasserting: Bool)
+
+    func adapterShouldSetNetworkSettings(_ adapter: WireGuardAdapterV2, settings: TunnelRemoteInfo) async throws -> IOInterface
+
+    func adapterShouldConfigureSockets(_ adapter: WireGuardAdapterV2, descriptors: [UInt64])
+
+    func adapterShouldClearNetworkSettings(_ adapter: WireGuardAdapterV2, tunnel: IOInterface) async
+}
+
+/// Enum representing internal state of the `WireGuardAdapterV2`
+private enum WireGuardAdapterV2State {
+    /// The tunnel is stopped
+    case stopped
+
+    /// The tunnel is up and running
+    case started(_ handle: Int32, _ settingsGenerator: TunnelRemoteInfoGeneratorV2)
+
+    /// The tunnel is temporarily shutdown due to device going offline
+    case temporaryShutdown(_ settingsGenerator: TunnelRemoteInfoGeneratorV2)
+}
+
+actor WireGuardAdapterV2 {
+    typealias LogHandler = @Sendable (WireGuardLogLevel, String) -> Void
+
+    private let ctx: PartoutLoggerContext
+
+    /// Adapter delegate.
+    private weak var delegate: WireGuardAdapterV2Delegate?
+
+    /// The ID of the original ``WireGuardModule``.
+    private let moduleId: UniqueID
+
+    private let dnsTimeout: Int
+
+    /// Backend implementation.
+    private let backend: WireGuardBackend
+
+    /// Network routes monitor.
+    private unowned let reachability: ReachabilityObserver
+
+    /// Log handler closure.
+    private let logHandler: LogHandler
+
+    /// Network reachability task.
+    private var reachabilityTask: Task<Void, Never>?
+
+    /// Virtual tunnel interface
+    private var tunnel: IOInterface?
+
+    /// Adapter state.
+    private var state: WireGuardAdapterV2State = .stopped
+
+    private var socketDescriptors: [Int32] {
+        guard case .started(let handle, _) = state else { return [] }
+        return backend.socketDescriptors(handle)
+    }
+
+    /// Tunnel device file descriptor.
+    private var tunnelFileDescriptor: Int32? {
+        didSet {
+            logHandler(.verbose, "Tunnel file descriptor: \(tunnelFileDescriptor.debugDescription)")
+            logHandler(.verbose, "Socket file descriptors: \(socketDescriptors)")
+        }
+    }
+
+    /// Returns a WireGuard version.
+    var backendVersion: String {
+        backend.version() ?? "unknown"
+    }
+
+    // MARK: - Initialization
+
+    /// Designated initializer.
+    init(
+        _ ctx: PartoutLoggerContext,
+        with delegate: WireGuardAdapterV2Delegate,
+        moduleId: UniqueID,
+        dnsTimeout: Int,
+        reachability: ReachabilityObserver,
+        logHandler: @escaping LogHandler
+    ) async {
+        self.ctx = ctx
+        self.delegate = delegate
+        self.moduleId = moduleId
+        self.dnsTimeout = dnsTimeout
+        backend = WireGuardBackend()
+        self.reachability = reachability
+        reachabilityTask = nil
+        self.logHandler = logHandler
+
+        setupReachabilityTask()
+        setupLogHandler()
+    }
+
+    deinit {
+        pp_log(ctx, .wireguard, .info, "Deinit WireGuardAdapterV2")
+
+        // Force remove logger to make sure that no further calls to the instance of this class
+        // can happen after deallocation.
+        backend.setLogger(context: nil, logger_fn: nil)
+
+        // Shutdown the tunnel
+        if case .started(let handle, _) = state {
+            backend.turnOff(handle)
+        }
+    }
+
+    // MARK: - Public methods
+
+    /// Returns a runtime configuration from WireGuard.
+    func getRuntimeConfiguration() async -> String? {
+        guard case .started(let handle, _) = state else {
+            return nil
+        }
+        return await Task.detached { [weak self] in
+            guard let self else { return nil }
+            guard let settings = backend.getConfig(handle) else { return nil }
+            return settings
+        }.value
+    }
+
+    /// Start the tunnel.
+    /// - Parameters:
+    ///   - tunnelConfiguration: tunnel configuration.
+    func start(tunnelConfiguration: WireGuard.Configuration) async throws {
+        pp_log(ctx, .wireguard, .info, "Start adapter")
+        guard case .stopped = state else {
+            throw WireGuardAdapterError.invalidState
+        }
+        do {
+            let settingsGenerator = makeSettingsGenerator(with: tunnelConfiguration)
+            let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
+            try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
+                moduleId: moduleId,
+                descriptors: socketDescriptors
+            ))
+            let handle = try startWireGuardBackend(wgConfig: wgConfig)
+            state = .started(handle, settingsGenerator)
+        } catch let error as WireGuardAdapterError {
+            throw error
+        } catch {
+            pp_log(ctx, .wireguard, .fault, "Unable to start: \(error)")
+            throw error
+        }
+    }
+
+    /// Stop the tunnel.
+    func stop() async throws {
+        pp_log(ctx, .wireguard, .info, "Stop adapter")
+        switch state {
+        case .started(let handle, _):
+            backend.turnOff(handle)
+        case .temporaryShutdown:
+            break
+        case .stopped:
+            throw WireGuardAdapterError.invalidState
+        }
+        state = .stopped
+        reachabilityTask?.cancel()
+        reachabilityTask = nil
+        if let tunnel {
+            await delegate?.adapterShouldClearNetworkSettings(self, tunnel: tunnel)
+            self.tunnel = nil
+        }
+    }
+
+    // MARK: - Private methods
+
+    private func setupReachabilityTask() {
+        reachabilityTask = Task { [weak self] in
+            guard let self else { return }
+            for await isReachable in reachability.isReachableStream {
+                guard !Task.isCancelled else { return }
+                await didUpdateReachable(isReachable: isReachable)
+            }
+        }
+    }
+
+    /// Setup WireGuard log handler.
+    private func setupLogHandler() {
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        backend.setLogger(context: context) { context, logLevel, message in
+            guard let context, let message else { return }
+
+            let unretainedSelf = Unmanaged<WireGuardAdapterV2>.fromOpaque(context)
+                .takeUnretainedValue()
+
+            let swiftString = String(cString: message).trimmingCharacters(in: .newlines)
+            let tunnelLogLevel = WireGuardLogLevel(rawValue: logLevel) ?? .verbose
+
+            unretainedSelf.logHandler(tunnelLogLevel, swiftString)
+        }
+    }
+
+    /// Set network tunnel configuration.
+    /// This method ensures that the call to `setTunnelNetworkSettings` does not time out, as in
+    /// certain scenarios the completion handler given to it may not be invoked by the system.
+    ///
+    /// - Parameters:
+    ///   - networkSettings: an instance of type `TunnelRemoteInfo`.
+    /// - Throws: an error of type `WireGuardAdapterError`.
+    /// - Returns: `PacketTunnelSettingsGenerator`.
+    private func setNetworkSettings(_ networkSettings: TunnelRemoteInfo) async throws {
+        guard let delegate else { return }
+        tunnel = try await delegate.adapterShouldSetNetworkSettings(self, settings: networkSettings)
+#if !os(Windows)
+        guard let tunFd = tunnel?.fileDescriptor.map(Int32.init) ?? fallbackFileDescriptor else {
+            throw WireGuardAdapterError.cannotLocateTunnelFileDescriptor
+        }
+        tunnelFileDescriptor = tunFd
+#endif
+    }
+
+    /// Start WireGuard backend.
+    /// - Parameter wgConfig: WireGuard configuration
+    /// - Throws: an error of type `WireGuardAdapterError`
+    /// - Returns: tunnel handle
+    private func startWireGuardBackend(wgConfig: String) throws -> Int32 {
+#if os(Windows)
+        guard let interfaceName else {
+            throw WireGuardAdapterError.cannotLocateTunnelFileDescriptor
+        }
+        let handle = backend.turnOn(settings: wgConfig, ifname: interfaceName)
+#else
+        guard let tunnelFileDescriptor else {
+            throw WireGuardAdapterError.cannotLocateTunnelFileDescriptor
+        }
+        let handle = backend.turnOn(settings: wgConfig, tun_fd: tunnelFileDescriptor)
+#endif
+        if handle < 0 {
+            throw WireGuardAdapterError.startWireGuardBackend(handle)
+        }
+#if os(iOS)
+        backend.disableSomeRoamingForBrokenMobileSemantics(handle)
+#endif
+        let socketFds = {
+            var rawFds = backend.socketDescriptors(handle)
+            if rawFds.isEmpty {
+                rawFds = fallbackFileDescriptor.map { [$0] } ?? []
+            }
+            return rawFds
+        }()
+        pp_log(ctx, .wireguard, .info, "Socket descriptors: \(socketFds)")
+        delegate?.adapterShouldConfigureSockets(self, descriptors: socketFds.map(UInt64.init))
+        return handle
+    }
+
+    /// Resolves the hostnames in the given tunnel configuration and return settings generator.
+    /// - Parameter tunnelConfiguration: an instance of type `WireGuard.Configuration`.
+    /// - Returns: an instance of type `TunnelRemoteInfoGeneratorV2`.
+    private func makeSettingsGenerator(with tunnelConfiguration: WireGuard.Configuration) -> TunnelRemoteInfoGeneratorV2 {
+        TunnelRemoteInfoGeneratorV2(
+            ctx,
+            tunnelConfiguration: tunnelConfiguration,
+            dnsTimeout: dnsTimeout
+        )
+    }
+
+    private func didUpdateReachable(isReachable: Bool) async {
+//        logHandler(.verbose, "Network change detected with \(path.status) route and interface order \(path.availableInterfaces)")
+        logHandler(.verbose, "Network change detected, reachable: \(isReachable)")
+
+        switch state {
+        case .started(let handle, let settingsGenerator):
+            if isReachable {
+                let wgConfig = await settingsGenerator.endpointUapiConfiguration(logHandler: logHandler)
+
+                backend.setConfig(handle, settings: wgConfig)
+                backend.disableSomeRoamingForBrokenMobileSemantics(handle)
+                backend.bumpSockets(handle)
+            } else {
+                logHandler(.verbose, "Connectivity offline, pausing backend.")
+
+                state = .temporaryShutdown(settingsGenerator)
+                backend.turnOff(handle)
+            }
+
+        case .temporaryShutdown(let settingsGenerator):
+            guard isReachable else { return }
+            logHandler(.verbose, "Connectivity online, resuming backend.")
+            do {
+                let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
+                try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
+                    moduleId: moduleId,
+                    descriptors: socketDescriptors
+                ))
+                let handle = try startWireGuardBackend(wgConfig: wgConfig)
+                state = .started(handle, settingsGenerator)
+            } catch {
+                logHandler(.error, "Failed to restart backend: \(error.localizedDescription)")
+            }
+
+        case .stopped:
+            // no-op
+            break
+        }
+    }
+
+    private nonisolated var fallbackFileDescriptor: Int32? {
+#if canImport(Darwin)
+        var ctlInfo = ctl_info()
+        withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
+            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
+                _ = strcpy($0, "com.apple.net.utun_control")
+            }
+        }
+        for fd: Int32 in 0...1024 {
+            var addr = sockaddr_ctl()
+            var ret: Int32 = -1
+            var len = socklen_t(MemoryLayout.size(ofValue: addr))
+            withUnsafeMutablePointer(to: &addr) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    ret = getpeername(fd, $0, &len)
+                }
+            }
+            if ret != 0 || addr.sc_family != AF_SYSTEM {
+                continue
+            }
+            if ctlInfo.ctl_id == 0 {
+                ret = ioctl(fd, CTLIOCGINFO, &ctlInfo)
+                if ret != 0 {
+                    continue
+                }
+            }
+            if addr.sc_id == ctlInfo.ctl_id {
+                return fd
+            }
+        }
+        return nil
+#else
+        return nil
+#endif
+    }
+}
+
+// MARK: - Low-level
+
+extension WireGuardAdapterV2 {
+    /// Returns the tunnel device interface name, or nil if unsupported or on error.
+    var interfaceName: String? {
+#if os(Windows)
+        moduleId.uuidString
+#elseif canImport(Darwin)
+        guard let tunnelFileDescriptor else { return nil }
+        var buffer = [UInt8](repeating: 0, count: Int(IFNAMSIZ))
+        return buffer.withUnsafeMutableBufferPointer { mutableBufferPointer in
+            guard let baseAddress = mutableBufferPointer.baseAddress else { return nil }
+
+            var ifnameSize = socklen_t(IFNAMSIZ)
+            let result = getsockopt(
+                tunnelFileDescriptor,
+                2 /* SYSPROTO_CONTROL */,
+                2 /* UTUN_OPT_IFNAME */,
+                baseAddress,
+                &ifnameSize)
+
+            guard result == 0 else { return nil }
+            return String(cString: baseAddress)
+        }
+#else
+        nil
+#endif
+    }
+}

--- a/Sources/PartoutWireGuardConnection/WireGuardConnection.swift
+++ b/Sources/PartoutWireGuardConnection/WireGuardConnection.swift
@@ -216,7 +216,7 @@ private extension String {
 
 // MARK: - Helpers
 
-private extension WireGuard.Configuration {
+extension WireGuard.Configuration {
     func withModules(from profile: Profile) throws -> Self {
         var newBuilder = builder()
 
@@ -226,9 +226,9 @@ private extension WireGuard.Configuration {
                 $0 as? IPModule
             }
             .forEach { ipModule in
-                newBuilder.peers = peers
+                newBuilder.peers = newBuilder.peers
                     .map { oldPeer in
-                        var peer = oldPeer.builder()
+                        var peer = oldPeer
                         ipModule.ipv4?.includedRoutes.forEach { route in
                             peer.allowedIPs.append(route.destination?.rawValue ?? "0.0.0.0/0")
                         }
@@ -248,9 +248,9 @@ private extension WireGuard.Configuration {
                 $0.routesThroughVPN == true
             }
             .forEach { dnsModule in
-                newBuilder.peers = peers
+                newBuilder.peers = newBuilder.peers
                     .map { oldPeer in
-                        var peer = oldPeer.builder()
+                        var peer = oldPeer
                         dnsModule.servers.forEach {
                             switch $0 {
                             case .ip(let addr, let family):

--- a/Sources/PartoutWireGuardConnection/WireGuardConnection.swift
+++ b/Sources/PartoutWireGuardConnection/WireGuardConnection.swift
@@ -216,7 +216,7 @@ private extension String {
 
 // MARK: - Helpers
 
-private extension WireGuard.Configuration {
+extension WireGuard.Configuration {
     func withModules(from profile: Profile) throws -> Self {
         var newBuilder = builder()
 

--- a/Sources/PartoutWireGuardConnection/WireGuardConnection.swift
+++ b/Sources/PartoutWireGuardConnection/WireGuardConnection.swift
@@ -13,6 +13,7 @@
 #endif
 
 /// Establishes a WireGuard connection.
+@available(*, deprecated, renamed: "WireGuardConnectionV2")
 public actor WireGuardConnection: Connection {
     private let ctx: PartoutLoggerContext
 

--- a/Sources/PartoutWireGuardConnection/WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/WireGuardConnectionV2.swift
@@ -13,7 +13,7 @@
 #endif
 
 /// Establishes a WireGuard connection.
-public actor WireGuardConnection: Connection {
+public actor WireGuardConnectionV2: Connection {
     private let ctx: PartoutLoggerContext
 
     private let statusSubject: CurrentValueStream<ConnectionStatus>
@@ -34,7 +34,7 @@ public actor WireGuardConnection: Connection {
 
     private var dataCountTimer: Task<Void, Error>?
 
-    private var adapter: WireGuardAdapter?
+    private var adapter: WireGuardAdapterV2?
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -52,14 +52,14 @@ public actor WireGuardConnection: Connection {
         guard let configuration = module.configuration else {
             throw PartoutError(.incompleteModule)
         }
-        pp_log(ctx, .wireguard, .notice, "WireGuard: Using cross-platform connection")
+        pp_log(ctx, .wireguard, .notice, "WireGuard: Using cross-platform connection V2")
 
-        tunnelConfiguration = try configuration.withModules(from: parameters.profile)
+        tunnelConfiguration = try configuration.withModulesV2(from: parameters.profile)
         dataCountTimerInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0
     }
 
     deinit {
-        pp_log(ctx, .wireguard, .info, "Deinit WireGuardConnection")
+        pp_log(ctx, .wireguard, .info, "Deinit WireGuardConnectionV2")
     }
 
     public nonisolated var statusStream: AsyncThrowingStream<ConnectionStatus, Error> {
@@ -68,14 +68,14 @@ public actor WireGuardConnection: Connection {
 
     public func start() async throws -> Bool {
         assert(adapter == nil)
-        adapter = await WireGuardAdapter(
+        adapter = await WireGuardAdapterV2(
             ctx,
             with: self,
             moduleId: moduleId,
             dnsTimeout: dnsTimeout,
             reachability: reachability,
             logHandler: { [weak self] logLevel, message in
-                pp_log(self?.ctx ?? .global, .wireguard, logLevel.debugLevel, message)
+                pp_log(self?.ctx ?? .global, .wireguard, logLevel.debugLevelV2, message)
             }
         )
         guard let adapter else { return false }
@@ -89,7 +89,7 @@ public actor WireGuardConnection: Connection {
                     return
                 }
                 guard !Task.isCancelled else {
-                    pp_log(ctx, .wireguard, .debug, "Cancelled WireGuardConnection.dataCountTimer")
+                    pp_log(ctx, .wireguard, .debug, "Cancelled WireGuardConnectionV2.dataCountTimer")
                     return
                 }
                 await onDataCountTimer()
@@ -141,16 +141,27 @@ public actor WireGuardConnection: Connection {
     }
 }
 
+private extension WireGuardLogLevel {
+    var debugLevelV2: DebugLog.Level {
+        switch self {
+        case .verbose:
+            return .debug
+        case .error:
+            return .error
+        }
+    }
+}
+
 // MARK: - WireGuardAdapterDelegate
 
-extension WireGuardConnection: WireGuardAdapterDelegate {
-    nonisolated func adapterShouldReassert(_ adapter: WireGuardAdapter, reasserting: Bool) {
+extension WireGuardConnectionV2: WireGuardAdapterV2Delegate {
+    nonisolated func adapterShouldReassert(_ adapter: WireGuardAdapterV2, reasserting: Bool) {
         if reasserting {
             statusSubject.send(.connecting)
         }
     }
 
-    func adapterShouldSetNetworkSettings(_ adapter: WireGuardAdapter, settings: TunnelRemoteInfo) async throws -> IOInterface {
+    func adapterShouldSetNetworkSettings(_ adapter: WireGuardAdapterV2, settings: TunnelRemoteInfo) async throws -> IOInterface {
         do {
             let tunnel = try await controller.setTunnelSettings(with: settings)
             pp_log(ctx, .wireguard, .info, "Tunnel interface is now UP")
@@ -163,23 +174,23 @@ extension WireGuardConnection: WireGuardAdapterDelegate {
         }
     }
 
-    nonisolated func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [UInt64]) {
+    nonisolated func adapterShouldConfigureSockets(_ adapter: WireGuardAdapterV2, descriptors: [UInt64]) {
         controller.configureSockets(with: descriptors)
     }
 
-    func adapterShouldClearNetworkSettings(_ adapter: WireGuardAdapter, tunnel: IOInterface) async {
+    func adapterShouldClearNetworkSettings(_ adapter: WireGuardAdapterV2, tunnel: IOInterface) async {
         await controller.clearTunnelSettings(tunnel)
     }
 }
 
 // MARK: - Data count
 
-private extension WireGuardConnection {
+private extension WireGuardConnectionV2 {
     func onDataCountTimer() async {
         guard let adapter else { return }
         guard statusSubject.value == .connected else { return }
         guard let configurationString = await adapter.getRuntimeConfiguration(),
-              let dataCount = DataCount.from(wireGuardString: configurationString) else {
+              let dataCount = DataCount.fromWireGuardStringV2(configurationString) else {
             return
         }
         environment.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
@@ -187,13 +198,13 @@ private extension WireGuardConnection {
 }
 
 private extension DataCount {
-    static func from(wireGuardString string: String) -> DataCount? {
+    static func fromWireGuardStringV2(_ string: String) -> DataCount? {
         var bytesReceived: UInt?
         var bytesSent: UInt?
         string.enumerateLines { line, stop in
-            if bytesReceived == nil, let value = line.getPrefix("rx_bytes=") {
+            if bytesReceived == nil, let value = line.getPrefixV2("rx_bytes=") {
                 bytesReceived = value
-            } else if bytesSent == nil, let value = line.getPrefix("tx_bytes=") {
+            } else if bytesSent == nil, let value = line.getPrefixV2("tx_bytes=") {
                 bytesSent = value
             }
             if bytesReceived != nil, bytesSent != nil {
@@ -206,7 +217,7 @@ private extension DataCount {
 }
 
 private extension String {
-    func getPrefix(_ prefixKey: String) -> UInt? {
+    func getPrefixV2(_ prefixKey: String) -> UInt? {
         guard hasPrefix(prefixKey) else {
             return nil
         }
@@ -217,7 +228,7 @@ private extension String {
 // MARK: - Helpers
 
 private extension WireGuard.Configuration {
-    func withModules(from profile: Profile) throws -> Self {
+    func withModulesV2(from profile: Profile) throws -> Self {
         var newBuilder = builder()
 
         // add IPModule.*.includedRoutes to AllowedIPs
@@ -226,9 +237,9 @@ private extension WireGuard.Configuration {
                 $0 as? IPModule
             }
             .forEach { ipModule in
-                newBuilder.peers = peers
+                newBuilder.peers = newBuilder.peers
                     .map { oldPeer in
-                        var peer = oldPeer.builder()
+                        var peer = oldPeer
                         ipModule.ipv4?.includedRoutes.forEach { route in
                             peer.allowedIPs.append(route.destination?.rawValue ?? "0.0.0.0/0")
                         }
@@ -248,9 +259,9 @@ private extension WireGuard.Configuration {
                 $0.routesThroughVPN == true
             }
             .forEach { dnsModule in
-                newBuilder.peers = peers
+                newBuilder.peers = newBuilder.peers
                     .map { oldPeer in
-                        var peer = oldPeer.builder()
+                        var peer = oldPeer
                         dnsModule.servers.forEach {
                             switch $0 {
                             case .ip(let addr, let family):
@@ -269,16 +280,5 @@ private extension WireGuard.Configuration {
             }
 
         return try newBuilder.build()
-    }
-}
-
-private extension WireGuardLogLevel {
-    var debugLevel: DebugLog.Level {
-        switch self {
-        case .verbose:
-            return .debug
-        case .error:
-            return .error
-        }
     }
 }

--- a/Sources/PartoutWireGuardConnection/WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/WireGuardConnectionV2.swift
@@ -227,7 +227,7 @@ private extension String {
 
 // MARK: - Helpers
 
-private extension WireGuard.Configuration {
+extension WireGuard.Configuration {
     func withModulesV2(from profile: Profile) throws -> Self {
         var newBuilder = builder()
 

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -6,7 +6,7 @@ import PartoutCore
 @testable import PartoutWireGuardConnection
 import Testing
 
-struct WireGuardAdapterTests {
+struct TunnelRemoteInfoGeneratorTests {
     @Test(arguments: [
         (["1.2.3.4", "22:4", "55:3:4::9f"], "1.2.3.4", "1.2.3.4"),
         (["22:4", "1.2.3.4", "55:3:4::9f"], "1.2.3.4", "22:4"),
@@ -24,7 +24,7 @@ struct WireGuardAdapterTests {
         }
         let targetIPv4Object = try Endpoint(targetIPv4, sourceEndpoint.port)
 
-        let withEnabled = WireGuard.Configuration.ResolvedMap()
+        let withEnabled = WireGuard.Configuration.ResolvedMapV2()
         await withEnabled.setEndpoints(endpointObjects, for: sourceEndpoint)
         let enabledMap = await withEnabled.toMap()
         #expect(enabledMap[sourceEndpoint] == targetIPv4Object)
@@ -37,7 +37,7 @@ struct WireGuardAdapterTests {
         let resolvedEndpoint1 = try Endpoint("1.2.3.4", sourceEndpoint1.port)
         let resolvedEndpoint2 = try Endpoint("5.6.7.8", sourceEndpoint2.port)
 
-        let withEnabled = WireGuard.Configuration.ResolvedMap()
+        let withEnabled = WireGuard.Configuration.ResolvedMapV2()
         await withEnabled.setEndpoints([resolvedEndpoint1], for: sourceEndpoint1)
         await withEnabled.setEndpoints([resolvedEndpoint2], for: sourceEndpoint2)
         let enabledMap = await withEnabled.toMap()
@@ -64,47 +64,24 @@ struct WireGuardAdapterTests {
             tunnelConfiguration: configuration,
             dnsTimeout: 1
         )
+        let sutV2 = TunnelRemoteInfoGeneratorV2(
+            .global,
+            tunnelConfiguration: configuration,
+            dnsTimeout: 1
+        )
         let info = sut.generateRemoteInfo(moduleId: UniqueID(), descriptors: [])
-        let ipModule = try #require(info.modules?.compactMap {
-            $0 as? IPModule
-        }.first)
+        let infoV2 = sutV2.generateRemoteInfo(moduleId: UniqueID(), descriptors: [])
+        let ipModule = try #require(info.modules?.compactMap { $0 as? IPModule }.first)
+        let ipModuleV2 = try #require(infoV2.modules?.compactMap { $0 as? IPModule }.first)
 
-        #expect(ipModule.ipv4?.includedRoutes.first?.destination?.rawValue == "10.0.0.0/24")
+        #expect(ipModule.ipv4?.includedRoutes.first?.destination?.rawValue != "10.0.0.0/24")
         #expect(ipModule.ipv4?.includedRoutes.first?.gateway?.rawValue == "10.0.0.2")
-        #expect(ipModule.ipv6?.includedRoutes.first?.destination?.rawValue == "fd00::/64")
+        #expect(ipModule.ipv6?.includedRoutes.first?.destination?.rawValue != "fd00::/64")
         #expect(ipModule.ipv6?.includedRoutes.first?.gateway?.rawValue == "fd00::2")
-    }
 
-    @Test
-    func givenIpRoutesAndVpnDns_whenApplyingProfileModules_thenKeepsAllAllowedIPs() throws {
-        let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
-        let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
-
-        var configurationBuilder = WireGuard.Configuration.Builder(privateKey: pvtkey)
-        var peerBuilder = WireGuard.RemoteInterface.Builder(publicKey: pubkey)
-        peerBuilder.allowedIPs = ["192.168.0.0/16"]
-        configurationBuilder.peers = [peerBuilder]
-
-        let ipSettings = IPSettings(subnet: try Subnet("10.10.10.2", 24))
-            .including(routes: [Route(try Subnet("10.20.0.0", 16), nil)])
-        let ipModule = IPModule.Builder(ipv4: ipSettings).build()
-        let dnsModule = try DNSModule.Builder(
-            servers: ["1.1.1.1", "2606:4700:4700::1111"],
-            routesThroughVPN: true
-        ).build()
-        let profile = try Profile.Builder(
-            name: "WG",
-            modules: [ipModule, dnsModule]
-        ).build()
-
-        let mergedConfiguration = try configurationBuilder.build().withModules(from: profile)
-        let allowedIPs = mergedConfiguration.peers[0].allowedIPs.map { $0.rawValue }
-
-        #expect(allowedIPs == [
-            "192.168.0.0/16",
-            "10.20.0.0/16",
-            "1.1.1.1/32",
-            "2606:4700:4700::1111/128"
-        ])
+        #expect(ipModuleV2.ipv4?.includedRoutes.first?.destination?.rawValue == "10.0.0.0/24")
+        #expect(ipModuleV2.ipv4?.includedRoutes.first?.gateway?.rawValue == "10.0.0.2")
+        #expect(ipModuleV2.ipv6?.includedRoutes.first?.destination?.rawValue == "fd00::/64")
+        #expect(ipModuleV2.ipv6?.includedRoutes.first?.gateway?.rawValue == "fd00::2")
     }
 }

--- a/Tests/PartoutWireGuardTests/WireGuardAdapterTests.swift
+++ b/Tests/PartoutWireGuardTests/WireGuardAdapterTests.swift
@@ -74,4 +74,37 @@ struct WireGuardAdapterTests {
         #expect(ipModule.ipv6?.includedRoutes.first?.destination?.rawValue == "fd00::/64")
         #expect(ipModule.ipv6?.includedRoutes.first?.gateway?.rawValue == "fd00::2")
     }
+
+    @Test
+    func givenIpRoutesAndVpnDns_whenApplyingProfileModules_thenKeepsAllAllowedIPs() throws {
+        let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
+        let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
+
+        var configurationBuilder = WireGuard.Configuration.Builder(privateKey: pvtkey)
+        var peerBuilder = WireGuard.RemoteInterface.Builder(publicKey: pubkey)
+        peerBuilder.allowedIPs = ["192.168.0.0/16"]
+        configurationBuilder.peers = [peerBuilder]
+
+        let ipSettings = IPSettings(subnet: try Subnet("10.10.10.2", 24))
+            .including(routes: [Route(try Subnet("10.20.0.0", 16), nil)])
+        let ipModule = IPModule.Builder(ipv4: ipSettings).build()
+        let dnsModule = try DNSModule.Builder(
+            servers: ["1.1.1.1", "2606:4700:4700::1111"],
+            routesThroughVPN: true
+        ).build()
+        let profile = try Profile.Builder(
+            name: "WG",
+            modules: [ipModule, dnsModule]
+        ).build()
+
+        let mergedConfiguration = try configurationBuilder.build().withModules(from: profile)
+        let allowedIPs = mergedConfiguration.peers[0].allowedIPs.map { $0.rawValue }
+
+        #expect(allowedIPs == [
+            "192.168.0.0/16",
+            "10.20.0.0/16",
+            "1.1.1.1/32",
+            "2606:4700:4700::1111/128"
+        ])
+    }
 }

--- a/Tests/PartoutWireGuardTests/WireGuardAdapterTests.swift
+++ b/Tests/PartoutWireGuardTests/WireGuardAdapterTests.swift
@@ -45,4 +45,33 @@ struct WireGuardAdapterTests {
         #expect(enabledMap[sourceEndpoint1] == resolvedEndpoint1)
         #expect(enabledMap[sourceEndpoint2] == resolvedEndpoint2)
     }
+
+    @Test
+    func givenInterfaceAddresses_whenGeneratingRemoteInfo_thenMasksInterfaceRoutes() throws {
+        let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
+        let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
+
+        var builder = WireGuard.Configuration.Builder(privateKey: pvtkey)
+        builder.interface.addresses = [
+            "10.0.0.2/24",
+            "fd00::2/64"
+        ]
+        builder.peers = [.init(publicKey: pubkey)]
+
+        let configuration = try builder.build()
+        let sut = TunnelRemoteInfoGenerator(
+            .global,
+            tunnelConfiguration: configuration,
+            dnsTimeout: 1
+        )
+        let info = sut.generateRemoteInfo(moduleId: UniqueID(), descriptors: [])
+        let ipModule = try #require(info.modules?.compactMap {
+            $0 as? IPModule
+        }.first)
+
+        #expect(ipModule.ipv4?.includedRoutes.first?.destination?.rawValue == "10.0.0.0/24")
+        #expect(ipModule.ipv4?.includedRoutes.first?.gateway?.rawValue == "10.0.0.2")
+        #expect(ipModule.ipv6?.includedRoutes.first?.destination?.rawValue == "fd00::/64")
+        #expect(ipModule.ipv6?.includedRoutes.first?.gateway?.rawValue == "fd00::2")
+    }
 }

--- a/Tests/PartoutWireGuardTests/WireGuardAdapterTests.swift
+++ b/Tests/PartoutWireGuardTests/WireGuardAdapterTests.swift
@@ -18,16 +18,31 @@ struct WireGuardAdapterTests {
         targetIPv4: String,
         targetAny: String
     ) async throws {
-        let address: Address = .hostname("foobar.com")
-        let port: UInt16 = 1080
+        let sourceEndpoint = try Endpoint("foobar.com", 1080)
         let endpointObjects = try endpoints.map {
-            try Endpoint($0, port)
+            try Endpoint($0, sourceEndpoint.port)
         }
-        let targetIPv4Object = try Endpoint(targetIPv4, port)
+        let targetIPv4Object = try Endpoint(targetIPv4, sourceEndpoint.port)
 
         let withEnabled = WireGuard.Configuration.ResolvedMap()
-        await withEnabled.setEndpoints(endpointObjects, for: address)
+        await withEnabled.setEndpoints(endpointObjects, for: sourceEndpoint)
         let enabledMap = await withEnabled.toMap()
-        #expect(enabledMap[address] == [targetIPv4Object])
+        #expect(enabledMap[sourceEndpoint] == targetIPv4Object)
+    }
+
+    @Test
+    func givenSameHostnameWithDifferentPorts_whenResolved_thenKeepsBothPeers() async throws {
+        let sourceEndpoint1 = try Endpoint("foobar.com", 1080)
+        let sourceEndpoint2 = try Endpoint("foobar.com", 2080)
+        let resolvedEndpoint1 = try Endpoint("1.2.3.4", sourceEndpoint1.port)
+        let resolvedEndpoint2 = try Endpoint("5.6.7.8", sourceEndpoint2.port)
+
+        let withEnabled = WireGuard.Configuration.ResolvedMap()
+        await withEnabled.setEndpoints([resolvedEndpoint1], for: sourceEndpoint1)
+        await withEnabled.setEndpoints([resolvedEndpoint2], for: sourceEndpoint2)
+        let enabledMap = await withEnabled.toMap()
+
+        #expect(enabledMap[sourceEndpoint1] == resolvedEndpoint1)
+        #expect(enabledMap[sourceEndpoint2] == resolvedEndpoint2)
     }
 }

--- a/Tests/PartoutWireGuardTests/WireGuardConfigurationTests.swift
+++ b/Tests/PartoutWireGuardTests/WireGuardConfigurationTests.swift
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import PartoutCore
+@testable import PartoutWireGuardConnection
+import Testing
+
+struct WireGuardConfigurationTests {
+    @Test
+    func givenIpRoutesAndVpnDns_whenApplyingProfileModules_thenKeepsAllAllowedIPs() throws {
+        let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
+        let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
+
+        var configurationBuilder = WireGuard.Configuration.Builder(privateKey: pvtkey)
+        var peerBuilder = WireGuard.RemoteInterface.Builder(publicKey: pubkey)
+        peerBuilder.allowedIPs = ["192.168.0.0/16"]
+        configurationBuilder.peers = [peerBuilder]
+
+        let ipSettings = IPSettings(subnet: try Subnet("10.10.10.2", 24))
+            .including(routes: [Route(try Subnet("10.20.0.0", 16), nil)])
+        let ipModule = IPModule.Builder(ipv4: ipSettings).build()
+        let dnsModule = try DNSModule.Builder(
+            servers: ["1.1.1.1", "2606:4700:4700::1111"],
+            routesThroughVPN: true
+        ).build()
+        let profile = try Profile.Builder(
+            name: "WG",
+            modules: [ipModule, dnsModule]
+        ).build()
+
+        let cfg = try configurationBuilder.build()
+        let mergedConfiguration = try cfg.withModules(from: profile)
+        let allowedIPs = mergedConfiguration.peers[0].allowedIPs.map(\.rawValue)
+        let mergedConfigurationV2 = try cfg.withModulesV2(from: profile)
+        let allowedIPsV2 = mergedConfigurationV2.peers[0].allowedIPs.map(\.rawValue)
+
+        let expectedAllowedIPs = [
+            "192.168.0.0/16",
+            "10.20.0.0/16",
+            "1.1.1.1/32",
+            "2606:4700:4700::1111/128"
+        ]
+        #expect(allowedIPs != expectedAllowedIPs)
+        #expect(allowedIPsV2 == expectedAllowedIPs)
+    }
+}


### PR DESCRIPTION
Some disparities surfaced after committing the .wgCrossConnection config flag in 3.6.3

- The "satisfiable" condition in NEObservablePath was not equal
- Resolved endpoints were keyed by address rather than endpoint (includes port)
- Re-resolve endpoints before applying tunnel config
- Merged modules could be discarded while applying to peers
- Included routes in remote info generator didn't account for the network mask
  - #323
  - E.g., 10.2.0.2/24 included the 10.2.0.2 route rather than 10.2.0.0
  - https://github.com/partout-io/partout/pull/324/changes#diff-f86b92b27090ea0181eef28cc16d1493591ee8ecadcb77e29807afcb59250382R211

Duplicate WireGuardConnection and related to "V2" suffix counterparts for soft migration.

Other than that, fix potential races in NEObservablePath.

Fixes #322 
Fixes #323 