### PR TITLE
Fail early on ineffective DNS settings

### DIFF
--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -155,7 +155,7 @@ extension DNSModule {
             let validProtocolType: ProtocolType
             switch protocolType {
             case .cleartext:
-                guard !servers.isEmpty else {
+                guard !validServers.isEmpty else {
                     throw PartoutError.invalidFields(["servers": nil])
                 }
                 validProtocolType = .cleartext

--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -155,6 +155,9 @@ extension DNSModule {
             let validProtocolType: ProtocolType
             switch protocolType {
             case .cleartext:
+                guard !servers.isEmpty else {
+                    throw PartoutError.invalidFields(["servers": nil])
+                }
                 validProtocolType = .cleartext
             case .https:
                 guard !dohURL.isEmpty,

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -13,7 +13,7 @@ extension DNSModule: NESettingsApplying {
         switch protocolType {
         case .cleartext:
             guard !rawServers.isEmpty else {
-                pp_log(ctx, .os, .info, "\t\tSkip DNS settings, cleartext requires non-empty servers")
+                pp_log(ctx, .os, .error, "\t\tSkip DNS settings, cleartext requires non-empty servers")
                 return
             }
             dnsSettings = NEDNSSettings(servers: rawServers)
@@ -48,36 +48,38 @@ extension DNSModule: NESettingsApplying {
         // Credit for .matchDomains:
         // https://github.com/WireGuard/wireguard-apple/pull/11
         //
-        switch domainPolicy {
-        case .search:
-            dnsSettings.searchDomains = searchDomains
-            // XXX: This works around a Network Extension bug. We add the
-            // search domains here because .searchDomains is ineffective when
-            // the VPN is not the default gateway
-            dnsSettings.matchDomains = [""] + searchDomains
-            dnsSettings.matchDomainsNoSearch = false
-            pp_log(ctx, .os, .info, "\t\tSearch-only domains: \(domainsDescription)")
-        case .match:
-            let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
+        if dnsSettings.dnsProtocol == .cleartext {
+            switch domainPolicy {
+            case .search:
+                dnsSettings.searchDomains = searchDomains
+                // XXX: This works around a Network Extension bug. We add the
+                // search domains here because .searchDomains is ineffective when
+                // the VPN is not the default gateway
+                dnsSettings.matchDomains = [""] + searchDomains
+                dnsSettings.matchDomainsNoSearch = false
+                pp_log(ctx, .os, .info, "\t\tSearch-only domains: \(domainsDescription)")
+            case .match:
+                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
+                dnsSettings.searchDomains = nil
+                dnsSettings.matchDomains = matchDomains
+                dnsSettings.matchDomainsNoSearch = true
+                pp_log(ctx, .os, .info, "\t\tMatch-only domains: \(domainsDescription)")
+            default:
+                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
+                dnsSettings.searchDomains = searchDomains
+                dnsSettings.matchDomains = matchDomains
+                dnsSettings.matchDomainsNoSearch = false
+                pp_log(ctx, .os, .info, "\t\tMatch/Search domains: \(domainsDescription)")
+            }
+        } else if !domains.isEmpty {
+            //
+            // This is why we guard before committing .matchDomains:
+            // https://git.zx2c4.com/wireguard-apple/commit/?id=20bdf46792905de8862ae7641e50e0f9f99ec946
+            //
+            // XXX: Network Extension seems to ignore domains completely
+            // when DNS is configured to use DoH/DoT
+            pp_log(ctx, .os, .error, "\t\tSkip DNS match/search domains, ignored in DoH/DoT")
             dnsSettings.searchDomains = nil
-            dnsSettings.matchDomains = matchDomains
-            dnsSettings.matchDomainsNoSearch = true
-            pp_log(ctx, .os, .info, "\t\tMatch-only domains: \(domainsDescription)")
-        default:
-            let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
-            dnsSettings.searchDomains = searchDomains
-            dnsSettings.matchDomains = matchDomains
-            dnsSettings.matchDomainsNoSearch = false
-            pp_log(ctx, .os, .info, "\t\tMatch/Search domains: \(domainsDescription)")
-        }
-
-        //
-        // This is why we guard before committing .matchDomains:
-        // https://git.zx2c4.com/wireguard-apple/commit/?id=20bdf46792905de8862ae7641e50e0f9f99ec946
-        //
-        assert(dnsSettings.matchDomains != nil)
-        if dnsSettings.servers.isEmpty {
-            pp_log(ctx, .os, .error, "\t\tIgnoring match domains without bootstrap DNS servers")
             dnsSettings.matchDomains = nil
         }
 

--- a/Sources/PartoutWireGuard/Internal/Configuration+WgQuickConfig.swift
+++ b/Sources/PartoutWireGuard/Internal/Configuration+WgQuickConfig.swift
@@ -175,8 +175,10 @@ extension WireGuard.Configuration {
                     dnsSearch.append(addr.rawValue)
                 }
             }
-            interface.dns.servers = dnsServers.map(\.rawValue)
-            interface.dns.domains = dnsSearch
+            var dns = DNSModule.Builder()
+            dns.servers = dnsServers.map(\.rawValue)
+            dns.domains = dnsSearch
+            interface.dns = dns
         }
         if let mtuString = attributes["mtu"] {
             guard let mtu = UInt16(mtuString) else {

--- a/Sources/PartoutWireGuard/LocalInterface.swift
+++ b/Sources/PartoutWireGuard/LocalInterface.swift
@@ -29,7 +29,7 @@ extension WireGuard {
         public func builder() -> Builder {
             var copy = Builder(privateKey: privateKey.rawValue)
             copy.addresses = addresses.map(\.rawValue)
-            copy.dns = dns?.builder() ?? DNSModule.Builder()
+            copy.dns = dns?.builder()
             copy.mtu = mtu
             return copy
         }
@@ -42,19 +42,19 @@ extension WireGuard.LocalInterface {
 
         public var addresses: [String]
 
-        public var dns: DNSModule.Builder
+        public var dns: DNSModule.Builder?
 
         public var mtu: UInt16?
 
         public init(privateKey: String) {
             self.privateKey = privateKey
-            dns = DNSModule.Builder()
+            dns = nil
             addresses = []
         }
 
         public init(keyGenerator: WireGuardKeyGenerator) {
             privateKey = keyGenerator.newPrivateKey()
-            dns = DNSModule.Builder()
+            dns = nil
             addresses = []
         }
 
@@ -71,7 +71,7 @@ extension WireGuard.LocalInterface {
             return WireGuard.LocalInterface(
                 privateKey: validPrivateKey,
                 addresses: validAddresses,
-                dns: try dns.build(),
+                dns: try dns?.build(),
                 mtu: mtu
             )
         }

--- a/Sources/PartoutWireGuard/StandardWireGuardParser+Validate.swift
+++ b/Sources/PartoutWireGuard/StandardWireGuardParser+Validate.swift
@@ -29,9 +29,11 @@ private extension WireGuard.Configuration.Builder {
         if !interface.addresses.isEmpty {
             lines.append("Address = \(interface.addresses.wgJoined)")
         }
-        let dnsEntries = interface.dns.servers + (interface.dns.domains ?? [])
-        if !dnsEntries.isEmpty {
-            lines.append("DNS = \(dnsEntries.wgJoined)")
+        if let dns = interface.dns {
+            let dnsEntries = dns.servers + (dns.domains ?? [])
+            if !dnsEntries.isEmpty {
+                lines.append("DNS = \(dnsEntries.wgJoined)")
+            }
         }
         if let mtu = interface.mtu {
             lines.append("MTU = \(mtu)")

--- a/Tests/PartoutCoreTests/ProfileDiffTests.swift
+++ b/Tests/PartoutCoreTests/ProfileDiffTests.swift
@@ -39,7 +39,7 @@ struct ProfileDiffTests {
 
         var diff: Set<Profile.DiffResult>
 
-        let dnsModule = try DNSModule.Builder().build()
+        let dnsModule = try DNSModule.Builder(servers: ["6.6.6.6"]).build()
         sut.modules = [dnsModule]
         let profileWithDNS = try sut.build()
         diff = profileWithDNS.differences(from: original)

--- a/Tests/PartoutCoreTests/ProfileTests.swift
+++ b/Tests/PartoutCoreTests/ProfileTests.swift
@@ -20,7 +20,7 @@ struct ProfileTests {
     @Test
     func givenProfile_whenCopy_thenHasNotSameModules() throws {
         var p1 = Profile.Builder()
-        let m1 = DNSModule.Builder()
+        let m1 = DNSModule.Builder(servers: ["1.2.3.4"])
         p1.name = "One"
         p1.modules = [try m1.build()]
 

--- a/Tests/PartoutCoreTests/TunnelTests.swift
+++ b/Tests/PartoutCoreTests/TunnelTests.swift
@@ -23,7 +23,7 @@ struct TunnelTests {
     @Test
     func givenTunnel_whenOperate_thenStatusFollows() async throws {
         let sut = newTunnel()
-        let module = try DNSModule.Builder().build()
+        let module = IPModule.Builder().build()
         let profile = try Profile.Builder(modules: [module], activatingModules: true).build()
         let stream = sut.snapshotsStream.removeDuplicates()
 

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -125,7 +125,7 @@ struct ProfileNetworkSettingsTests {
 
     @Test
     func givenProfile_whenGetNetworkSettingsWithInfo_thenAppliesInfo() throws {
-        let bogusModule = try DNSModule.Builder().build()
+        let bogusModule = try DNSModule.Builder(servers: ["1.1.1.1"]).build()
         let profile = try Profile.Builder(
             modules: [bogusModule],
             activeModulesIds: [bogusModule.id]
@@ -134,7 +134,7 @@ struct ProfileNetworkSettingsTests {
         let sut = profile.networkSettings(with: .init(
             originalModuleId: bogusModule.id,
             address: Address(rawValue: "5.6.7.8")!,
-            modules: [try DNSModule.Builder(servers: ["1.1.1.1"]).build()],
+            modules: [bogusModule],
             fileDescriptors: []
         ))
 

--- a/Tests/PartoutTests/CodingRegistryTests.swift
+++ b/Tests/PartoutTests/CodingRegistryTests.swift
@@ -22,7 +22,7 @@ struct CodingRegistryTests {
         wgBuilder.peers = [WireGuard.RemoteInterface.Builder(publicKey: "")]
 
         var profileBuilder = Profile.Builder()
-        profileBuilder.modules.append(try DNSModule.Builder().build())
+        profileBuilder.modules.append(try DNSModule.Builder(servers: ["1.1.1.1"]).build())
         profileBuilder.modules.append(IPModule.Builder(ipv4: .init(subnet: try .init("1.2.3.4", 16))).build())
         profileBuilder.modules.append(OnDemandModule.Builder().build())
         profileBuilder.modules.append(try HTTPProxyModule.Builder(address: "1.1.1.1", port: 1080).build())
@@ -43,7 +43,7 @@ struct CodingRegistryTests {
             DNSModule.moduleHandler
         ])
         let sut = registry.withLegacyEncoding(legacy)
-        let module = try DNSModule.Builder().build()
+        let module = try DNSModule.Builder(servers: ["1.1.1.1"]).build()
         let profile = try Profile.Builder(modules: [module]).build()
 
         let encoded = try sut.string(fromProfile: profile)
@@ -57,7 +57,7 @@ struct CodingRegistryTests {
             DNSModule.moduleHandler
         ])
         let sut = registry.withLegacyEncoding(legacy)
-        let module = try DNSModule.Builder().build()
+        let module = try DNSModule.Builder(servers: ["1.1.1.1"]).build()
         let profile = try Profile.Builder(modules: [module]).build()
 
         let encoded = try sut.string(fromProfile: profile)

--- a/Tests/PartoutTests/NEProtocolCoderTests.swift
+++ b/Tests/PartoutTests/NEProtocolCoderTests.swift
@@ -59,7 +59,7 @@ private extension NEProtocolCoderTests {
     func newProfile() throws -> Profile {
         var builder = Profile.Builder()
         builder.name = "foobar"
-        builder.modules.append(try DNSModule.Builder().build())
+        builder.modules.append(try DNSModule.Builder(servers: ["2.4.2.4"]).build())
         builder.modules.append(try HTTPProxyModule.Builder(address: "1.1.1.1", port: 1080, pacURLString: "http://proxy.pac").build())
         builder.modules.append(IPModule.Builder(ipv4: .init(subnet: try .init("1.2.3.4", 16))).build())
         builder.modules.append(OnDemandModule.Builder().build())


### PR DESCRIPTION
- Reject .cleartext settings with empty servers, makes match/search domains ineffective (throw on build)
- Ignore ineffective domains in .https/.tls and log (NE-specific bug)
- Make DNS optional in WireGuardModule