### PR TITLE
Start daemon connection on demand

### DIFF
--- a/Sources/PartoutCore/Connection/ConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/ConnectionDaemon.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /// Connection daemon handling async I/O.
-public protocol ConnectionDaemon: Sendable {
+public protocol ConnectionDaemon: AnyObject, Sendable {
     nonisolated var profile: Profile { get }
 
     func start() async throws

--- a/Sources/PartoutCore/Connection/DummyReachabilityObserver.swift
+++ b/Sources/PartoutCore/Connection/DummyReachabilityObserver.swift
@@ -4,9 +4,14 @@
 
 /// A ``ReachabilityObserver`` that never emits reachable events (for development).
 public final class DummyReachabilityObserver: ReachabilityObserver {
-    public init() {}
+    private let stream: CurrentValueStream<Bool>
+
+    public init() {
+        stream = CurrentValueStream(false)
+    }
 
     public func startObserving() {
+        stream.send(true)
     }
 
     public var isReachable: Bool {
@@ -15,6 +20,6 @@ public final class DummyReachabilityObserver: ReachabilityObserver {
 
     // BEWARE that true will emit INFINITE events (CPU 100%)
     public var isReachableStream: AsyncStream<Bool> {
-        AsyncStream { nil }
+        stream.subscribe()
     }
 }

--- a/Sources/PartoutCore/Connection/NetworkObserver.swift
+++ b/Sources/PartoutCore/Connection/NetworkObserver.swift
@@ -13,7 +13,7 @@ public final class NetworkObserver: @unchecked Sendable {
     private let isStatusReady: (ConnectionStatus) -> Bool
 
     /// Publishes when the network state is ready for reconnection.
-    public let onReady: PassthroughStream<Void>
+    public let onReady: CurrentValueStream<Bool>
 
     private var subscriptions: [Task<Void, Never>]
 
@@ -34,7 +34,7 @@ public final class NetworkObserver: @unchecked Sendable {
         state = AtomicState()
         signalSubject = CurrentValueStream(false)
         self.isStatusReady = isStatusReady
-        onReady = PassthroughStream()
+        onReady = CurrentValueStream(false)
         subscriptions = []
 
         observeObjects(reachabilityStream, statusStream)
@@ -56,7 +56,7 @@ private extension NetworkObserver {
         guard isSatisfied else {
             return
         }
-        onReady.send()
+        onReady.send(true)
     }
 }
 

--- a/Sources/PartoutCore/Connection/ReachabilityObserver.swift
+++ b/Sources/PartoutCore/Connection/ReachabilityObserver.swift
@@ -4,7 +4,6 @@
 
 /// Publishes path updates.
 public protocol ReachabilityObserver: AnyObject, Sendable {
-
     /// Starts observing network events.
     func startObserving()
 

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -218,12 +218,15 @@ extension SimpleConnectionDaemon {
         assert(statusSubscription == nil)
         assert(networkSubscription == nil)
 
+        let connectionStatusStream = connection.statusStream.dropFirst()
+        let onNetworkReadyStream = networkObserver.onReady.subscribe()
+
         // Observe the connection status (except the initial .disconnected)
         statusSubscription?.cancel()
         statusSubscription = Task { [weak self] in
             guard let self else { return }
             do {
-                for try await status in connection.statusStream.dropFirst() {
+                for try await status in connectionStatusStream {
                     guard !Task.isCancelled else {
                         pp_log_id(profile.id, .core, .debug, "Cancelled SimpleConnectionDaemon.statusStream")
                         return
@@ -238,7 +241,7 @@ extension SimpleConnectionDaemon {
         // Observe the network for starting the connection
         networkSubscription = Task { [weak self] in
             guard let self else { return }
-            for await _ in networkObserver.onReady.subscribe() {
+            for await _ in onNetworkReadyStream {
                 guard !Task.isCancelled else {
                     pp_log_id(profile.id, .core, .debug, "Cancelled NetworkObserver.onReady")
                     return

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -170,7 +170,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         clearEnvironment()
 
         // Cancel pending tasks to avoid leaks
-        statusSubscription?.cancel()
+//        statusSubscription?.cancel()
         networkSubscription?.cancel()
         networkObserverTask?.cancel()
 
@@ -219,6 +219,7 @@ extension SimpleConnectionDaemon {
         assert(networkSubscription == nil)
 
         // Observe the connection status (except the initial .disconnected)
+        statusSubscription?.cancel()
         statusSubscription = Task { [weak self] in
             guard let self else { return }
             do {

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -23,6 +23,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let reconnectionDelay: Int
 
+    private let onStatus: ((ConnectionStatus) -> Void)?
+
     private var connection: Connection?
 
     private let networkObserver: NetworkObserver?
@@ -62,6 +64,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         messageHandler = params.messageHandler
         stopDelay = params.stopDelay
         reconnectionDelay = params.reconnectionDelay
+        onStatus = params.onStatus
 
         isStarted = false
         isStopped = false
@@ -335,6 +338,7 @@ extension SimpleConnectionDaemon {
             controller.setReasserting(false)
             resumeNetworkObserver(after: reconnectionDelay)
         }
+        onStatus?(connectionStatus)
     }
 
     func onConnectionError(_ error: Error) {
@@ -357,18 +361,22 @@ extension SimpleConnectionDaemon {
 
         let reconnectionDelay: Int
 
+        let onStatus: ((ConnectionStatus) -> Void)?
+
         public init(
             connectionFactory: ConnectionFactory,
             connectionParameters: ConnectionParameters,
             messageHandler: MessageHandler,
             stopDelay: Int? = nil,
-            reconnectionDelay: Int? = nil
+            reconnectionDelay: Int? = nil,
+            onStatus: ((ConnectionStatus) -> Void)? = nil
         ) {
             self.connectionFactory = connectionFactory
             self.connectionParameters = connectionParameters
             self.messageHandler = messageHandler
             self.stopDelay = stopDelay ?? 2000
             self.reconnectionDelay = reconnectionDelay ?? 2000
+            self.onStatus = onStatus
         }
     }
 }

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -23,7 +23,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let reconnectionDelay: Int
 
-    private let onStatus: ((ConnectionStatus) -> Void)?
+    private let onStatus: StatusCallback?
 
     private var connection: Connection?
 
@@ -335,7 +335,7 @@ extension SimpleConnectionDaemon {
             controller.setReasserting(false)
             resumeNetworkObserver(after: reconnectionDelay)
         }
-        onStatus?(connectionStatus)
+        onStatus?(profile.id, connectionStatus)
     }
 
     func onConnectionError(_ error: Error) {
@@ -347,6 +347,8 @@ extension SimpleConnectionDaemon {
 // MARK: - Parameters
 
 extension SimpleConnectionDaemon {
+    public typealias StatusCallback = @Sendable (Profile.ID, ConnectionStatus) -> Void
+
     public final class Parameters: Sendable {
         let connectionFactory: ConnectionFactory
 
@@ -358,7 +360,7 @@ extension SimpleConnectionDaemon {
 
         let reconnectionDelay: Int
 
-        let onStatus: ((ConnectionStatus) -> Void)?
+        let onStatus: StatusCallback?
 
         public init(
             connectionFactory: ConnectionFactory,
@@ -366,7 +368,7 @@ extension SimpleConnectionDaemon {
             messageHandler: MessageHandler,
             stopDelay: Int? = nil,
             reconnectionDelay: Int? = nil,
-            onStatus: ((ConnectionStatus) -> Void)? = nil
+            onStatus: StatusCallback? = nil
         ) {
             self.connectionFactory = connectionFactory
             self.connectionParameters = connectionParameters

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -125,15 +125,11 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
                 // Monitor network events
                 observeEvents()
-
-                // Start the first connection right away
-                await evaluateConnection()
             }
             // Otherwise, configure the tunnel immediately
             else {
                 settingsOnlyTunnel = try await controller.setTunnelSettings(with: nil)
             }
-
             pp_log_id(profile.id, .core, .notice, "Daemon started successfully")
         } catch {
             pp_log_id(profile.id, .core, .fault, "Unable to start daemon: \(error)")
@@ -141,6 +137,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
             controller.setReasserting(false)
             controller.cancelTunnelConnection(with: error)
         }
+        networkObserver?.setEnabled(true)
     }
 
     public func hold() async {

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -19,6 +19,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let messageHandler: MessageHandler
 
+    private let startsImmediately: Bool
+
     private let stopDelay: Int
 
     private let reconnectionDelay: Int
@@ -62,6 +64,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         controller = params.connectionParameters.controller
         reachability = params.connectionParameters.reachability
         messageHandler = params.messageHandler
+        startsImmediately = params.startsImmediately
         stopDelay = params.stopDelay
         reconnectionDelay = params.reconnectionDelay
         onStatus = params.onStatus
@@ -125,6 +128,11 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
                 // Monitor network events
                 observeEvents()
+
+                // Start the first connection right away
+                if startsImmediately {
+                    await evaluateConnection()
+                }
             }
             // Otherwise, configure the tunnel immediately
             else {
@@ -137,7 +145,9 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
             controller.setReasserting(false)
             controller.cancelTunnelConnection(with: error)
         }
-        networkObserver?.setEnabled(true)
+        if !startsImmediately {
+            networkObserver?.setEnabled(true)
+        }
     }
 
     public func hold() async {
@@ -365,6 +375,8 @@ extension SimpleConnectionDaemon {
 
         let messageHandler: MessageHandler
 
+        let startsImmediately: Bool
+
         let stopDelay: Int
 
         let reconnectionDelay: Int
@@ -375,6 +387,7 @@ extension SimpleConnectionDaemon {
             connectionFactory: ConnectionFactory,
             connectionParameters: ConnectionParameters,
             messageHandler: MessageHandler,
+            startsImmediately: Bool,
             stopDelay: Int? = nil,
             reconnectionDelay: Int? = nil,
             onStatus: StatusCallback? = nil
@@ -382,6 +395,7 @@ extension SimpleConnectionDaemon {
             self.connectionFactory = connectionFactory
             self.connectionParameters = connectionParameters
             self.messageHandler = messageHandler
+            self.startsImmediately = startsImmediately
             self.stopDelay = stopDelay ?? 2000
             self.reconnectionDelay = reconnectionDelay ?? 2000
             self.onStatus = onStatus

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -218,6 +218,10 @@ extension SimpleConnectionDaemon {
         assert(statusSubscription == nil)
         assert(networkSubscription == nil)
 
+        // IMPORTANT: Create streams BEFORE Task blocks. If we create
+        // onNetworkReadyStream inside a Task, we might miss early
+        // onReady events because Task objects might be executed after
+        // the events are delivered.
         let connectionStatusStream = connection.statusStream.dropFirst()
         let onNetworkReadyStream = networkObserver.onReady.subscribe()
 

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -241,7 +241,8 @@ extension SimpleConnectionDaemon {
         // Observe the network for starting the connection
         networkSubscription = Task { [weak self] in
             guard let self else { return }
-            for await _ in onNetworkReadyStream {
+            for await isReady in onNetworkReadyStream {
+                guard isReady else { continue }
                 guard !Task.isCancelled else {
                     pp_log_id(profile.id, .core, .debug, "Cancelled NetworkObserver.onReady")
                     return

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -50,6 +50,7 @@ public actor NEPTPForwarder {
             connectionFactory: connectionFactory,
             connectionParameters: connectionParameters,
             messageHandler: messageHandler,
+            startsImmediately: true,
             stopDelay: stopDelay,
             reconnectionDelay: reconnectionDelay
         )

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -197,6 +197,7 @@ private extension SimpleConnectionDaemonTests {
                 options: options
             ),
             messageHandler: DefaultMessageHandler(.global, environment: environment),
+            startsImmediately: false,
             stopDelay: stopDelay,
             reconnectionDelay: reconnectionDelay
         ))

--- a/scripts/manifest.yaml
+++ b/scripts/manifest.yaml
@@ -9,6 +9,7 @@ paths:
   - PartoutWireGuard
 entities:
   - Address
+  - ConnectionStatus
   - CustomModule
   - DNSModule
   - DNSModule.DomainPolicy

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -2,6 +2,18 @@ components:
   schemas:
     Address:
       type: string
+    ConnectionStatus:
+      enum:
+        - disconnected
+        - connecting
+        - connected
+        - disconnecting
+      type: string
+      x-enum-varnames:
+        - disconnected
+        - connecting
+        - connected
+        - disconnecting
     CustomModule:
       additionalProperties: false
       properties:


### PR DESCRIPTION
Make start() and stop() operations quick to avoid subtle races. Let network observation start the connection when conditions are met (opt in).

For this to work consistently, some races had to be fixed in observeEvents():

- Create the observed streams before the `Task` blocks
- Use CurrentValueStream rather than PassthroughStream in NetworkObserver.onReady

The `networkObserver?.setEnabled(true)` statement may trigger an `onReady` event before `Task` objects are executed. Given that the streams were created too late (inside the tasks), an early `onReady` event could be missed. Be paranoid and bufferize `onReady` with CurrentValueStream.

Additionally, expose changes to ConnectionStatus from the daemon:

- Receive an optional onStatus() callback
- Retain statusSubscription after stop() to catch final .disconnected events

For testing, assume DummyReachabilityObserver to be reachable rather than not.