### PR TITLE
OpenVPN: Use modern cipher negotiation

### DIFF
--- a/Sources/PartoutOpenVPN/OpenVPN+Configuration.swift
+++ b/Sources/PartoutOpenVPN/OpenVPN+Configuration.swift
@@ -246,8 +246,13 @@ extension OpenVPN {
 
         // MARK: Shortcuts
 
+        /// Returns the effective cipher to use when negotiation does not yield one.
+        ///
+        /// `cipher` takes precedence because the parser also uses it to store
+        /// `data-ciphers-fallback`, allowing deprecated `cipher` input to be
+        /// normalized to the modern fallback form on serialization.
         public var fallbackCipher: Cipher {
-            return cipher ?? Fallback.cipher
+            return cipher ?? dataCiphers?.first ?? Fallback.cipher
         }
 
         public var fallbackDigest: Digest {
@@ -279,7 +284,11 @@ extension OpenVPN.Configuration {
 
         // MARK: General
 
-        /// The cipher algorithm for data encryption.
+        /// The legacy cipher algorithm for data encryption.
+        ///
+        /// When `dataCiphers` is set, this same field also stores the effective
+        /// `data-ciphers-fallback` value so deprecated `cipher` input can be
+        /// normalized on output.
         public var cipher: OpenVPN.Cipher?
 
         /// The set of supported cipher algorithms for data encryption (2.5.).
@@ -447,7 +456,6 @@ extension OpenVPN.Configuration {
          - Throws: If `isClient` is `true` and some required options are missing.
          */
         public func build(isClient: Bool) throws -> OpenVPN.Configuration {
-            let fallbackCipher: OpenVPN.Cipher?
             if isClient {
                 guard ca != nil else {
                     throw PartoutError.invalidField(.OpenVPN.ca)
@@ -455,12 +463,9 @@ extension OpenVPN.Configuration {
                 guard !(remotes?.isEmpty ?? true) else {
                     throw PartoutError.invalidField(.OpenVPN.remotes)
                 }
-                fallbackCipher = cipher ?? .aes128cbc
-            } else {
-                fallbackCipher = cipher
             }
             return OpenVPN.Configuration(
-                cipher: fallbackCipher,
+                cipher: cipher,
                 dataCiphers: dataCiphers,
                 digest: digest,
                 compressionFraming: compressionFraming,

--- a/Sources/PartoutOpenVPN/OpenVPN+Serialization.swift
+++ b/Sources/PartoutOpenVPN/OpenVPN+Serialization.swift
@@ -98,6 +98,8 @@ extension OpenVPN.Configuration {
         if let dataCiphers, !dataCiphers.isEmpty {
             append("data-ciphers \(dataCiphers.map(\.rawValue).joined(separator: ":"))")
             if let cipher {
+                // Prefer the explicit modern fallback directive when a
+                // negotiated cipher list is present.
                 append("data-ciphers-fallback \(cipher.rawValue)")
             }
         } else if let cipher {

--- a/Sources/PartoutOpenVPN/StandardOpenVPNParser+Builder.swift
+++ b/Sources/PartoutOpenVPN/StandardOpenVPNParser+Builder.swift
@@ -563,6 +563,8 @@ extension StandardOpenVPNParser.Builder {
 
         // MARK: General
 
+        // Normalize deprecated `cipher` to the same slot used for the modern
+        // `data-ciphers-fallback`, since serialization prefers the modern form.
         builder.cipher = optDataCiphersFallback ?? optCipher
         builder.dataCiphers = optDataCiphers
         builder.digest = optDigest

--- a/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
@@ -194,9 +194,7 @@ extension OpenVPN.Configuration {
     /// Keep `cipher` in this string only when the configuration explicitly
     /// carries a legacy/fallback cipher. Negotiated `data-ciphers` are
     /// advertised separately via `IV_CIPHERS`.
-    func asLocalOptionsString(
-        withLocalOptions: Bool
-    ) -> String {
+    func asLocalOptionsString(withLocalOptions: Bool) -> String {
         guard withLocalOptions else {
             return "V0 UNDEF"
         }

--- a/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
@@ -12,6 +12,8 @@ fileprivate extension CrossZD {
 final class Authenticator {
     private let ctx: PartoutLoggerContext
 
+    private let parser = StandardOpenVPNParser(decrypter: nil)
+
     private var controlBuffer: CrossZD
 
     private(set) var preMaster: CrossZD
@@ -23,6 +25,8 @@ final class Authenticator {
     private(set) var serverRandom1: CrossZD?
 
     private(set) var serverRandom2: CrossZD?
+
+    private(set) var serverOptions: OpenVPN.Configuration?
 
     private(set) var username: CrossZD?
 
@@ -59,6 +63,7 @@ final class Authenticator {
         random2.zero()
         serverRandom1?.zero()
         serverRandom2?.zero()
+        serverOptions = nil
         username = nil
         password = nil
     }
@@ -109,7 +114,7 @@ final class Authenticator {
 
         // peer info
         var extra: [String: String] = [:]
-        if let dataCiphers = options.dataCiphers {
+        if let dataCiphers = options.negotiableDataCiphers {
             extra["IV_CIPHERS"] = dataCiphers.map(\.rawValue).joined(separator: ":")
         }
         let peerInfo = Constants.ControlChannel.peerInfo(sslVersion: sslVersion, extra: extra)
@@ -159,7 +164,17 @@ final class Authenticator {
         pp_log(ctx, .openvpn, .info, "TLS.auth: Parsed server random [\(serverRandom1.asSensitiveBytes(ctx)), \(serverRandom2.asSensitiveBytes(ctx))]")
 
         if let serverOptsString = serverOpts.nullTerminatedString(fromOffset: 0) {
-            pp_log(ctx, .openvpn, .info, "TLS.auth: Parsed server options: \"\(serverOptsString)\"")
+            pp_log(ctx, .openvpn, .info, "TLS.auth: Parsed server options (string): \"\(serverOptsString)\"")
+            let lines = serverOptsString.components(separatedBy: ",").map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            do {
+                let serverOptions = try parser.parsed(fromLines: lines, isClient: false).configuration
+                pp_log(ctx, .openvpn, .info, "TLS.auth: Server options: \(serverOptions)")
+                self.serverOptions = serverOptions
+            } catch {
+                pp_log(ctx, .openvpn, .error, "TLS.auth: Unable to parse server options: \(error)")
+            }
         }
 
         self.serverRandom1 = serverRandom1

--- a/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
@@ -24,7 +24,7 @@ final class Authenticator {
 
     private(set) var serverRandom2: CrossZD?
 
-    private(set) var serverOptions: OpenVPN.ServerOCC?
+    private(set) var serverOptions: ServerOCC?
 
     private(set) var username: CrossZD?
 
@@ -143,7 +143,7 @@ final class Authenticator {
 
         if let serverOptsString = serverOpts.nullTerminatedString(fromOffset: 0) {
             pp_log(ctx, .openvpn, .info, "TLS.auth: Parsed server options (string): \"\(serverOptsString)\"")
-            let serverOptions = OpenVPN.ServerOCC.parsed(from: serverOptsString)
+            let serverOptions = ServerOCC.parsed(from: serverOptsString)
             pp_log(ctx, .openvpn, .info, "TLS.auth: Server options: \(serverOptions)")
             self.serverOptions = serverOptions
         }

--- a/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
@@ -207,8 +207,10 @@ extension OpenVPN.Configuration {
         if let direction = tlsWrap?.key.direction?.rawValue {
             opts.append("keydir \(direction)")
         }
-        opts.append("cipher \(fallbackCipher.rawValue)")
-        opts.append("keysize \(fallbackCipher.keySize)")
+        if let cipher {
+            opts.append("cipher \(cipher.rawValue)")
+            opts.append("keysize \(cipher.keySize)")
+        }
         opts.append("auth \(fallbackDigest.rawValue)")
         if let strategy = tlsWrap?.strategy {
             opts.append("tls-\(strategy.rawValue)")

--- a/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
@@ -40,7 +40,7 @@ final class Authenticator {
         random1 = prng.safeCrossData(length: Constants.Keys.randomLength)
         random2 = prng.safeCrossData(length: Constants.Keys.randomLength)
 
-        // XXX: not 100% secure, can't erase input username/password
+        // XXX: Not 100% secure, can't erase input username/password
         if let username = username, let password = password {
             self.username = CZ(username, nullTerminated: true)
             self.password = CZ(password, nullTerminated: true)
@@ -71,37 +71,17 @@ final class Authenticator {
     func putAuth(into tls: TLSProtocol, options: OpenVPN.Configuration) throws {
         let raw = CZ(Constants.ControlChannel.tlsPrefix)
 
-        // local keys
+        // Local keys
         raw.append(preMaster)
         raw.append(random1)
         raw.append(random2)
 
-        // options string
-        let optsString: String
-        if withLocalOptions {
-            var opts = [
-                "V4",
-                "dev-type tun"
-            ]
-            if let direction = options.tlsWrap?.key.direction?.rawValue {
-                opts.append("keydir \(direction)")
-            }
-            opts.append("cipher \(options.fallbackCipher.rawValue)")
-            opts.append("auth \(options.fallbackDigest.rawValue)")
-            opts.append("keysize \(options.fallbackCipher.keySize)")
-            if let strategy = options.tlsWrap?.strategy {
-                opts.append("tls-\(strategy.rawValue)")
-            }
-            opts.append("key-method 2")
-            opts.append("tls-client")
-            optsString = opts.joined(separator: ",")
-        } else {
-            optsString = "V0 UNDEF"
-        }
+        // Local options string
+        let optsString = options.asLocalOptionsString(withLocalOptions: withLocalOptions)
         pp_log(ctx, .openvpn, .info, "TLS.auth: Local options: \(optsString)")
         raw.appendSized(CZ(optsString, nullTerminated: true))
 
-        // credentials
+        // Credentials
         if let username = username, let password = password {
             raw.appendSized(username)
             raw.appendSized(password)
@@ -110,7 +90,7 @@ final class Authenticator {
             raw.append(CZ(UInt16(0)))
         }
 
-        // peer info
+        // Peer info
         var extra: [String: String] = [:]
         if let dataCiphers = options.negotiableDataCiphers {
             extra["IV_CIPHERS"] = dataCiphers.map(\.rawValue).joined(separator: ":")
@@ -205,5 +185,36 @@ final class Authenticator {
             serverRandom1: serverRandom1,
             serverRandom2: serverRandom2
         )
+    }
+}
+
+extension OpenVPN.Configuration {
+    /// Builds the legacy OCC/auth-options string sent during TLS auth.
+    ///
+    /// Keep `cipher` in this string only when the configuration explicitly
+    /// carries a legacy/fallback cipher. Negotiated `data-ciphers` are
+    /// advertised separately via `IV_CIPHERS`.
+    func asLocalOptionsString(
+        withLocalOptions: Bool
+    ) -> String {
+        guard withLocalOptions else {
+            return "V0 UNDEF"
+        }
+        var opts = [
+            "V4",
+            "dev-type tun"
+        ]
+        if let direction = tlsWrap?.key.direction?.rawValue {
+            opts.append("keydir \(direction)")
+        }
+        opts.append("cipher \(fallbackCipher.rawValue)")
+        opts.append("keysize \(fallbackCipher.keySize)")
+        opts.append("auth \(fallbackDigest.rawValue)")
+        if let strategy = tlsWrap?.strategy {
+            opts.append("tls-\(strategy.rawValue)")
+        }
+        opts.append("key-method 2")
+        opts.append("tls-client")
+        return opts.joined(separator: ",")
     }
 }

--- a/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Authenticator.swift
@@ -12,8 +12,6 @@ fileprivate extension CrossZD {
 final class Authenticator {
     private let ctx: PartoutLoggerContext
 
-    private let parser = StandardOpenVPNParser(decrypter: nil)
-
     private var controlBuffer: CrossZD
 
     private(set) var preMaster: CrossZD
@@ -26,7 +24,7 @@ final class Authenticator {
 
     private(set) var serverRandom2: CrossZD?
 
-    private(set) var serverOptions: OpenVPN.Configuration?
+    private(set) var serverOptions: OpenVPN.ServerOCC?
 
     private(set) var username: CrossZD?
 
@@ -165,16 +163,9 @@ final class Authenticator {
 
         if let serverOptsString = serverOpts.nullTerminatedString(fromOffset: 0) {
             pp_log(ctx, .openvpn, .info, "TLS.auth: Parsed server options (string): \"\(serverOptsString)\"")
-            let lines = serverOptsString.components(separatedBy: ",").map {
-                $0.trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            do {
-                let serverOptions = try parser.parsed(fromLines: lines, isClient: false).configuration
-                pp_log(ctx, .openvpn, .info, "TLS.auth: Server options: \(serverOptions)")
-                self.serverOptions = serverOptions
-            } catch {
-                pp_log(ctx, .openvpn, .error, "TLS.auth: Unable to parse server options: \(error)")
-            }
+            let serverOptions = OpenVPN.ServerOCC.parsed(from: serverOptsString)
+            pp_log(ctx, .openvpn, .info, "TLS.auth: Server options: \(serverOptions)")
+            self.serverOptions = serverOptions
         }
 
         self.serverRandom1 = serverRandom1

--- a/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
@@ -684,7 +684,10 @@ private extension Negotiator {
 //        pp_log(ctx, .openvpn, .info, "\tremoteSessionId: \(remoteSessionId.toHex())")
 
         let parameters = DataPathWrapper.Parameters(
-            cipher: history.pushReply.options.cipher ?? options.configuration.fallbackCipher,
+            cipher: options.configuration.negotiatedDataChannelCipher(
+                with: history.pushReply.options,
+                serverOptions: authenticator?.serverOptions
+            ),
             digest: options.configuration.fallbackDigest,
             compressionFraming: history.pushReply.options.compressionFraming ?? options.configuration.fallbackCompressionFraming,
             compressionAlgorithm: history.pushReply.options.compressionAlgorithm ?? options.configuration.fallbackCompressionAlgorithm,

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+extension OpenVPN.Configuration {
+    /// Returns the ciphers this client can advertise for OpenVPN data-channel
+    /// negotiation.
+    ///
+    /// The explicit `dataCiphers` list is preferred for negotiation, while the
+    /// legacy/fallback `cipher` is appended only for compatibility with peers
+    /// that still rely on the older single-cipher model.
+    var negotiableDataCiphers: [OpenVPN.Cipher]? {
+        guard var ciphers = dataCiphers, !ciphers.isEmpty else {
+            return nil
+        }
+        if let cipher, !ciphers.contains(cipher) {
+            ciphers.append(cipher)
+        }
+        return ciphers
+    }
+
+    /// Resolves the data-channel cipher to actually use for this session.
+    ///
+    /// OpenVPN expects the server to select the negotiated cipher and communicate
+    /// it back to the client as a single `cipher` value, either via pushed
+    /// options or via the TLS auth-options/OCC exchange. If neither path yields
+    /// a server-selected cipher, fall back to the locally configured legacy
+    /// cipher or, when only `dataCiphers` is set, to its first entry.
+    func negotiatedDataChannelCipher(
+        with pushedOptions: OpenVPN.Configuration,
+        serverOptions: OpenVPN.Configuration?
+    ) -> OpenVPN.Cipher {
+        if let pushedCipher = pushedOptions.cipher {
+            return pushedCipher
+        }
+        if let serverCipher = serverOptions?.cipher,
+           negotiableDataCiphers?.contains(serverCipher) ?? false {
+            return serverCipher
+        }
+        return fallbackCipher
+    }
+}

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
@@ -33,7 +33,7 @@ extension OpenVPN.Configuration {
         if let pushedCipher = pushedOptions.cipher {
             return pushedCipher
         }
-        if let serverCipher = serverOptions?.effectiveCipher,
+        if let serverCipher = serverOptions?.cipher,
            negotiableDataCiphers?.contains(serverCipher) ?? false {
             return serverCipher
         }

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
@@ -28,12 +28,12 @@ extension OpenVPN.Configuration {
     /// cipher or, when only `dataCiphers` is set, to its first entry.
     func negotiatedDataChannelCipher(
         with pushedOptions: OpenVPN.Configuration,
-        serverOptions: OpenVPN.Configuration?
+        serverOptions: OpenVPN.ServerOCC?
     ) -> OpenVPN.Cipher {
         if let pushedCipher = pushedOptions.cipher {
             return pushedCipher
         }
-        if let serverCipher = serverOptions?.cipher,
+        if let serverCipher = serverOptions?.effectiveCipher,
            negotiableDataCiphers?.contains(serverCipher) ?? false {
             return serverCipher
         }

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNConfiguration+CipherNegotiation.swift
@@ -28,7 +28,7 @@ extension OpenVPN.Configuration {
     /// cipher or, when only `dataCiphers` is set, to its first entry.
     func negotiatedDataChannelCipher(
         with pushedOptions: OpenVPN.Configuration,
-        serverOptions: OpenVPN.ServerOCC?
+        serverOptions: ServerOCC?
     ) -> OpenVPN.Cipher {
         if let pushedCipher = pushedOptions.cipher {
             return pushedCipher

--- a/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
@@ -2,19 +2,17 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-extension OpenVPN {
-    /// The subset of server-side OCC/auth-options values that can affect client
-    /// runtime behavior.
-    struct ServerOCC: Hashable, Sendable {
-        /// The server-selected data-channel cipher, when provided explicitly.
-        let cipher: OpenVPN.Cipher?
+/// The subset of server-side OCC/auth-options values that can affect client
+/// runtime behavior.
+struct ServerOCC: Hashable, Sendable {
+    /// The server-selected data-channel cipher, when provided explicitly.
+    let cipher: OpenVPN.Cipher?
 
-        /// The server-selected HMAC digest, when provided explicitly.
-        let digest: OpenVPN.Digest?
-    }
+    /// The server-selected HMAC digest, when provided explicitly.
+    let digest: OpenVPN.Digest?
 }
 
-extension OpenVPN.ServerOCC {
+extension ServerOCC {
     /// Parses the OCC/auth-options string exchanged during TLS auth.
     ///
     /// This string is not a full `.ovpn` representation, so parsing is kept

--- a/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
@@ -58,9 +58,6 @@ extension ServerOCC {
             }
         }
 
-        return Self(
-            cipher: cipher,
-            digest: digest
-        )
+        return Self(cipher: cipher, digest: digest)
     }
 }

--- a/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+extension OpenVPN {
+    /// The subset of server-side OCC/auth-options values that can affect client
+    /// runtime behavior.
+    struct ServerOCC: Hashable, Sendable {
+        /// The server-selected data-channel cipher, when provided explicitly.
+        let cipher: OpenVPN.Cipher?
+
+        /// The server-advertised negotiated cipher list, if present.
+        let dataCiphers: [OpenVPN.Cipher]?
+
+        /// The legacy fallback cipher, if advertised separately.
+        let dataCiphersFallback: OpenVPN.Cipher?
+
+        /// The server-selected HMAC digest, when provided explicitly.
+        let digest: OpenVPN.Digest?
+    }
+}
+
+extension OpenVPN.ServerOCC {
+    /// Returns the effective single-cipher value carried by the OCC string.
+    ///
+    /// Standard OpenVPN normally communicates the server-selected cipher as
+    /// `cipher`, but `data-ciphers-fallback` is treated as the legacy
+    /// single-cipher equivalent when present.
+    var effectiveCipher: OpenVPN.Cipher? {
+        cipher ?? dataCiphersFallback
+    }
+
+    /// Parses the OCC/auth-options string exchanged during TLS auth.
+    ///
+    /// This string is not a full `.ovpn` representation, so parsing is kept
+    /// intentionally narrow and tolerant: unknown tokens are ignored and only
+    /// the subset relevant to negotiation is extracted.
+    static func parsed(from string: String) -> Self {
+        var cipher: OpenVPN.Cipher?
+        var dataCiphers: [OpenVPN.Cipher]?
+        var dataCiphersFallback: OpenVPN.Cipher?
+        var digest: OpenVPN.Digest?
+
+        for line in string.components(separatedBy: ",") {
+            let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedLine.isEmpty else {
+                continue
+            }
+
+            let components = trimmedLine.split(whereSeparator: \.isWhitespace)
+            guard let option = components.first?.lowercased() else {
+                continue
+            }
+            guard components.count > 1 else {
+                continue
+            }
+
+            switch option {
+            case "cipher":
+                cipher = OpenVPN.Cipher(rawValue: components[1].uppercased())
+
+            case "data-ciphers", "ncp-ciphers":
+                let parsedCiphers = components[1]
+                    .split(separator: ":")
+                    .compactMap {
+                        OpenVPN.Cipher(rawValue: $0.uppercased())
+                    }
+                if !parsedCiphers.isEmpty {
+                    dataCiphers = parsedCiphers
+                }
+
+            case "data-ciphers-fallback":
+                dataCiphersFallback = OpenVPN.Cipher(rawValue: components[1].uppercased())
+
+            case "auth":
+                digest = OpenVPN.Digest(rawValue: components[1].uppercased())
+
+            default:
+                break
+            }
+        }
+
+        return Self(
+            cipher: cipher,
+            dataCiphers: dataCiphers,
+            dataCiphersFallback: dataCiphersFallback,
+            digest: digest
+        )
+    }
+}

--- a/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/ServerOCC.swift
@@ -9,36 +9,22 @@ extension OpenVPN {
         /// The server-selected data-channel cipher, when provided explicitly.
         let cipher: OpenVPN.Cipher?
 
-        /// The server-advertised negotiated cipher list, if present.
-        let dataCiphers: [OpenVPN.Cipher]?
-
-        /// The legacy fallback cipher, if advertised separately.
-        let dataCiphersFallback: OpenVPN.Cipher?
-
         /// The server-selected HMAC digest, when provided explicitly.
         let digest: OpenVPN.Digest?
     }
 }
 
 extension OpenVPN.ServerOCC {
-    /// Returns the effective single-cipher value carried by the OCC string.
-    ///
-    /// Standard OpenVPN normally communicates the server-selected cipher as
-    /// `cipher`, but `data-ciphers-fallback` is treated as the legacy
-    /// single-cipher equivalent when present.
-    var effectiveCipher: OpenVPN.Cipher? {
-        cipher ?? dataCiphersFallback
-    }
-
     /// Parses the OCC/auth-options string exchanged during TLS auth.
     ///
     /// This string is not a full `.ovpn` representation, so parsing is kept
     /// intentionally narrow and tolerant: unknown tokens are ignored and only
-    /// the subset relevant to negotiation is extracted.
+    /// the subset relevant to negotiation is extracted. Standard OpenVPN sends
+    /// a single `cipher` value here; `data-ciphers-fallback` is accepted as a
+    /// tolerant alias for peers that expose the same information under that
+    /// name.
     static func parsed(from string: String) -> Self {
         var cipher: OpenVPN.Cipher?
-        var dataCiphers: [OpenVPN.Cipher]?
-        var dataCiphersFallback: OpenVPN.Cipher?
         var digest: OpenVPN.Digest?
 
         for line in string.components(separatedBy: ",") {
@@ -59,18 +45,12 @@ extension OpenVPN.ServerOCC {
             case "cipher":
                 cipher = OpenVPN.Cipher(rawValue: components[1].uppercased())
 
-            case "data-ciphers", "ncp-ciphers":
-                let parsedCiphers = components[1]
-                    .split(separator: ":")
-                    .compactMap {
-                        OpenVPN.Cipher(rawValue: $0.uppercased())
-                    }
-                if !parsedCiphers.isEmpty {
-                    dataCiphers = parsedCiphers
-                }
-
             case "data-ciphers-fallback":
-                dataCiphersFallback = OpenVPN.Cipher(rawValue: components[1].uppercased())
+                // Treat the fallback directive as a tolerant alias, but keep an
+                // explicit OCC `cipher` if the peer sent both.
+                if cipher == nil {
+                    cipher = OpenVPN.Cipher(rawValue: components[1].uppercased())
+                }
 
             case "auth":
                 digest = OpenVPN.Digest(rawValue: components[1].uppercased())
@@ -82,8 +62,6 @@ extension OpenVPN.ServerOCC {
 
         return Self(
             cipher: cipher,
-            dataCiphers: dataCiphers,
-            dataCiphersFallback: dataCiphersFallback,
             digest: digest
         )
     }

--- a/Tests/PartoutOpenVPNTests/ConfigurationBuilderTests.swift
+++ b/Tests/PartoutOpenVPNTests/ConfigurationBuilderTests.swift
@@ -13,7 +13,8 @@ struct ConfigurationBuilderTests {
         sut.ca = .init(pem: "")
         sut.remotes = [.init(rawValue: "1.2.3.4:UDP:1000")!]
         let cfg = try sut.build(isClient: true)
-        #expect(cfg.cipher == .aes128cbc)
+        #expect(cfg.cipher == nil)
+        #expect(cfg.fallbackCipher == .aes128cbc)
         #expect(cfg.digest == nil)
         #expect(cfg.compressionFraming == nil)
         #expect(cfg.compressionAlgorithm == nil)
@@ -27,5 +28,19 @@ struct ConfigurationBuilderTests {
         #expect(cfg.digest == nil)
         #expect(cfg.compressionFraming == nil)
         #expect(cfg.compressionAlgorithm == nil)
+    }
+
+    @Test
+    func givenBuilderWithDataCiphersButNoCipher_whenClient_thenFallbackCipherUsesFirstDataCipher() throws {
+        var sut = OpenVPN.Configuration.Builder()
+        sut.ca = .init(pem: "")
+        sut.remotes = [.init(rawValue: "1.2.3.4:UDP:1000")!]
+        sut.dataCiphers = [.aes256cbc]
+
+        let cfg = try sut.build(isClient: true)
+
+        #expect(cfg.cipher == nil)
+        #expect(cfg.dataCiphers == [.aes256cbc])
+        #expect(cfg.fallbackCipher == .aes256cbc)
     }
 }

--- a/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
+++ b/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
@@ -68,8 +68,6 @@ struct ConfigurationTests {
 
         let server = OpenVPN.ServerOCC(
             cipher: .aes128gcm,
-            dataCiphers: nil,
-            dataCiphersFallback: nil,
             digest: nil
         )
 
@@ -110,6 +108,16 @@ struct ConfigurationTests {
 
         #expect(serverOptions.cipher == .aes256cbc)
         #expect(serverOptions.digest == .sha256)
+    }
+
+    @Test
+    func givenOCCFallbackCipherAlias_whenParsing_thenMapsItToCipher() throws {
+        let serverOptions = OpenVPN.ServerOCC.parsed(
+            from: "V4,data-ciphers-fallback AES-128-CBC,auth SHA1"
+        )
+
+        #expect(serverOptions.cipher == .aes128cbc)
+        #expect(serverOptions.digest == .sha1)
     }
 
     @Test

--- a/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
+++ b/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
@@ -66,7 +66,7 @@ struct ConfigurationTests {
 
         let pushed = try OpenVPN.Configuration.Builder().build(isClient: false)
 
-        let server = OpenVPN.ServerOCC(
+        let server = ServerOCC(
             cipher: .aes128gcm,
             digest: nil
         )
@@ -102,7 +102,7 @@ struct ConfigurationTests {
 
     @Test
     func givenOCCServerOptionsString_whenParsing_thenIgnoresNonProfileTokensAndExtractsCipher() throws {
-        let serverOptions = OpenVPN.ServerOCC.parsed(
+        let serverOptions = ServerOCC.parsed(
             from: "V4,dev-type tun,link-mtu 1569,tun-mtu 1500,proto UDPv4,keydir 0,cipher AES-256-CBC,auth SHA256,keysize 256,tls-auth,key-method 2,tls-server"
         )
 
@@ -112,7 +112,7 @@ struct ConfigurationTests {
 
     @Test
     func givenOCCFallbackCipherAlias_whenParsing_thenMapsItToCipher() throws {
-        let serverOptions = OpenVPN.ServerOCC.parsed(
+        let serverOptions = ServerOCC.parsed(
             from: "V4,data-ciphers-fallback AES-128-CBC,auth SHA1"
         )
 

--- a/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
+++ b/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 struct ConfigurationTests {
     @Test
-    func givenRandomizeHostnames_whenProcessRemotes_thenHostnamesHaveAlphanumericPrefix() throws {
+    func givenRandomizeHostnames_whenProcessingRemotes_thenPrefixesOnlyHostnames() throws {
         var builder = OpenVPN.Configuration.Builder()
         let hostname = "my.host.name"
         let ipv4 = "1.2.3.4"
@@ -34,7 +34,7 @@ struct ConfigurationTests {
     }
 
     @Test
-    func givenDataCiphersAndFallback_whenBuildingNegotiableDataCiphers_thenAppendsFallbackCipher() throws {
+    func givenDataCiphersAndLegacyCipher_whenComputingNegotiableDataCiphers_thenAppendsLegacyCipher() throws {
         var builder = OpenVPN.Configuration.Builder()
         builder.cipher = .aes128cbc
         builder.dataCiphers = [.aes256gcm, .aes128gcm]
@@ -44,7 +44,64 @@ struct ConfigurationTests {
     }
 
     @Test
-    func givenServerCipher_whenNegotiatingDataChannel_thenUsesServerCipher() throws {
+    func givenExplicitLegacyCipher_whenBuildingLocalOCCOptions_thenIncludesCipherAndKeysize() throws {
+        var builder = OpenVPN.Configuration.Builder()
+        builder.cipher = .aes128cbc
+        builder.dataCiphers = [.aes256gcm, .aes128gcm]
+        let options = try builder.build(isClient: false)
+
+        let occ = options.asLocalOptionsString(withLocalOptions: true)
+
+        #expect(occ.contains("cipher AES-128-CBC"))
+        #expect(occ.contains("keysize 128"))
+    }
+
+    @Test
+    func givenOnlyDataCiphers_whenBuildingLocalOCCOptions_thenOmitsLegacyCipherAndKeysize() throws {
+        var builder = OpenVPN.Configuration.Builder()
+        builder.dataCiphers = [.aes256cbc]
+        let options = try builder.build(isClient: false)
+
+        let occ = options.asLocalOptionsString(withLocalOptions: true)
+
+        #expect(!occ.contains("cipher "))
+        #expect(!occ.contains("keysize "))
+        #expect(occ.contains("auth SHA1"))
+    }
+
+    @Test
+    func givenOCCDataCiphersFallbackAlias_whenParsing_thenMapsItToCipher() throws {
+        let serverOptions = ServerOCC.parsed(
+            from: "V4,data-ciphers-fallback AES-128-CBC,auth SHA1"
+        )
+
+        #expect(serverOptions.cipher == .aes128cbc)
+        #expect(serverOptions.digest == .sha1)
+    }
+
+    @Test
+    func givenOCCOptionsStringWithNonProfileTokens_whenParsing_thenExtractsCipherAndDigest() throws {
+        let serverOptions = ServerOCC.parsed(
+            from: "V4,dev-type tun,link-mtu 1569,tun-mtu 1500,proto UDPv4,keydir 0,cipher AES-256-CBC,auth SHA256,keysize 256,tls-auth,key-method 2,tls-server"
+        )
+
+        #expect(serverOptions.cipher == .aes256cbc)
+        #expect(serverOptions.digest == .sha256)
+    }
+
+    @Test
+    func givenNoServerSelectedCipher_whenNegotiatingDataChannel_thenUsesFallbackCipher() throws {
+        var localBuilder = OpenVPN.Configuration.Builder()
+        localBuilder.cipher = .aes256cbc
+        let local = try localBuilder.build(isClient: false)
+
+        let pushed = try OpenVPN.Configuration.Builder().build(isClient: false)
+
+        #expect(local.negotiatedDataChannelCipher(with: pushed, serverOptions: nil) == .aes256cbc)
+    }
+
+    @Test
+    func givenPushedCipher_whenNegotiatingDataChannel_thenUsesPushedCipher() throws {
         var localBuilder = OpenVPN.Configuration.Builder()
         localBuilder.cipher = .aes128cbc
         localBuilder.dataCiphers = [.aes256gcm, .aes128gcm]
@@ -58,77 +115,16 @@ struct ConfigurationTests {
     }
 
     @Test
-    func givenServerOptionsCipherInNegotiableList_whenNegotiatingDataChannel_thenUsesServerCipher() throws {
+    func givenServerOCCCipherInNegotiableList_whenNegotiatingDataChannel_thenUsesServerCipher() throws {
         var localBuilder = OpenVPN.Configuration.Builder()
         localBuilder.cipher = .aes128cbc
         localBuilder.dataCiphers = [.aes256gcm, .aes128gcm]
         let local = try localBuilder.build(isClient: false)
 
         let pushed = try OpenVPN.Configuration.Builder().build(isClient: false)
-
-        let server = ServerOCC(
-            cipher: .aes128gcm,
-            digest: nil
-        )
+        let server = ServerOCC(cipher: .aes128gcm, digest: nil)
 
         #expect(local.negotiatedDataChannelCipher(with: pushed, serverOptions: server) == .aes128gcm)
-    }
-
-    @Test
-    func givenOnlyDataCiphers_whenBuildingLocalOCCOptions_thenOmitsLegacyCipher() throws {
-        var builder = OpenVPN.Configuration.Builder()
-        builder.dataCiphers = [.aes256cbc]
-        let options = try builder.build(isClient: false)
-
-        let occ = options.asLocalOptionsString(withLocalOptions: true)
-
-        #expect(!occ.contains("cipher "))
-        #expect(!occ.contains("keysize "))
-        #expect(occ.contains("auth SHA1"))
-    }
-
-    @Test
-    func givenExplicitCipher_whenBuildingLocalOCCOptions_thenIncludesLegacyCipher() throws {
-        var builder = OpenVPN.Configuration.Builder()
-        builder.cipher = .aes128cbc
-        builder.dataCiphers = [.aes256gcm, .aes128gcm]
-        let options = try builder.build(isClient: false)
-
-        let occ = options.asLocalOptionsString(withLocalOptions: true)
-
-        #expect(occ.contains("cipher AES-128-CBC"))
-        #expect(occ.contains("keysize 128"))
-    }
-
-    @Test
-    func givenOCCServerOptionsString_whenParsing_thenIgnoresNonProfileTokensAndExtractsCipher() throws {
-        let serverOptions = ServerOCC.parsed(
-            from: "V4,dev-type tun,link-mtu 1569,tun-mtu 1500,proto UDPv4,keydir 0,cipher AES-256-CBC,auth SHA256,keysize 256,tls-auth,key-method 2,tls-server"
-        )
-
-        #expect(serverOptions.cipher == .aes256cbc)
-        #expect(serverOptions.digest == .sha256)
-    }
-
-    @Test
-    func givenOCCFallbackCipherAlias_whenParsing_thenMapsItToCipher() throws {
-        let serverOptions = ServerOCC.parsed(
-            from: "V4,data-ciphers-fallback AES-128-CBC,auth SHA1"
-        )
-
-        #expect(serverOptions.cipher == .aes128cbc)
-        #expect(serverOptions.digest == .sha1)
-    }
-
-    @Test
-    func givenNoServerCipher_whenNegotiatingDataChannel_thenUsesFallbackCipher() throws {
-        var localBuilder = OpenVPN.Configuration.Builder()
-        localBuilder.cipher = .aes256cbc
-        let local = try localBuilder.build(isClient: false)
-
-        let pushed = try OpenVPN.Configuration.Builder().build(isClient: false)
-
-        #expect(local.negotiatedDataChannelCipher(with: pushed, serverOptions: nil) == .aes256cbc)
     }
 }
 

--- a/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
+++ b/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
@@ -32,6 +32,57 @@ struct ConfigurationTests {
                 }
             }
     }
+
+    @Test
+    func givenDataCiphersAndFallback_whenBuildingNegotiableDataCiphers_thenAppendsFallbackCipher() throws {
+        var builder = OpenVPN.Configuration.Builder()
+        builder.cipher = .aes128cbc
+        builder.dataCiphers = [.aes256gcm, .aes128gcm]
+        let cfg = try builder.build(isClient: false)
+
+        #expect(cfg.negotiableDataCiphers == [.aes256gcm, .aes128gcm, .aes128cbc])
+    }
+
+    @Test
+    func givenServerCipher_whenNegotiatingDataChannel_thenUsesServerCipher() throws {
+        var localBuilder = OpenVPN.Configuration.Builder()
+        localBuilder.cipher = .aes128cbc
+        localBuilder.dataCiphers = [.aes256gcm, .aes128gcm]
+        let local = try localBuilder.build(isClient: false)
+
+        var pushedBuilder = OpenVPN.Configuration.Builder()
+        pushedBuilder.cipher = .aes128gcm
+        let pushed = try pushedBuilder.build(isClient: false)
+
+        #expect(local.negotiatedDataChannelCipher(with: pushed, serverOptions: nil) == .aes128gcm)
+    }
+
+    @Test
+    func givenServerOptionsCipherInNegotiableList_whenNegotiatingDataChannel_thenUsesServerCipher() throws {
+        var localBuilder = OpenVPN.Configuration.Builder()
+        localBuilder.cipher = .aes128cbc
+        localBuilder.dataCiphers = [.aes256gcm, .aes128gcm]
+        let local = try localBuilder.build(isClient: false)
+
+        let pushed = try OpenVPN.Configuration.Builder().build(isClient: false)
+
+        var serverBuilder = OpenVPN.Configuration.Builder()
+        serverBuilder.cipher = .aes128gcm
+        let server = try serverBuilder.build(isClient: false)
+
+        #expect(local.negotiatedDataChannelCipher(with: pushed, serverOptions: server) == .aes128gcm)
+    }
+
+    @Test
+    func givenNoServerCipher_whenNegotiatingDataChannel_thenUsesFallbackCipher() throws {
+        var localBuilder = OpenVPN.Configuration.Builder()
+        localBuilder.cipher = .aes256cbc
+        let local = try localBuilder.build(isClient: false)
+
+        let pushed = try OpenVPN.Configuration.Builder().build(isClient: false)
+
+        #expect(local.negotiatedDataChannelCipher(with: pushed, serverOptions: nil) == .aes256cbc)
+    }
 }
 
 private final class MockPRNG: PRNGProtocol {

--- a/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
+++ b/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
@@ -77,6 +77,32 @@ struct ConfigurationTests {
     }
 
     @Test
+    func givenOnlyDataCiphers_whenBuildingLocalOCCOptions_thenOmitsLegacyCipher() throws {
+        var builder = OpenVPN.Configuration.Builder()
+        builder.dataCiphers = [.aes256cbc]
+        let options = try builder.build(isClient: false)
+
+        let occ = options.asLocalOptionsString(withLocalOptions: true)
+
+        #expect(!occ.contains("cipher "))
+        #expect(!occ.contains("keysize "))
+        #expect(occ.contains("auth SHA1"))
+    }
+
+    @Test
+    func givenExplicitCipher_whenBuildingLocalOCCOptions_thenIncludesLegacyCipher() throws {
+        var builder = OpenVPN.Configuration.Builder()
+        builder.cipher = .aes128cbc
+        builder.dataCiphers = [.aes256gcm, .aes128gcm]
+        let options = try builder.build(isClient: false)
+
+        let occ = options.asLocalOptionsString(withLocalOptions: true)
+
+        #expect(occ.contains("cipher AES-128-CBC"))
+        #expect(occ.contains("keysize 128"))
+    }
+
+    @Test
     func givenOCCServerOptionsString_whenParsing_thenIgnoresNonProfileTokensAndExtractsCipher() throws {
         let serverOptions = OpenVPN.ServerOCC.parsed(
             from: "V4,dev-type tun,link-mtu 1569,tun-mtu 1500,proto UDPv4,keydir 0,cipher AES-256-CBC,auth SHA256,keysize 256,tls-auth,key-method 2,tls-server"

--- a/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
+++ b/Tests/PartoutOpenVPNTests/ConfigurationTests.swift
@@ -66,11 +66,24 @@ struct ConfigurationTests {
 
         let pushed = try OpenVPN.Configuration.Builder().build(isClient: false)
 
-        var serverBuilder = OpenVPN.Configuration.Builder()
-        serverBuilder.cipher = .aes128gcm
-        let server = try serverBuilder.build(isClient: false)
+        let server = OpenVPN.ServerOCC(
+            cipher: .aes128gcm,
+            dataCiphers: nil,
+            dataCiphersFallback: nil,
+            digest: nil
+        )
 
         #expect(local.negotiatedDataChannelCipher(with: pushed, serverOptions: server) == .aes128gcm)
+    }
+
+    @Test
+    func givenOCCServerOptionsString_whenParsing_thenIgnoresNonProfileTokensAndExtractsCipher() throws {
+        let serverOptions = OpenVPN.ServerOCC.parsed(
+            from: "V4,dev-type tun,link-mtu 1569,tun-mtu 1500,proto UDPv4,keydir 0,cipher AES-256-CBC,auth SHA256,keysize 256,tls-auth,key-method 2,tls-server"
+        )
+
+        #expect(serverOptions.cipher == .aes256cbc)
+        #expect(serverOptions.digest == .sha256)
     }
 
     @Test


### PR DESCRIPTION
Raised by https://github.com/orgs/partout-io/discussions/1773

Factor the modern `data-ciphers` option (replacing the deprecated `cipher`) into the computation of the negotiated cipher. Remotely, the OpenVPN server is expected to use the client's `IV_CIPHERS` to send a `cipher` in the server options during the TLS handshake. We eventually use it to pick the final data cipher.

Side tasks:

- Parse the server OCC string (options consistency check) separately from the full configuration parser, the syntax differs.
- Do NOT hardcode `cipher` to AES-128-CBC when none is given, because that would alter the cipher decision in the Configuration builder (method `build(isClient: Bool)`).
- Treat `cipher` as an alias `data-ciphers-fallback` in the parser.