### PR TITLE
Restore DNS search behavior

### DIFF
--- a/Sources/PartoutCore/Modules/DNSModule.swift
+++ b/Sources/PartoutCore/Modules/DNSModule.swift
@@ -13,8 +13,8 @@ public struct DNSModule: Module, BuildableType, Hashable, Codable {
     }
 
     public enum DomainPolicy: String, Hashable, Codable, Sendable {
-        case search
         case match
+        case matchAndSearch
     }
 
     public static let moduleType = ModuleType("DNS")
@@ -118,7 +118,7 @@ extension DNSModule {
             dohURL: String = "",
             dotHostname: String = "",
             domains: [String]? = nil,
-            domainPolicy: DomainPolicy? = nil,
+            domainPolicy: DomainPolicy? = .matchAndSearch,
             isFirstDomainPrimary: Bool = false,
             routesThroughVPN: Bool? = nil
         ) {

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -51,8 +51,8 @@ extension DNSModule: NESettingsApplying {
         if dnsSettings.dnsProtocol == .cleartext {
             switch domainPolicy {
             case .search:
-                // FIXME: #298/passepartout, .searchDomains ineffective when not default gateway
-                // Appending .searchDomains to .matchDomains would be a partial
+                // XXX: .searchDomains is ineffective when the VPN is not the default
+                // gateway. Appending .searchDomains to .matchDomains would be a partial
                 // workaround, but this is essentially a bug in Network Extension.
                 dnsSettings.searchDomains = searchDomains
                 dnsSettings.matchDomains = [""]

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -50,7 +50,19 @@ extension DNSModule: NESettingsApplying {
         //
         if dnsSettings.dnsProtocol == .cleartext {
             switch domainPolicy {
-            case .search:
+            case .match:
+                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
+                dnsSettings.searchDomains = nil
+                dnsSettings.matchDomains = matchDomains
+                dnsSettings.matchDomainsNoSearch = true
+                pp_log(ctx, .os, .info, "\t\tMatch-only domains: \(domainsDescription)")
+            case .matchAndSearch:
+                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
+                dnsSettings.searchDomains = searchDomains
+                dnsSettings.matchDomains = matchDomains
+                dnsSettings.matchDomainsNoSearch = false
+                pp_log(ctx, .os, .info, "\t\tMatch/Search domains: \(domainsDescription)")
+            default:
                 // XXX: .searchDomains is ineffective when the VPN is not the default
                 // gateway. Appending .searchDomains to .matchDomains would be a partial
                 // workaround, but this is essentially a bug in Network Extension.
@@ -58,18 +70,6 @@ extension DNSModule: NESettingsApplying {
                 dnsSettings.matchDomains = [""]
                 dnsSettings.matchDomainsNoSearch = false
                 pp_log(ctx, .os, .info, "\t\tSearch-only domains: \(domainsDescription)")
-            case .match:
-                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
-                dnsSettings.searchDomains = nil
-                dnsSettings.matchDomains = matchDomains
-                dnsSettings.matchDomainsNoSearch = true
-                pp_log(ctx, .os, .info, "\t\tMatch-only domains: \(domainsDescription)")
-            default:
-                let matchDomains = !searchDomains.isEmpty ? searchDomains : [""]
-                dnsSettings.searchDomains = searchDomains
-                dnsSettings.matchDomains = matchDomains
-                dnsSettings.matchDomainsNoSearch = false
-                pp_log(ctx, .os, .info, "\t\tMatch/Search domains: \(domainsDescription)")
             }
         } else if !domains.isEmpty {
             //

--- a/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/DNSModule+NE.swift
@@ -51,11 +51,11 @@ extension DNSModule: NESettingsApplying {
         if dnsSettings.dnsProtocol == .cleartext {
             switch domainPolicy {
             case .search:
+                // FIXME: #298/passepartout, .searchDomains ineffective when not default gateway
+                // Appending .searchDomains to .matchDomains would be a partial
+                // workaround, but this is essentially a bug in Network Extension.
                 dnsSettings.searchDomains = searchDomains
-                // XXX: This works around a Network Extension bug. We add the
-                // search domains here because .searchDomains is ineffective when
-                // the VPN is not the default gateway
-                dnsSettings.matchDomains = [""] + searchDomains
+                dnsSettings.matchDomains = [""]
                 dnsSettings.matchDomainsNoSearch = false
                 pp_log(ctx, .os, .info, "\t\tSearch-only domains: \(domainsDescription)")
             case .match:

--- a/Sources/PartoutOS/AppleNE/Modules/Profile+NE.swift
+++ b/Sources/PartoutOS/AppleNE/Modules/Profile+NE.swift
@@ -16,20 +16,20 @@ extension Profile {
         pp_log(ctx, .os, .info, "Build NetworkExtension settings from Profile")
         pp_log(ctx, .os, .info, "\tTunnel remote address: \(tunnelRemoteAddress.asSensitiveAddress(ctx))")
 
-        // 1. gather active modules
+        // 1. Gather active modules
 
         var applicableModules = modules.filter {
             isActiveModule(withId: $0.id)
         }
 
-        // 2. inject remote modules right after the originating module
+        // 2. Inject remote modules right after the originating module
 
         if let info, let remoteModules = info.modules,
            let indexOfRemoteModule = applicableModules.firstIndex(where: { $0.id == info.originalModuleId }) {
             applicableModules.insert(contentsOf: remoteModules, at: indexOfRemoteModule + 1)
         }
 
-        // 3. apply modules to NE settings
+        // 3. Apply modules to NE settings
 
         applicableModules.forEach {
             let moduleDescription = LoggableModule(ctx, $0)
@@ -52,19 +52,7 @@ extension Profile {
         let isGateway = isGatewayIPv4 || isGatewayIPv6
         pp_log(ctx, .os, .info, "\tVPN is default gateway: \(isGateway)")
 
-        // 4. configure DNS for domain-based routing
-
-        if let dnsSettings = neSettings.dnsSettings {
-            // Route DNS through VPN first unless:
-            // - No servers provided
-            // - .matchDomains is not configured
-            // This is a fallback as it *SHOULD* be accomplished by DNSModule+NE
-            if !dnsSettings.servers.isEmpty, dnsSettings.matchDomains == nil {
-                neSettings.dnsSettings?.matchDomains = [""]
-            }
-        }
-
-        // 5. configure DNS for non-connection profiles
+        // 4. Configure DNS for non-connection profiles
 
         if activeConnectionModule == nil {
             // XXX: The tunnel takes several seconds to stop if only DNS settings
@@ -79,7 +67,7 @@ extension Profile {
             pp_log(ctx, .os, .info, "\tRoute DNS-only settings with empty matchDomains")
         }
 
-        // 6. optionally enable DNS fallback if default gateway without DNS settings
+        // 5. Optionally enable DNS fallback if default gateway without DNS settings
 
         if isGateway, neSettings.dnsSettings == nil {
             pp_log(ctx, .os, .info, "\tVPN is default gateway but has no DNS settings")
@@ -91,7 +79,7 @@ extension Profile {
             }
         }
 
-        // 7. optionally route DNS through the VPN
+        // 6. Optionally route DNS through the VPN
 
         applicableModules.forEach {
             guard let dnsModule = $0 as? DNSModule else {

--- a/Sources/PartoutOpenVPNConnection/Internal/NetworkSettingsBuilder.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/NetworkSettingsBuilder.swift
@@ -227,6 +227,7 @@ private extension NetworkSettingsBuilder {
 
         pp_log(ctx, .openvpn, .info, "\tDNS: Set servers \(dnsServers.map { $0.asSensitiveAddress(ctx) })")
         var dnsSettings = DNSModule.Builder(servers: dnsServers)
+        dnsSettings.domainPolicy = .search
 
         if let domain = dnsDomain {
             pp_log(ctx, .openvpn, .info, "\tDNS: Set domain: \(domain.asSensitiveAddress(ctx))")

--- a/Sources/PartoutOpenVPNConnection/Internal/NetworkSettingsBuilder.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/NetworkSettingsBuilder.swift
@@ -227,7 +227,7 @@ private extension NetworkSettingsBuilder {
 
         pp_log(ctx, .openvpn, .info, "\tDNS: Set servers \(dnsServers.map { $0.asSensitiveAddress(ctx) })")
         var dnsSettings = DNSModule.Builder(servers: dnsServers)
-        dnsSettings.domainPolicy = .search
+        dnsSettings.domainPolicy = nil
 
         if let domain = dnsDomain {
             pp_log(ctx, .openvpn, .info, "\tDNS: Set domain: \(domain.asSensitiveAddress(ctx))")

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -100,7 +100,8 @@ struct ProfileNetworkSettingsTests {
 
         //
 
-        dnsModuleBuilder.domains = ["domain.com"]
+        let domains = ["domain.com"]
+        dnsModuleBuilder.domains = domains
         dnsModuleBuilder.domainPolicy = policy
         sut = try Profile.Builder(
             modules: [connectionModule, ipModule, try dnsModuleBuilder.build()],
@@ -110,13 +111,16 @@ struct ProfileNetworkSettingsTests {
         let dns = try #require(sut.dnsSettings)
         switch policy {
         case .search:
+            #expect(dns.searchDomains == domains)
             #expect(dns.matchDomains == [""])
             #expect(dns.matchDomainsNoSearch == false)
         case .match:
-            #expect(dns.matchDomains == ["domain.com"])
+            #expect(dns.searchDomains == nil)
+            #expect(dns.matchDomains == domains)
             #expect(dns.matchDomainsNoSearch == true)
         default:
-            #expect(dns.matchDomains == ["domain.com"])
+            #expect(dns.searchDomains == domains)
+            #expect(dns.matchDomains == domains)
             #expect(dns.matchDomainsNoSearch == false)
         }
     }

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -109,12 +109,12 @@ struct ProfileNetworkSettingsTests {
 
         let dns = try #require(sut.dnsSettings)
         switch policy {
+        case .search:
+            #expect(dns.matchDomains == [""])
+            #expect(dns.matchDomainsNoSearch == false)
         case .match:
             #expect(dns.matchDomains == ["domain.com"])
             #expect(dns.matchDomainsNoSearch == true)
-        case .search:
-            #expect(dns.matchDomains == ["", "domain.com"])
-            #expect(dns.matchDomainsNoSearch == false)
         default:
             #expect(dns.matchDomains == ["domain.com"])
             #expect(dns.matchDomainsNoSearch == false)

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -67,7 +67,7 @@ struct ProfileNetworkSettingsTests {
     @Test(arguments: [
         nil as DNSModule.DomainPolicy?,
         .match,
-        .search
+        .matchAndSearch
     ])
     func givenProfile_whenGetNetworkSettings_thenAppliesProperDNSPolicy(policy: DNSModule.DomainPolicy?) throws {
         let connectionModule = BogusConnectionModule()
@@ -110,17 +110,17 @@ struct ProfileNetworkSettingsTests {
 
         let dns = try #require(sut.dnsSettings)
         switch policy {
-        case .search:
-            #expect(dns.searchDomains == domains)
-            #expect(dns.matchDomains == [""])
-            #expect(dns.matchDomainsNoSearch == false)
         case .match:
             #expect(dns.searchDomains == nil)
             #expect(dns.matchDomains == domains)
             #expect(dns.matchDomainsNoSearch == true)
-        default:
+        case .matchAndSearch:
             #expect(dns.searchDomains == domains)
             #expect(dns.matchDomains == domains)
+            #expect(dns.matchDomainsNoSearch == false)
+        default:
+            #expect(dns.searchDomains == domains)
+            #expect(dns.matchDomains == [""])
             #expect(dns.matchDomainsNoSearch == false)
         }
     }


### PR DESCRIPTION
Revert to the former .searchDomains behavior without appending them to .matchDomains, because the meaning is not equivalent. Also, make .search the default policy, and remove the .matchDomains fallback because:

- If OpenVPN provides a DNSModule (in NetworkSettingsBuilder), it takes care of .matchDomains
- WireGuard provides a whole NEPacketTunnelSettings object with .matchDomains = [""]

The only other place where DNS was configured was in Profile+NE for fallback servers when the VPN is the default gateway. However, matchDomains is redundant there because, quoting [the documentation](https://developer.apple.com/documentation/networkextension/nednssettings/matchdomains):

> If the VPN tunnel becomes the network’s default route, the servers listed earlier by NEDNSSettings become the default resolver and the matchDomains list is ignored.