### PR TITLE
OpenVPN: Fix leaks related to the overall stack

### DIFF
--- a/Sources/PartoutCore/Connection/AutoUpgradingLink.swift
+++ b/Sources/PartoutCore/Connection/AutoUpgradingLink.swift
@@ -78,6 +78,7 @@ public final class AutoUpgradingLink: LinkInterface {
     public func shutdown() {
         Task {
             await io.shutdown()
+            betterPathStream.finish()
         }
     }
 

--- a/Sources/PartoutCore/Connection/ConnectionStatus.swift
+++ b/Sources/PartoutCore/Connection/ConnectionStatus.swift
@@ -15,19 +15,16 @@ public enum ConnectionStatus: String, Codable {
 }
 
 extension ConnectionStatus {
-    func canChange(to nextStatus: ConnectionStatus) -> Bool {
+    public func canChange(to nextStatus: ConnectionStatus) -> Bool {
         switch self {
         case .connected:
             return [.connecting, .disconnecting, .disconnected]
                 .contains(nextStatus)
-
         case .connecting:
             return [.connected, .disconnecting, .disconnected]
                 .contains(nextStatus)
-
         case .disconnecting:
             return nextStatus == .disconnected
-
         case .disconnected:
             return nextStatus == .connecting
         }

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -204,7 +204,6 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         connection = nil
 
         pp_log_id(profile.id, .core, .notice, "Daemon stopped successfully")
-        reportStatus(.disconnected)
     }
 
     public func sendMessage(_ input: Message.Input) async throws -> Message.Output? {

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -334,9 +334,10 @@ extension SimpleConnectionDaemon {
         }
 
         // start() returns false if the connection is still active
-        if !didStart {
+        guard didStart else {
             pp_log_id(profile.id, .core, .error, "Connection still active")
             resumeNetworkObserver(after: reconnectionDelay)
+            return
         }
     }
 

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -204,6 +204,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         connection = nil
 
         pp_log_id(profile.id, .core, .notice, "Daemon stopped successfully")
+        reportStatus(.disconnected)
     }
 
     public func sendMessage(_ input: Message.Input) async throws -> Message.Output? {

--- a/Sources/PartoutCore/PRNG/PRNGProtocol.swift
+++ b/Sources/PartoutCore/PRNG/PRNGProtocol.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /// Pseudo-random number generator.
-public protocol PRNGProtocol: Sendable {
+public protocol PRNGProtocol: AnyObject, Sendable {
     /// - Parameter length: The data length.
     /// - Returns: New data of the given length.
     func data(length: Int) -> Data

--- a/Sources/PartoutOS/AppleNE/Connection/NESocket.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NESocket.swift
@@ -218,6 +218,7 @@ extension NESocket {
 
     nonisolated func shutdown() {
         nwConnection.cancel()
+        betterPathStream.finish()
     }
 }
 

--- a/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
@@ -30,7 +30,7 @@ final class Negotiator {
 
     let link: LinkInterface
 
-    private var channel: ControlChannel
+    private let channel: ControlChannel
 
     private let prng: PRNGProtocol
 
@@ -122,6 +122,10 @@ final class Negotiator {
         shouldResendWrappedKey = false
     }
 
+    deinit {
+        pp_log(ctx, .openvpn, .debug, "Deinit OpenVPN.Negotiator")
+    }
+
     func forRenegotiation(initiatedBy newRenegotiation: RenegotiationType) -> Negotiator {
         guard let history else {
             pp_log(ctx, .openvpn, .error, "Negotiator has no history (not connected yet?)")
@@ -179,6 +183,8 @@ extension Negotiator {
 
     func cancel() {
         checkNegotiationTask?.cancel()
+        pendingPackets.removeAll()
+        authenticator = nil
     }
 
     func readInboundPacket(withData packet: Data, offset: Int) throws -> CrossPacket {
@@ -269,13 +275,11 @@ private extension Negotiator {
         guard state == .connected else {
             checkNegotiationTask?.cancel()
             checkNegotiationTask = Task { [weak self] in
-                guard let self else {
-                    return
-                }
-                try? await Task.sleep(milliseconds: Int(options.sessionOptions.tickInterval * 1000))
-                guard !Task.isCancelled else {
-                    return
-                }
+                guard let self else { return }
+                try? await Task.sleep(
+                    milliseconds: Int(options.sessionOptions.tickInterval * 1000)
+                )
+                guard !Task.isCancelled else { return }
                 do {
                     try checkNegotiationComplete()
                 } catch {

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
@@ -8,28 +8,34 @@ internal import _PartoutOpenVPNConnection_C
 extension OpenVPNSession {
     func loopTunnel() {
         runInActor { [weak self] in
-            guard let self else {
+            guard let ctx = self?.ctx else {
                 pp_log(.global, .openvpn, .debug, "Ignore TUN read from outdated OpenVPNSession")
                 return
             }
-            guard let tunnel else {
+            guard let tunnel = self?.tunnel else {
                 pp_log(ctx, .openvpn, .debug, "Ignore read from outdated TUN")
                 return
             }
+            let packets: [Data]
             do {
-                let packets = try await tunnel.readPackets()
-                guard !packets.isEmpty else {
-                    pp_log(ctx, .openvpn, .debug, "Exit TUN loop after empty packets")
-                    return
-                }
-                try await receiveTunnel(packets: packets)
+                packets = try await tunnel.readPackets()
             } catch {
                 pp_log(ctx, .openvpn, .error, "Failed TUN read: \(error)")
-                await shutdown(error)
+                await self?.shutdown(error)
+                return
             }
+            guard let self else {
+                pp_log(.global, .openvpn, .debug, "Ignore TUN packets from outdated OpenVPNSession")
+                return
+            }
+            guard !packets.isEmpty else {
+                pp_log(ctx, .openvpn, .debug, "Exit TUN loop after empty packets")
+                return
+            }
+            try await self.receiveTunnel(packets: packets)
 
             // repeat as long as self and tunnel exist
-            loopTunnel()
+            self.loopTunnel()
         }
     }
 

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
@@ -32,10 +32,10 @@ extension OpenVPNSession {
                 pp_log(ctx, .openvpn, .debug, "Exit TUN loop after empty packets")
                 return
             }
-            try await self.receiveTunnel(packets: packets)
+            try await receiveTunnel(packets: packets)
 
             // repeat as long as self and tunnel exist
-            self.loopTunnel()
+            loopTunnel()
         }
     }
 

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
@@ -128,7 +128,7 @@ final class OpenVPNSession {
     }
 
     deinit {
-        pp_log(ctx, .core, .debug, "Deinit OpenVPNSession")
+        pp_log(ctx, .openvpn, .debug, "Deinit OpenVPNSession")
     }
 }
 

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
@@ -126,6 +126,10 @@ final class OpenVPNSession {
         withLocalOptions = true
         dataCount = BidirectionalState(withResetValue: 0)
     }
+
+    deinit {
+        pp_log(ctx, .core, .debug, "Deinit OpenVPNSession")
+    }
 }
 
 // MARK: - Public API

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
@@ -357,7 +357,9 @@ extension OpenVPNSession {
         }
 
         sessionState = .started
-        Task {
+        let pushReplyOptions = pushReply.options
+        Task { [weak self] in
+            guard let self else { return }
             guard let remoteAddress = link?.remoteAddress,
                   let remoteProtocol = link?.remoteProtocol else {
                 pp_log(ctx, .openvpn, .fault, "Unable to resolve link remote address/protocol")
@@ -368,7 +370,7 @@ extension OpenVPNSession {
                 self,
                 remoteAddress: remoteAddress,
                 remoteProtocol: remoteProtocol,
-                remoteOptions: pushReply.options,
+                remoteOptions: pushReplyOptions,
                 remoteFd: link?.fileDescriptor
             )
         }
@@ -499,8 +501,10 @@ private extension OpenVPNSession {
             }
         }
         lastDataCountDate = Date()
-        Task {
-            await delegate?.session(self, didUpdateDataCount: .init(UInt(dataCount.inbound), UInt(dataCount.outbound)))
+        let currentDataCount = DataCount(UInt(dataCount.inbound), UInt(dataCount.outbound))
+        Task { [weak self] in
+            guard let self else { return }
+            await delegate?.session(self, didUpdateDataCount: currentDataCount)
         }
     }
 }

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionProtocol.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionProtocol.swift
@@ -28,7 +28,7 @@ protocol OpenVPNSessionDelegate: AnyObject, Sendable {
 }
 
 /// Provides methods to set up and maintain an OpenVPN session.
-protocol OpenVPNSessionProtocol: Sendable {
+protocol OpenVPNSessionProtocol: AnyObject, Sendable {
 
     /// Observe events with a `OpenVPNSessionDelegate`.
     func setDelegate(_ delegate: OpenVPNSessionDelegate) async

--- a/Sources/PartoutOpenVPNConnection/Internal/TLSProtocol.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/TLSProtocol.swift
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-protocol TLSProtocol {
+protocol TLSProtocol: AnyObject {
     func start() throws
 
     func isConnected() -> Bool

--- a/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2+Default.swift
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+extension OpenVPNConnectionV2 {
+    public init(
+        _ ctx: PartoutLoggerContext,
+        parameters: ConnectionParameters,
+        module: OpenVPNModule,
+        cachesURL: URL,
+        options: OpenVPNConnection.Options = .init()
+    ) throws {
+        guard let configuration = module.configuration else {
+            fatalError("Creating session without OpenVPN configuration?")
+        }
+        pp_log(ctx, .openvpn, .notice, "OpenVPN: Using cross-platform connection")
+
+        // Hardcode portable implementations
+        let prng = PlatformPRNG()
+        let dns = SimpleDNSResolver {
+            POSIXDNSStrategy(hostname: $0)
+        }
+        let sessionFactory = {
+            try await OpenVPNSession(
+                ctx,
+                configuration: configuration,
+                credentials: module.credentials,
+                prng: prng,
+                cachesURL: cachesURL,
+                options: options,
+                tlsFactory: {
+                    try TLSWrapper.native(with: $0).tls
+                },
+                dpFactory: {
+                    try DataPathWrapper.native(with: $0, prf: $1, prng: $2).dataPath
+                }
+            )
+        }
+
+        try self.init(
+            ctx,
+            parameters: parameters,
+            module: module,
+            prng: prng,
+            dns: dns,
+            sessionFactory: sessionFactory
+        )
+    }
+}

--- a/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
@@ -91,7 +91,11 @@ extension OpenVPNConnectionV2: Connection {
             if currentSession == nil {
                 currentSession = try await sessionFactory()
             }
-            await currentSession?.setDelegate(self)
+            guard let session = currentSession else {
+                fatalError("No session from factory?")
+                return false
+            }
+            await session.setDelegate(self)
             guard status == .disconnected else {
                 pp_log(ctx, .core, .error, "Ignore start, connection status \(status) != .disconnected")
                 return false
@@ -99,7 +103,7 @@ extension OpenVPNConnectionV2: Connection {
             sendStatus(.connecting)
             do {
                 let newLink = try await setupLink(upgradingCurrent: false)
-                try await currentSession?.setLink(newLink)
+                try await session.setLink(newLink)
                 observeBetterPath(on: newLink)
                 return true
             } catch {

--- a/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
@@ -74,7 +74,7 @@ public actor OpenVPNConnectionV2 {
     }
 
     deinit {
-        pp_log(ctx, .openvpn, .debug, "Deinit OpenVPNConnection")
+        pp_log(ctx, .openvpn, .debug, "Deinit OpenVPNConnectionV2")
     }
 }
 
@@ -394,10 +394,8 @@ private extension OpenVPNConnectionV2 {
 
     func observeBetterPath(on link: LinkInterface) {
         pathSubscription?.cancel()
-        pathSubscription = Task { [weak self] in
-            guard let self else {
-                return
-            }
+        pathSubscription = Task { [weak self, weak link] in
+            guard let self, let link else { return }
             for await _ in link.hasBetterPath {
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled CyclingConnection.pathSubscription")

--- a/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
@@ -1,0 +1,412 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+#if !USE_CMAKE
+@_exported import PartoutOpenVPN
+#endif
+
+/// Swift/C implementation of an OpenVPN connection.
+public actor OpenVPNConnectionV2 {
+    private let ctx: PartoutLoggerContext
+
+    private let statusSubject: CurrentValueStream<ConnectionStatus>
+
+    private let moduleId: UniqueID
+
+    private let controller: TunnelController
+
+    private let environment: TunnelEnvironment
+
+    private let factory: NetworkInterfaceFactory
+
+    private let options: ConnectionParameters.Options
+
+    private let endpoints: [ExtendedEndpoint]
+
+    private let configuration: OpenVPN.Configuration
+
+    private let sessionFactory: () async throws -> OpenVPNSessionProtocol
+
+    private let dns: DNSResolver
+
+    // MARK: State
+
+    private var currentSession: OpenVPNSessionProtocol?
+
+    private var endpointResolver: EndpointResolver
+
+    private var currentLink: LinkInterface?
+
+    private var tunnelInterface: IOInterface?
+
+    private var pathSubscription: Task<Void, Never>?
+
+    init(
+        _ ctx: PartoutLoggerContext,
+        parameters: ConnectionParameters,
+        module: OpenVPNModule,
+        prng: PRNGProtocol,
+        dns: DNSResolver,
+        sessionFactory: @escaping () async throws -> OpenVPNSessionProtocol
+    ) throws {
+        self.ctx = ctx
+        statusSubject = CurrentValueStream(.disconnected)
+        moduleId = module.id
+        controller = parameters.controller
+        environment = parameters.environment
+        factory = parameters.factory
+        options = parameters.options
+
+        guard let configuration = module.configuration else {
+            throw PartoutError(.incompleteModule)
+        }
+        guard let endpoints = configuration.processedRemotes(prng: prng),
+              !endpoints.isEmpty else {
+            fatalError("No OpenVPN remotes defined?")
+        }
+
+        self.configuration = try configuration.withModules(from: parameters.profile)
+        self.sessionFactory = sessionFactory
+        self.dns = dns
+        self.endpoints = endpoints
+        endpointResolver = EndpointResolver(ctx, endpoints: endpoints)
+    }
+
+    deinit {
+        pp_log(ctx, .openvpn, .debug, "Deinit OpenVPNConnection")
+    }
+}
+
+// MARK: - Connection
+
+extension OpenVPNConnectionV2: Connection {
+    public nonisolated var statusStream: AsyncThrowingStream<ConnectionStatus, Error> {
+        statusSubject.subscribeThrowing().removeDuplicates()
+    }
+
+    @discardableResult
+    public func start() async throws -> Bool {
+        guard currentSession == nil else { return false }
+        do {
+            currentSession = try await sessionFactory()
+            await currentSession?.setDelegate(self)
+            guard status == .disconnected else {
+                pp_log(ctx, .core, .error, "Ignore start, connection status \(status) != .disconnected")
+                return false
+            }
+            sendStatus(.connecting)
+            do {
+                let newLink = try await setupLink(upgradingCurrent: false)
+                try await currentSession?.setLink(newLink)
+                observeBetterPath(on: newLink)
+                return true
+            } catch {
+                sendStatus(.disconnected)
+                throw error
+            }
+        } catch let error as PartoutError {
+            await currentSession?.shutdown(error)
+            if error.code == .exhaustedEndpoints, let reason = error.reason {
+                throw reason
+            }
+            throw error
+        } catch {
+            await currentSession?.shutdown(error)
+            throw error
+        }
+    }
+
+    public func stop(timeout: Int) async {
+        guard let currentSession else { return }
+        guard status != .disconnected else {
+            pp_log(ctx, .core, .error, "Ignore stop, connection not started")
+            return
+        }
+        sendStatus(.disconnecting)
+
+        // Stop the OpenVPN connection on user request
+        await currentSession.shutdown(nil, timeout: TimeInterval(timeout) / 1000.0)
+
+        // XXX: Poll session status until link clean-up
+        // In the future, make OpenVPNSession.shutdown() wait for stop async-ly
+        let delta = 500
+        var remaining = timeout
+        while remaining > 0, await currentSession.hasLink() {
+            pp_log(ctx, .openvpn, .notice, "Link active, wait \(delta) milliseconds more")
+            try? await Task.sleep(milliseconds: delta)
+            remaining = max(0, remaining - delta)
+        }
+        if remaining > 0 {
+            pp_log(ctx, .openvpn, .notice, "Link shut down gracefully")
+        } else {
+            pp_log(ctx, .openvpn, .error, "Link shut down due to timeout")
+        }
+
+        sendStatus(.disconnected)
+    }
+}
+
+// MARK: - OpenVPNSessionDelegate
+
+extension OpenVPNConnectionV2: OpenVPNSessionDelegate {
+    func sessionDidStart(
+        _ session: OpenVPNSessionProtocol,
+        remoteAddress: String,
+        remoteProtocol: EndpointProtocol,
+        remoteOptions: OpenVPN.Configuration,
+        remoteFd: UInt64?
+    ) async {
+        let addressObject = Address(rawValue: remoteAddress)
+        if addressObject == nil {
+            pp_log(ctx, .openvpn, .error, "Unable to parse remote tunnel address")
+        }
+
+        pp_log(ctx, .openvpn, .notice, "Session did start")
+        pp_log(ctx, .openvpn, .info, "\tAddress: \(remoteAddress.asSensitiveAddress(ctx))")
+        pp_log(ctx, .openvpn, .info, "\tProtocol: \(remoteProtocol)")
+
+        pp_log(ctx, .openvpn, .notice, "Local options:")
+        configuration.print(ctx, isLocal: true)
+        pp_log(ctx, .openvpn, .notice, "Remote options:")
+        remoteOptions.print(ctx, isLocal: false)
+
+        environment.setEnvironmentValue(remoteOptions, forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+
+        let builder = NetworkSettingsBuilder(
+            ctx,
+            localOptions: configuration,
+            remoteOptions: remoteOptions
+        )
+        builder.print()
+        do {
+            let tunnelInterface = try await controller.setTunnelSettings(
+                with: TunnelRemoteInfo(
+                    originalModuleId: moduleId,
+                    address: addressObject,
+                    modules: builder.modules(),
+                    fileDescriptors: remoteFd.map { [$0] } ?? []
+                )
+            )
+            await session.setTunnel(tunnelInterface)
+            self.tunnelInterface = tunnelInterface
+
+            // In this suspended interval, sessionDidStop may have been called and
+            // the status may have changed to .disconnected in the meantime
+            //
+            // sendStatus() should prevent .connected from happening when in the
+            // .disconnected state, because it must go through .connecting first
+
+            // Signal success and show the "VPN" icon
+            if sendStatus(.connected) {
+                pp_log(ctx, .openvpn, .notice, "Tunnel interface is now UP")
+            }
+        } catch {
+            pp_log(ctx, .openvpn, .error, "Unable to start tunnel: \(error)")
+            await session.shutdown(error)
+        }
+    }
+
+    func sessionDidStop(_ session: OpenVPNSessionProtocol, withError error: Error?) async {
+        if let error {
+            pp_log(ctx, .openvpn, .error, "Session did stop: \(error)")
+        } else {
+            pp_log(ctx, .openvpn, .notice, "Session did stop")
+        }
+
+        // Clean up tunnel
+        if let tunnelInterface {
+            await controller.clearTunnelSettings(tunnelInterface)
+            self.tunnelInterface = nil
+        }
+
+        // If user stopped the tunnel, let it go
+        guard status != .disconnecting else {
+            pp_log(ctx, .openvpn, .info, "User requested disconnection")
+            return
+        }
+
+        // If error is not recoverable, just fail
+        if let error, !error.isOpenVPNRecoverable {
+            pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
+            sendError(error)
+            return
+        }
+
+        // Go back to the disconnected state (e.g. daemon will reconnect)
+        sendStatus(.disconnected)
+    }
+
+    func session(_ session: OpenVPNSessionProtocol, didUpdateDataCount dataCount: DataCount) async {
+        guard status == .connected else {
+            return
+        }
+        pp_log(ctx, .openvpn, .debug, "Updated data count: \(dataCount.debugDescription)")
+        environment.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
+    }
+}
+
+// MARK: - Helpers
+
+private extension OpenVPN.Configuration {
+    func withModules(from profile: Profile) throws -> Self {
+        var newBuilder = builder()
+        let ipModules = profile.activeModules
+            .compactMap {
+                $0 as? IPModule
+            }
+
+        ipModules.forEach { ipModule in
+            var policies = newBuilder.routingPolicies ?? []
+            if !policies.contains(.IPv4), ipModule.shouldAddIPv4Policy {
+                policies.append(.IPv4)
+            }
+            if !policies.contains(.IPv6), ipModule.shouldAddIPv6Policy {
+                policies.append(.IPv6)
+            }
+            newBuilder.routingPolicies = policies
+        }
+        return try newBuilder.build(isClient: true)
+    }
+}
+
+private extension IPModule {
+    var shouldAddIPv4Policy: Bool {
+        guard let ipv4 else {
+            return false
+        }
+        let defaultRoute = Route(defaultWithGateway: nil)
+        return ipv4.includedRoutes.contains(defaultRoute) && !ipv4.excludedRoutes.contains(defaultRoute)
+    }
+
+    var shouldAddIPv6Policy: Bool {
+        guard let ipv6 else {
+            return false
+        }
+        let defaultRoute = Route(defaultWithGateway: nil)
+        return ipv6.includedRoutes.contains(defaultRoute) && !ipv6.excludedRoutes.contains(defaultRoute)
+    }
+}
+
+extension OpenVPNConnectionV2 {
+    var status: ConnectionStatus {
+        statusSubject.value
+    }
+}
+
+private extension OpenVPNConnectionV2 {
+    @discardableResult
+    func sendStatus(_ connectionStatus: ConnectionStatus) -> Bool {
+        guard status.canChange(to: connectionStatus) else {
+            pp_log(ctx, .core, .error, "Ignore unexpected status change: \(status) -> \(connectionStatus)")
+            return false
+        }
+        pp_log(ctx, .core, .info, "Report link status: \(connectionStatus.debugDescription)")
+        statusSubject.send(connectionStatus)
+        onStatus(connectionStatus)
+        return true
+    }
+
+    func sendError(_ connectionError: Error) {
+        pp_log(ctx, .core, .info, "Report link failure: \(connectionError)")
+        statusSubject.send(completion: .failure(connectionError))
+        onError(connectionError)
+    }
+
+    nonisolated func onStatus(_ connectionStatus: ConnectionStatus) {
+        switch connectionStatus {
+        case .connected:
+            break
+        case .disconnected:
+            environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
+            environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+        default:
+            break
+        }
+    }
+
+    nonisolated func onError(_ connectionError: Error) {
+        environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
+        environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+    }
+}
+
+private extension LinkInterface {
+    func openVPNLink(method: OpenVPN.ObfuscationMethod?) -> LinkInterface {
+        switch linkType.plainType {
+        case .udp:
+            return OpenVPNUDPLink(link: self, method: method)
+
+        case .tcp:
+            return OpenVPNTCPLink(link: self, method: method)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension OpenVPNConnectionV2 {
+    func setupLink(upgradingCurrent: Bool) async throws -> LinkInterface {
+        do {
+            pp_log(ctx, .core, .notice, "Create new link")
+            var newLink: LinkInterface
+
+            // upgrade current link if possible
+            if upgradingCurrent, let upgradedLink = try await currentLink?.upgraded() {
+                pp_log(ctx, .core, .notice, "Will reconnect to current link")
+                newLink = upgradedLink
+            }
+            // create new link
+            else {
+                pp_log(ctx, .core, .notice, "Cycle to next endpoint")
+                let result = try await endpointResolver.withNextEndpoint(
+                    dns: dns,
+                    timeout: options.dnsTimeout
+                )
+                endpointResolver = result.nextResolver
+
+                let linkObserver = try factory.linkObserver(to: result.endpoint)
+                pp_log(ctx, .core, .notice, "Connect to \(result.endpoint.asSensitiveAddress(ctx))")
+                newLink = try await linkObserver.waitForActivity(timeout: options.linkActivityTimeout)
+
+                pp_log(ctx, .core, .notice, "Link is active")
+                pp_log(ctx, .core, .info, "Link type is \(newLink.linkDescription)")
+                // Wrap new link into a specific OpenVPN link
+                newLink = newLink.openVPNLink(method: configuration.xorMethod)
+            }
+
+            pp_log(ctx, .core, .info, "Processed link type is \(newLink.linkDescription)")
+
+            currentLink = newLink
+            return newLink
+        } catch {
+            pp_log(ctx, .core, .fault, "Unable to create link: \(error)")
+
+            // reset endpoints on exhaustion
+            if (error as? PartoutError)?.code == .exhaustedEndpoints {
+                endpointResolver = EndpointResolver(ctx, endpoints: endpoints)
+            }
+
+            // stop here
+            throw error
+        }
+    }
+
+    func observeBetterPath(on link: LinkInterface) {
+        pathSubscription?.cancel()
+        pathSubscription = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            for await _ in link.hasBetterPath {
+                guard !Task.isCancelled else {
+                    pp_log(ctx, .core, .debug, "Cancelled CyclingConnection.pathSubscription")
+                    return
+                }
+                // TODO: #143/notes, may improve this with floating
+                pp_log(ctx, .openvpn, .notice, "Link has a better path, shut down session to reconnect")
+                await currentSession?.shutdown(PartoutError(.networkChanged))
+            }
+        }
+    }
+}

--- a/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/OpenVPNConnectionV2.swift
@@ -87,9 +87,10 @@ extension OpenVPNConnectionV2: Connection {
 
     @discardableResult
     public func start() async throws -> Bool {
-        guard currentSession == nil else { return false }
         do {
-            currentSession = try await sessionFactory()
+            if currentSession == nil {
+                currentSession = try await sessionFactory()
+            }
             await currentSession?.setDelegate(self)
             guard status == .disconnected else {
                 pp_log(ctx, .core, .error, "Ignore start, connection status \(status) != .disconnected")

--- a/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
+++ b/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
@@ -6,6 +6,13 @@ import PartoutCore
 @testable import PartoutOpenVPNConnection
 import Testing
 
+private typealias OpenVPNConnectionType = OpenVPNConnectionV2
+extension OpenVPNConnectionV2 {
+    var backend: Self {
+        self
+    }
+}
+
 struct OpenVPNConnectionTests {
     private let constants = Constants()
 
@@ -313,14 +320,14 @@ private struct Constants {
         controller: TunnelController = MockTunnelController(),
         factory: NetworkInterfaceFactory = MockNetworkInterfaceFactory(),
         environment: TunnelEnvironment = SharedTunnelEnvironment(profileId: nil)
-    ) async throws -> OpenVPNConnection {
+    ) async throws -> OpenVPNConnectionType {
         let profile = try Profile.Builder().build()
         let impl = OpenVPNModule.Implementation(
             importerBlock: {
                 StandardOpenVPNParser(decrypter: nil)
             },
             connectionBlock: {
-                try OpenVPNConnection(
+                try OpenVPNConnectionType(
                     .global,
                     parameters: $0,
                     module: $1,
@@ -339,7 +346,7 @@ private struct Constants {
             environment: environment,
             options: options
         ))
-        return try #require(conn as? OpenVPNConnection)
+        return try #require(conn as? OpenVPNConnectionType)
     }
 }
 


### PR DESCRIPTION
- Merge deprecated CyclingConnection into OpenVPNConnectionV2
  - Use typealias in tests
- Resolve leaks in the connection/session/negotiator chain
  - Fix long-lived tun loop holding self (OpenVPNSession)
  - Release Negotiator pending packets and authenticator on cancel()
  - Finish .hasBetterPath stream in LinkInterface implementations

Fixes #204 