### PR TITLE
NE: Disconnect from unmatched network when on-demand policy is "Including"

### DIFF
--- a/Sources/PartoutOS/AppleNE/Modules/OnDemandModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/OnDemandModule+NE.swift
@@ -8,7 +8,7 @@ extension OnDemandModule {
     func neRules(_ ctx: PartoutLoggerContext) -> [NEOnDemandRule] {
         var rules: [NEOnDemandRule] = []
 
-        // apply exceptions (unless .any)
+        // Apply exceptions (unless .any)
         if policy != .any {
             if Self.supportsCellular, withMobileNetwork {
                 if let rule = cellularRule() {
@@ -30,14 +30,13 @@ extension OnDemandModule {
             }
         }
 
-        // IMPORTANT: append fallback rule last
+        // IMPORTANT: Append fallback rule last
         rules.append(globalRule())
 
         pp_log(ctx, .os, .info, "On-demand rules:")
         rules.forEach {
             pp_log(ctx, .os, .info, "\($0)")
         }
-
         return rules
     }
 }
@@ -89,7 +88,7 @@ private extension OnDemandModule {
 
     func wifiRule(SSIDs: [String]) -> NEOnDemandRule {
         let rule = networkRule(matchingInterface: .wiFi)
-        rule.ssidMatch = SSIDs.sorted() // for testing
+        rule.ssidMatch = SSIDs.sorted() // Predictable, for testing
         return rule
     }
 }

--- a/Sources/PartoutOS/AppleNE/Modules/OnDemandModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/OnDemandModule+NE.swift
@@ -48,10 +48,14 @@ private extension OnDemandModule {
         case .any, .excluding:
             rule = NEOnDemandRuleConnect()
         case .including:
-            rule = NEOnDemandRuleIgnore()
+            rule = NEOnDemandRuleDisconnect()
         @unknown default:
             rule = NEOnDemandRuleConnect()
         }
+        // This might be the culprit, WG only matches .wiFi
+        // IIRC, when .any is set with .including policy (i.e. fall
+        // back to a disconnect rule), the profile could not
+        // activate (forcibly disconnected). Maybe only on iOS?
         rule.interfaceTypeMatch = .any
         return rule
     }

--- a/Tests/PartoutOSTests/AppleNE/OnDemandModuleRulesTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/OnDemandModuleRulesTests.swift
@@ -100,7 +100,7 @@ struct OnDemandModuleRulesTests {
             wifiRule.interfaceTypeMatch = .wiFi
             wifiRule.ssidMatch = ["home", "nope"]
             rules.append(wifiRule)
-            rules.append(NEOnDemandRuleIgnore())
+            rules.append(NEOnDemandRuleDisconnect())
             return rules
         }()
         #expect(sut.neRules == computedRules)


### PR DESCRIPTION
It seems to work properly on iOS/macOS 26.

Fixes #10 