### PR TITLE
NE: Inherit VPN DNS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   run_tests:
     name: Run SwiftPM tests
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 5
     steps:
       - uses: partout-io/action-prepare-xcode-build@master

--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -14,7 +14,6 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
 
     public enum DomainPolicy: String, Hashable, Codable, Sendable {
         case match
-        case matchAndSearch
     }
 
     public static let moduleType = ModuleType("DNS")
@@ -126,7 +125,7 @@ extension DNSModule {
             dotHostname: String = "",
             domains: [String]? = nil,
             inheritsVPN: Bool = false,
-            domainPolicy: DomainPolicy? = .matchAndSearch,
+            domainPolicy: DomainPolicy? = .match,
             isFirstDomainPrimary: Bool = false,
             routesThroughVPN: Bool? = nil
         ) {

--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -14,6 +14,7 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
 
     public enum DomainPolicy: String, Hashable, Codable, Sendable {
         case match
+        case matchAndSearch
     }
 
     public static let moduleType = ModuleType("DNS")
@@ -125,7 +126,7 @@ extension DNSModule {
             dotHostname: String = "",
             domains: [String]? = nil,
             inheritsVPN: Bool = false,
-            domainPolicy: DomainPolicy? = .match,
+            domainPolicy: DomainPolicy? = .matchAndSearch,
             isFirstDomainPrimary: Bool = false,
             routesThroughVPN: Bool? = nil
         ) {

--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -29,6 +29,8 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
 
     public let searchDomains: [Address]?
 
+    public let inheritsVPN: Bool?
+
     public let domainPolicy: DomainPolicy?
 
     public let routesThroughVPN: Bool?
@@ -39,6 +41,7 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
         servers: [Address],
         domainName: Address?,
         searchDomains: [Address]?,
+        inheritsVPN: Bool?,
         domainPolicy: DomainPolicy?,
         routesThroughVPN: Bool?
     ) {
@@ -47,6 +50,7 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
         self.servers = servers
         self.domainName = domainName
         self.searchDomains = searchDomains
+        self.inheritsVPN = inheritsVPN
         self.domainPolicy = domainPolicy
         self.routesThroughVPN = routesThroughVPN
     }
@@ -81,6 +85,7 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
             builder.isFirstDomainPrimary = false
             builder.domains = searchDomains.map(\.rawValue)
         }
+        builder.inheritsVPN = inheritsVPN
         builder.domainPolicy = domainPolicy
         builder.routesThroughVPN = routesThroughVPN
         return builder
