### PR TITLE
Fix incorrect handling of daemon state

### DIFF
--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -157,7 +157,9 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     public func stop() async {
         assert(isStarted || onHold, "Daemon not started or on hold")
-        guard isStarted else { return }
+        guard isStarted && !isStopped else { return }
+        isStopped = true
+
         pp_log_id(profile.id, .core, .notice, "Stop daemon (\(onHold ? "keep" : "clear") environment)")
 
         // Prevent reconnection
@@ -185,7 +187,6 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         networkObserverTask?.cancel()
 
         pp_log_id(profile.id, .core, .notice, "Daemon stopped successfully")
-        isStopped = true
     }
 
     public func destroy() {

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -322,6 +322,10 @@ extension SimpleConnectionDaemon {
     }
 
     func resumeNetworkObserver(after delay: Int) {
+        guard isStarted && !isStopped else {
+            pp_log_id(profile.id, .core, .info, "Ignore resume network observer, daemon is stopped")
+            return
+        }
         guard !onHold else {
             pp_log_id(profile.id, .core, .info, "Ignore resume network observer, daemon on hold")
             return

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -30,11 +30,11 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let reconnectionDelay: Int
 
-    private let onStatus: StatusCallback?
+    private var onStatus: StatusCallback?
 
     private var connection: Connection?
 
-    private let networkObserver: NetworkObserver?
+    private var networkObserver: NetworkObserver?
 
     // MARK: State
 
@@ -191,6 +191,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 //        statusSubscription?.cancel()
         networkSubscription?.cancel()
         networkObserverTask?.cancel()
+        networkObserver = nil
+        connection = nil
 
         pp_log_id(profile.id, .core, .notice, "Daemon stopped successfully")
     }
@@ -339,7 +341,7 @@ extension SimpleConnectionDaemon {
 
             guard !Task.isCancelled else { return }
             pp_log_id(profile.id, .core, .info, "Resume network observer now")
-            networkObserver?.setEnabled(true)
+            await networkObserver?.setEnabled(true)
         }
     }
 

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -195,11 +195,6 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         pp_log_id(profile.id, .core, .notice, "Daemon stopped successfully")
     }
 
-    public func destroy() {
-        assert(state == .stopped, "Daemon not stopped")
-        connection = nil
-    }
-
     public func sendMessage(_ input: Message.Input) async throws -> Message.Output? {
         pp_log_id(profile.id, .core, .debug, "Handle message input: \(String(describing: input))")
         let output = try await messageHandler.handleMessage(input)

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -4,6 +4,11 @@
 
 /// Basic implementation of ``ConnectionDaemon``.
 public actor SimpleConnectionDaemon: ConnectionDaemon {
+    private enum State {
+        case initial
+        case started
+        case stopped
+    }
 
     // MARK: Initialization
 
@@ -33,9 +38,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     // MARK: State
 
-    private var isStarted: Bool
-
-    private var isStopped: Bool
+    private var state: State
 
     private var isEvaluatingConnection: Bool
 
@@ -69,8 +72,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         reconnectionDelay = params.reconnectionDelay
         onStatus = params.onStatus
 
-        isStarted = false
-        isStopped = false
+        state = .initial
         isEvaluatingConnection = false
         onHold = false
 
@@ -114,10 +116,11 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
     }
 
     public func start() async throws {
-        assert(!isStarted, "Daemon already started")
-        assert(!isStopped, "Daemon stopped and cannot restart")
-        guard !isStarted && !isStopped else { return }
-        isStarted = true
+        guard state == .initial else {
+            assertionFailure("Daemon may only start once")
+            return
+        }
+        state = .started
         do {
             pp_log_id(profile.id, .core, .notice, "Start daemon")
             clearEnvironment()
@@ -151,14 +154,17 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
     }
 
     public func hold() async {
+        guard !onHold else { return }
         onHold = true
         await stop()
     }
 
     public func stop() async {
-        assert(isStarted || onHold, "Daemon not started or on hold")
-        guard isStarted && !isStopped else { return }
-        isStopped = true
+        guard state != .stopped else {
+            assertionFailure("Daemon is stopped")
+            return
+        }
+        state = .stopped
 
         pp_log_id(profile.id, .core, .notice, "Stop daemon (\(onHold ? "keep" : "clear") environment)")
 
@@ -190,8 +196,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
     }
 
     public func destroy() {
-        assert(isStopped, "Daemon not stopped")
-        guard isStopped else { return }
+        assert(state == .stopped, "Daemon not stopped")
         connection = nil
     }
 
@@ -205,9 +210,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
 private extension SimpleConnectionDaemon {
     func clearEnvironment() {
-        guard !onHold else {
-            return
-        }
+        guard !onHold else { return }
         pp_log_id(profile.id, .core, .notice, "Clear connection environment")
         environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.connectionStatus)
         environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
@@ -323,8 +326,8 @@ extension SimpleConnectionDaemon {
     }
 
     func resumeNetworkObserver(after delay: Int) {
-        guard isStarted && !isStopped else {
-            pp_log_id(profile.id, .core, .info, "Ignore resume network observer, daemon is stopped")
+        guard state == .started else {
+            pp_log_id(profile.id, .core, .info, "Ignore resume network observer, daemon unstarted or stopped")
             return
         }
         guard !onHold else {

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -140,7 +140,6 @@ struct SimpleConnectionDaemonTests {
         reachability.isReachable = false
         await sut.stop()
         #expect(await stream.nextElement() == .disconnected)
-        await sut.destroy()
     }
 
     @Test


### PR DESCRIPTION
- Merge isStarted/isStopped into single state
- Ensure .started before restarting NetworkObserver
- Prevent multiple stop()
- Clean up on stop()
- Remove destroy()