@@ -101,6 +106,8 @@ extension DNSModule {
 
         public var domains: [String]?
 
+        public var inheritsVPN: Bool?
+
         public var domainPolicy: DomainPolicy?
 
         public var isFirstDomainPrimary: Bool
@@ -118,6 +125,7 @@ extension DNSModule {
             dohURL: String = "",
             dotHostname: String = "",
             domains: [String]? = nil,
+            inheritsVPN: Bool? = false,
             domainPolicy: DomainPolicy? = nil,
             isFirstDomainPrimary: Bool = false,
             routesThroughVPN: Bool? = nil
@@ -128,6 +136,7 @@ extension DNSModule {
             self.dohURL = dohURL
             self.dotHostname = dotHostname
             self.domains = domains
+            self.inheritsVPN = inheritsVPN
             self.domainPolicy = domainPolicy
             self.isFirstDomainPrimary = isFirstDomainPrimary
             self.routesThroughVPN = routesThroughVPN
@@ -178,6 +187,7 @@ extension DNSModule {
                 servers: validServers,
                 domainName: isFirstDomainPrimary ? validDomains?.first : nil,
                 searchDomains: validDomains,
+                inheritsVPN: inheritsVPN,
                 domainPolicy: domainPolicy,
                 routesThroughVPN: routesThroughVPN
             )

--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -85,7 +85,7 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
             builder.isFirstDomainPrimary = false
             builder.domains = searchDomains.map(\.rawValue)
         }
-        builder.inheritsVPN = inheritsVPN
+        builder.inheritsVPN = inheritsVPN ?? false
         builder.domainPolicy = domainPolicy
         builder.routesThroughVPN = routesThroughVPN
         return builder
@@ -106,7 +106,7 @@ extension DNSModule {
 
         public var domains: [String]?
 
-        public var inheritsVPN: Bool?
+        public var inheritsVPN: Bool
 
         public var domainPolicy: DomainPolicy?
 
@@ -125,7 +125,7 @@ extension DNSModule {
             dohURL: String = "",
             dotHostname: String = "",
             domains: [String]? = nil,
-            inheritsVPN: Bool? = false,
+            inheritsVPN: Bool = false,
             domainPolicy: DomainPolicy? = nil,
             isFirstDomainPrimary: Bool = false,
             routesThroughVPN: Bool? = nil

--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -142,43 +142,51 @@ extension DNSModule {
         }
 
         public func build() throws -> DNSModule {
-            let validServers = try servers.compactMap {
-                guard !$0.isEmpty else {
-                    return nil as Address?
+            let validServers: [Address]
+            let validDomains: [Address]?
+            let validProtocolType: DNSModule.ProtocolType
+            if inheritsVPN != true {
+                validServers = try servers.compactMap {
+                    guard !$0.isEmpty else {
+                        return nil as Address?
+                    }
+                    guard let addr = Address(rawValue: $0), addr.isIPAddress else {
+                        throw PartoutError.invalidFields(["servers": $0])
+                    }
+                    return addr
                 }
-                guard let addr = Address(rawValue: $0), addr.isIPAddress else {
-                    throw PartoutError.invalidFields(["servers": $0])
+                validDomains = try domains?.compactMap {
+                    guard !$0.isEmpty else {
+                        return nil as Address?
+                    }
+                    guard let addr = Address(rawValue: $0), !addr.isIPAddress else {
+                        throw PartoutError.invalidFields(["domains": $0])
+                    }
+                    return addr
                 }
-                return addr
-            }
-            let validDomains = try domains?.compactMap {
-                guard !$0.isEmpty else {
-                    return nil as Address?
+                switch protocolType {
+                case .cleartext:
+                    guard !validServers.isEmpty else {
+                        throw PartoutError.invalidFields(["servers": nil])
+                    }
+                    validProtocolType = .cleartext
+                case .https:
+                    guard !dohURL.isEmpty,
+                          let url = URL(string: dohURL),
+                          url.scheme == "https" else {
+                        throw PartoutError.invalidFields(["dohURL": dohURL])
+                    }
+                    validProtocolType = .https(url: url)
+                case .tls:
+                    guard !dotHostname.isEmpty else {
+                        throw PartoutError.invalidFields(["dotHostname": nil])
+                    }
+                    validProtocolType = .tls(hostname: dotHostname)
                 }
-                guard let addr = Address(rawValue: $0), !addr.isIPAddress else {
-                    throw PartoutError.invalidFields(["domains": $0])
-                }
-                return addr
-            }
-            let validProtocolType: ProtocolType
-            switch protocolType {
-            case .cleartext:
-                guard !validServers.isEmpty else {
-                    throw PartoutError.invalidFields(["servers": nil])
-                }
+            } else {
+                validServers = []
+                validDomains = nil
                 validProtocolType = .cleartext
-            case .https:
-                guard !dohURL.isEmpty,
-                      let url = URL(string: dohURL),
-                      url.scheme == "https" else {
-                    throw PartoutError.invalidFields(["dohURL": dohURL])
-                }
-                validProtocolType = .https(url: url)
-            case .tls:
-                guard !dotHostname.isEmpty else {
-                    throw PartoutError.invalidFields(["dotHostname": nil])
-                }
-                validProtocolType = .tls(hostname: dotHostname)
             }
             return DNSModule(
                 id: id,

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -65,7 +65,7 @@ extension DNSModule: NESettingsApplying {
                 dnsSettings.searchDomains = searchDomains
                 dnsSettings.matchDomains = matchDomains
                 dnsSettings.matchDomainsNoSearch = false
-                pp_log(ctx, .os, .info, "\t\tMatch domains: \(domainsDescription)")
+                pp_log(ctx, .os, .info, "\t\tMatch/Search domains: \(domainsDescription)")
             default:
                 // XXX: .searchDomains is ineffective when the VPN is not the default
                 // gateway. Appending .searchDomains to .matchDomains would be a partial

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -34,16 +34,27 @@ extension DNSModule: NESettingsApplying {
             break
         }
 
+        // Reuse DNS servers/domains from VPN if desired
+        let rawDomainName: String?
+        let rawDomains: [String]?
+        if inheritsVPN == true {
+            rawDomainName = settings.dnsSettings?.domainName
+            rawDomains = settings.dnsSettings?.searchDomains
+        } else {
+            rawDomainName = domainName?.rawValue
+            rawDomains = searchDomains?.map(\.rawValue)
+        }
+
         // Main domain (if set)
-        domainName.map {
-            dnsSettings.domainName = $0.rawValue
+        rawDomainName.map {
+            dnsSettings.domainName = $0
             pp_log(ctx, .os, .info, "\t\tDomain: \($0.asSensitiveAddress(ctx))")
         }
 
         // Apply domains with the given policy
-        let domains = searchDomains ?? []
+        let domains = rawDomains ?? []
         let domainsDescription = domains.map { $0.asSensitiveAddress(ctx) }
-        let searchDomains = domains.map(\.rawValue)
+        let searchDomains = domains
         //
         // Credit for .matchDomains:
         // https://github.com/WireGuard/wireguard-apple/pull/11

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -7,7 +7,20 @@ import NetworkExtension
 extension DNSModule: NESettingsApplying {
     public func apply(_ ctx: PartoutLoggerContext, to settings: inout NEPacketTunnelNetworkSettings) {
         let dnsSettings: NEDNSSettings
-        let rawServers = servers.map(\.rawValue)
+
+        // Reuse DNS servers/domains from VPN if desired
+        let rawServers: [String]
+        let rawDomainName: String?
+        let rawDomains: [String]?
+        if inheritsVPN == true {
+            rawServers = settings.dnsSettings?.servers ?? []
+            rawDomainName = settings.dnsSettings?.domainName
+            rawDomains = settings.dnsSettings?.searchDomains
+        } else {
+            rawServers = servers.map(\.rawValue)
+            rawDomainName = domainName?.rawValue
+            rawDomains = searchDomains?.map(\.rawValue)
+        }
 
         // Former DNS settings are always overridden, even with empty servers
         switch protocolType {
@@ -32,17 +45,6 @@ extension DNSModule: NESettingsApplying {
             pp_log(ctx, .os, .info, "\t\tDoT hostname: \(hostname.asSensitiveAddress(ctx))")
         @unknown default:
             break
-        }
-
-        // Reuse DNS servers/domains from VPN if desired
-        let rawDomainName: String?
-        let rawDomains: [String]?
-        if inheritsVPN == true {
-            rawDomainName = settings.dnsSettings?.domainName
-            rawDomains = settings.dnsSettings?.searchDomains
-        } else {
-            rawDomainName = domainName?.rawValue
-            rawDomains = searchDomains?.map(\.rawValue)
         }
 
         // Main domain (if set)

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -62,16 +62,10 @@ extension DNSModule: NESettingsApplying {
             switch domainPolicy {
             case .match:
                 let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
-                dnsSettings.searchDomains = nil
-                dnsSettings.matchDomains = matchDomains
-                dnsSettings.matchDomainsNoSearch = true
-                pp_log(ctx, .os, .info, "\t\tMatch-only domains: \(domainsDescription)")
-            case .matchAndSearch:
-                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
                 dnsSettings.searchDomains = searchDomains
                 dnsSettings.matchDomains = matchDomains
                 dnsSettings.matchDomainsNoSearch = false
-                pp_log(ctx, .os, .info, "\t\tMatch/Search domains: \(domainsDescription)")
+                pp_log(ctx, .os, .info, "\t\tMatch domains: \(domainsDescription)")
             default:
                 // XXX: .searchDomains is ineffective when the VPN is not the default
                 // gateway. Appending .searchDomains to .matchDomains would be a partial

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -7,54 +7,51 @@ import NetworkExtension
 extension DNSModule: NESettingsApplying {
     public func apply(_ ctx: PartoutLoggerContext, to settings: inout NEPacketTunnelNetworkSettings) {
         let dnsSettings: NEDNSSettings
+        let domains: [String]
 
-        // Reuse DNS servers/domains from VPN if desired
-        let rawServers: [String]
-        let rawDomainName: String?
-        let rawDomains: [String]?
-        if inheritsVPN == true {
-            rawServers = settings.dnsSettings?.servers ?? []
-            rawDomainName = settings.dnsSettings?.domainName
-            rawDomains = settings.dnsSettings?.searchDomains
+        // Reuse DNS settings from VPN if desired (and if any)
+        if inheritsVPN == true, let currentDNSSettings = settings.dnsSettings {
+            dnsSettings = currentDNSSettings
+            domains = dnsSettings.searchDomains ?? []
         } else {
-            rawServers = servers.map(\.rawValue)
-            rawDomainName = domainName?.rawValue
-            rawDomains = searchDomains?.map(\.rawValue)
-        }
+            let rawServers = servers.map(\.rawValue)
+            let rawDomainName = domainName?.rawValue
+            let rawDomains = searchDomains?.map(\.rawValue)
+            domains = rawDomains ?? []
 
-        // Former DNS settings are always overridden, even with empty servers
-        switch protocolType {
-        case .cleartext:
-            guard !rawServers.isEmpty else {
-                pp_log(ctx, .os, .error, "\t\tSkip DNS settings, cleartext requires non-empty servers")
-                return
+            // Former DNS settings are always overridden, even with empty servers
+            switch protocolType {
+            case .cleartext:
+                guard !rawServers.isEmpty else {
+                    pp_log(ctx, .os, .error, "\t\tSkip DNS settings, cleartext requires non-empty servers")
+                    return
+                }
+                dnsSettings = NEDNSSettings(servers: rawServers)
+                pp_log(ctx, .os, .info, "\t\tServers: \(servers.map { $0.asSensitiveAddress(ctx) })")
+            case .https(let url):
+                let specificSettings = NEDNSOverHTTPSSettings(servers: rawServers)
+                specificSettings.serverURL = url
+                dnsSettings = specificSettings
+                pp_log(ctx, .os, .info, "\t\tServers: \(servers.map { $0.asSensitiveAddress(ctx) })")
+                pp_log(ctx, .os, .info, "\t\tDoH URL: \(url.absoluteString.asSensitiveAddress(ctx))")
+            case .tls(let hostname):
+                let specificSettings = NEDNSOverTLSSettings(servers: rawServers)
+                specificSettings.serverName = hostname
+                dnsSettings = specificSettings
+                pp_log(ctx, .os, .info, "\t\tServers: \(servers.map { $0.asSensitiveAddress(ctx) })")
+                pp_log(ctx, .os, .info, "\t\tDoT hostname: \(hostname.asSensitiveAddress(ctx))")
+            @unknown default:
+                break
             }
-            dnsSettings = NEDNSSettings(servers: rawServers)
-            pp_log(ctx, .os, .info, "\t\tServers: \(servers.map { $0.asSensitiveAddress(ctx) })")
-        case .https(let url):
-            let specificSettings = NEDNSOverHTTPSSettings(servers: rawServers)
-            specificSettings.serverURL = url
-            dnsSettings = specificSettings
-            pp_log(ctx, .os, .info, "\t\tServers: \(servers.map { $0.asSensitiveAddress(ctx) })")
-            pp_log(ctx, .os, .info, "\t\tDoH URL: \(url.absoluteString.asSensitiveAddress(ctx))")
-        case .tls(let hostname):
-            let specificSettings = NEDNSOverTLSSettings(servers: rawServers)
-            specificSettings.serverName = hostname
-            dnsSettings = specificSettings
-            pp_log(ctx, .os, .info, "\t\tServers: \(servers.map { $0.asSensitiveAddress(ctx) })")
-            pp_log(ctx, .os, .info, "\t\tDoT hostname: \(hostname.asSensitiveAddress(ctx))")
-        @unknown default:
-            break
-        }
 
-        // Main domain (if set)
-        rawDomainName.map {
-            dnsSettings.domainName = $0
-            pp_log(ctx, .os, .info, "\t\tDomain: \($0.asSensitiveAddress(ctx))")
+            // Main domain (if set)
+            rawDomainName.map {
+                dnsSettings.domainName = $0
+                pp_log(ctx, .os, .info, "\t\tDomain: \($0.asSensitiveAddress(ctx))")
+            }
         }
 
         // Apply domains with the given policy
-        let domains = rawDomains ?? []
         let domainsDescription = domains.map { $0.asSensitiveAddress(ctx) }
         let searchDomains = domains
         //

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -62,6 +62,12 @@ extension DNSModule: NESettingsApplying {
             switch domainPolicy {
             case .match:
                 let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
+                dnsSettings.searchDomains = nil
+                dnsSettings.matchDomains = matchDomains
+                dnsSettings.matchDomainsNoSearch = true
+                pp_log(ctx, .os, .info, "\t\tMatch-only domains: \(domainsDescription)")
+            case .matchAndSearch:
+                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
                 dnsSettings.searchDomains = searchDomains
                 dnsSettings.matchDomains = matchDomains
                 dnsSettings.matchDomainsNoSearch = false

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -7,17 +7,17 @@ import NetworkExtension
 extension DNSModule: NESettingsApplying {
     public func apply(_ ctx: PartoutLoggerContext, to settings: inout NEPacketTunnelNetworkSettings) {
         let dnsSettings: NEDNSSettings
-        let domains: [String]
+        let rawDomains: [String]
 
         // Reuse DNS settings from VPN if desired (and if any)
         if inheritsVPN == true, let currentDNSSettings = settings.dnsSettings {
             dnsSettings = currentDNSSettings
-            domains = dnsSettings.searchDomains ?? []
+
+            // Reuse search domains for matching
+            rawDomains = dnsSettings.searchDomains ?? []
         } else {
             let rawServers = servers.map(\.rawValue)
-            let rawDomainName = domainName?.rawValue
-            let rawDomains = searchDomains?.map(\.rawValue)
-            domains = rawDomains ?? []
+            rawDomains = searchDomains?.map(\.rawValue) ?? []
 
             // Former DNS settings are always overridden, even with empty servers
             switch protocolType {
@@ -45,15 +45,15 @@ extension DNSModule: NESettingsApplying {
             }
 
             // Main domain (if set)
-            rawDomainName.map {
-                dnsSettings.domainName = $0
+            domainName.map {
+                dnsSettings.domainName = $0.rawValue
                 pp_log(ctx, .os, .info, "\t\tDomain: \($0.asSensitiveAddress(ctx))")
             }
         }
 
         // Apply domains with the given policy
-        let domainsDescription = domains.map { $0.asSensitiveAddress(ctx) }
-        let searchDomains = domains
+        let domainsDescription = rawDomains.map { $0.asSensitiveAddress(ctx) }
+        let searchDomains = rawDomains
         //
         // Credit for .matchDomains:
         // https://github.com/WireGuard/wireguard-apple/pull/11
@@ -81,7 +81,7 @@ extension DNSModule: NESettingsApplying {
                 dnsSettings.matchDomainsNoSearch = false
                 pp_log(ctx, .os, .info, "\t\tSearch-only domains: \(domainsDescription)")
             }
-        } else if !domains.isEmpty {
+        } else if !rawDomains.isEmpty {
             //
             // This is why we guard before committing .matchDomains:
             // https://git.zx2c4.com/wireguard-apple/commit/?id=20bdf46792905de8862ae7641e50e0f9f99ec946

--- a/Sources/PartoutOS/AppleNE/Modules/Profile+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/Profile+NE.swift
@@ -105,8 +105,9 @@ extension Profile {
             } else {
                 pp_log(ctx, .os, .info, "\tRoute DNS outside the VPN")
             }
-            dnsModule.servers.forEach {
-                switch $0 {
+            neSettings.dnsSettings?.servers.forEach {
+                guard let addr = Address(rawValue: $0) else { return }
+                switch addr {
                 case .ip(let addr, let family):
                     switch family {
                     case .v4:

--- a/Tests/PartoutOSTests/AppleNE/NESettingsApplyingTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NESettingsApplyingTests.swift
@@ -121,6 +121,45 @@ struct NESettingsApplyingTests {
         #expect(dnsSettings.searchDomains == expSearchDomains)
     }
 
+    @Test(arguments: [true, false])
+    func givenDNS_whenInheritsVPN_thenInheritsServersAndDomains(inheritsVPN: Bool) throws {
+        let moduleServers = ["1.1.1.1"]
+        let moduleDomainName = "other.org"
+        let moduleSearchDomains = ["other.org", "some.co.uk", "who.net"]
+        let vpnServers = ["8.8.8.8"]
+        let vpnDomainName = "main.com"
+        let vpnSearchDomains = ["domain.com", "one.com", "two.com"]
+
+        let module = try DNSModule.Builder(
+            protocolType: .cleartext,
+            servers: moduleServers,
+            domains: moduleSearchDomains,
+            inheritsVPN: inheritsVPN,
+            isFirstDomainPrimary: true
+        ).build()
+
+        let dns = NEDNSSettings(servers: vpnServers)
+        dns.domainName = vpnDomainName
+        dns.searchDomains = vpnSearchDomains
+
+        var sut = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: "")
+        sut.dnsSettings = dns
+        module.apply(.global, to: &sut)
+
+        let dnsSettings = try #require(sut.dnsSettings)
+        #expect(dnsSettings.dnsProtocol == .cleartext)
+        switch inheritsVPN {
+        case true:
+            #expect(dnsSettings.servers == vpnServers)
+            #expect(dnsSettings.domainName == vpnDomainName)
+            #expect(dnsSettings.searchDomains == vpnSearchDomains)
+        case false:
+            #expect(dnsSettings.servers == moduleServers)
+            #expect(dnsSettings.domainName == moduleDomainName)
+            #expect(dnsSettings.searchDomains == moduleSearchDomains)
+        }
+    }
+
     @Test
     func givenDNSOverHTTPS_whenApply_thenUpdatesSettings() throws {
         let module = try DNSModule.Builder(

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -66,7 +66,8 @@ struct ProfileNetworkSettingsTests {
 
     @Test(arguments: [
         nil as DNSModule.DomainPolicy?,
-        .match
+        .match,
+        .matchAndSearch
     ])
     func givenProfile_whenGetNetworkSettings_thenAppliesProperDNSPolicy(policy: DNSModule.DomainPolicy?) throws {
         let connectionModule = BogusConnectionModule()
@@ -110,6 +111,10 @@ struct ProfileNetworkSettingsTests {
         let dns = try #require(sut.dnsSettings)
         switch policy {
         case .match:
+            #expect(dns.searchDomains == nil)
+            #expect(dns.matchDomains == domains)
+            #expect(dns.matchDomainsNoSearch == true)
+        case .matchAndSearch:
             #expect(dns.searchDomains == domains)
             #expect(dns.matchDomains == domains)
             #expect(dns.matchDomainsNoSearch == false)

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -66,8 +66,7 @@ struct ProfileNetworkSettingsTests {
 
     @Test(arguments: [
         nil as DNSModule.DomainPolicy?,
-        .match,
-        .matchAndSearch
+        .match
     ])
     func givenProfile_whenGetNetworkSettings_thenAppliesProperDNSPolicy(policy: DNSModule.DomainPolicy?) throws {
         let connectionModule = BogusConnectionModule()
@@ -111,10 +110,6 @@ struct ProfileNetworkSettingsTests {
         let dns = try #require(sut.dnsSettings)
         switch policy {
         case .match:
-            #expect(dns.searchDomains == nil)
-            #expect(dns.matchDomains == domains)
-            #expect(dns.matchDomainsNoSearch == true)
-        case .matchAndSearch:
             #expect(dns.searchDomains == domains)
             #expect(dns.matchDomains == domains)
             #expect(dns.matchDomainsNoSearch == false)

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -21,6 +21,8 @@ components:
           title: DomainPolicy
         id:
           "$ref": "#/components/schemas/UniqueID"
+        inheritsVPN:
+          type: boolean
         protocolType:
           "$ref": "#/components/schemas/DNSModule.ProtocolType"
         routesThroughVPN:

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -43,9 +43,11 @@ components:
     DNSModule.DomainPolicy:
       enum:
         - match
+        - matchAndSearch
       type: string
       x-enum-varnames:
         - match
+        - matchAndSearch
     DNSModule.ProtocolType:
       discriminator:
         mapping:

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -43,11 +43,9 @@ components:
     DNSModule.DomainPolicy:
       enum:
         - match
-        - matchAndSearch
       type: string
       x-enum-varnames:
         - match
-        - matchAndSearch
     DNSModule.ProtocolType:
       discriminator:
         mapping:


### PR DESCRIPTION
Add a field to inherit DNS protocol/servers/domains from the VPN module of the profile (if any). Skip validations in that case.