### PR TITLE
Core: Fix POSIX socket close semantics and partial writes

### DIFF
--- a/Sources/PartoutCore/Connection/POSIXBlockingSocket.swift
+++ b/Sources/PartoutCore/Connection/POSIXBlockingSocket.swift
@@ -57,8 +57,7 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
         )
     }
 
-    // Assumes fd to be an open socket descriptor. The socket is not
-    // closed on deinit (isOwned is false).
+    // Assumes fd to be an open socket descriptor. Acquires ownership.
     init(
         _ ctx: PartoutLoggerContext,
         sock: pp_socket,

--- a/Sources/PartoutCore/Connection/POSIXBlockingSocket.swift
+++ b/Sources/PartoutCore/Connection/POSIXBlockingSocket.swift
@@ -15,6 +15,9 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
     nonisolated(unsafe)
     private let sock: pp_socket
 
+    nonisolated(unsafe)
+    private var descriptor: UInt64?
+
     private let endpoint: ExtendedEndpoint?
 
     private let closesOnEmptyRead: Bool
@@ -79,10 +82,12 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
         maxReadLength: Int
     ) {
         self.ctx = ctx
-        let queueLabelContext = pp_socket_fd(sock).description
+        let newDescriptor = pp_socket_fd(sock)
+        let queueLabelContext = newDescriptor.description
         readQueue = DispatchQueue(label: "POSIXBlockingSocket[R:\(queueLabelContext)]")
         writeQueue = DispatchQueue(label: "POSIXBlockingSocket[W:\(queueLabelContext)]")
         self.sock = sock
+        descriptor = newDescriptor
         self.endpoint = endpoint
         self.closesOnEmptyRead = closesOnEmptyRead
         readBuf = [UInt8](repeating: 0, count: maxReadLength)
@@ -95,7 +100,7 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
     }
 
     public nonisolated var fileDescriptor: UInt64? {
-        pp_socket_fd(sock)
+        descriptor
     }
 
     public func readPackets() async throws -> [Data] {
@@ -123,8 +128,11 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
                 }
             }
         } catch {
+            guard isActive else {
+                throw PartoutError(.linkNotActive)
+            }
             pp_log(ctx, .core, .fault, "Unable to read packets: \(error)")
-            shutdown()
+            await shutdown()
             throw error
         }
     }
@@ -136,7 +144,10 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
         do {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 writeQueue.async { [weak self] in
-                    guard let sock = self?.sock else { return }
+                    guard let sock = self?.sock else {
+                        continuation.resume(throwing: PartoutError(.releasedObject))
+                        return
+                    }
                     for toWrite in packets {
                         guard !toWrite.isEmpty else { continue }
                         let writtenCount = toWrite.withUnsafeBytes {
@@ -151,16 +162,31 @@ public actor POSIXBlockingSocket: SocketIOInterface, @unchecked Sendable {
                 }
             }
         } catch {
+            guard isActive else {
+                throw PartoutError(.linkNotActive)
+            }
             pp_log(ctx, .core, .fault, "Unable to write packets: \(error)")
-            shutdown()
+            await shutdown()
             throw error
         }
     }
 
-    public func shutdown() {
+    public func shutdown() async {
         guard isActive else { return }
         isActive = false
+        descriptor = nil
         pp_log(ctx, .core, .info, "Shut down socket")
-        pp_socket_free(sock)
+        pp_socket_shutdown(sock)
+        await Self.waitUntilIdle(readQueue)
+        await Self.waitUntilIdle(writeQueue)
+        pp_socket_close(sock)
+    }
+
+    private static func waitUntilIdle(_ queue: DispatchQueue) async {
+        await withCheckedContinuation { continuation in
+            queue.async {
+                continuation.resume()
+            }
+        }
     }
 }

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -18,8 +18,10 @@ typedef enum {
 /* The opaque socket type. */
 typedef struct _pp_socket *pp_socket;
 
-/* Externally managed. */
-pp_socket _Nonnull pp_socket_create(uint64_t fd, bool is_owned);
+/* Create a socket wrapper from an already open native descriptor. The
+ * wrapper acquires ownership and will close the descriptor on
+ * pp_socket_close() or pp_socket_free(). */
+pp_socket _Nonnull pp_socket_create(uint64_t fd);
 void pp_socket_shutdown(pp_socket _Nonnull sock);
 void pp_socket_close(pp_socket _Nonnull sock);
 void pp_socket_free(pp_socket _Nonnull sock);

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -20,6 +20,8 @@ typedef struct _pp_socket *pp_socket;
 
 /* Externally managed. */
 pp_socket _Nonnull pp_socket_create(uint64_t fd, bool is_owned);
+void pp_socket_shutdown(pp_socket _Nonnull sock);
+void pp_socket_close(pp_socket _Nonnull sock);
 void pp_socket_free(pp_socket _Nonnull sock);
 
 /* Create socket to endpoint. */

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -10,6 +10,8 @@
 #define os_socket_fd SOCKET
 #define OS_INVALID_SOCKET INVALID_SOCKET
 #define os_close_socket closesocket
+#define os_shutdown_socket shutdown
+#define OS_SHUTDOWN_BOTH SD_BOTH
 #define SOCKET_PRINT_ERROR(msg) \
     pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed with error %d", msg, WSAGetLastError())
 #else
@@ -21,6 +23,8 @@
 #define os_socket_fd int
 #define OS_INVALID_SOCKET -1
 #define os_close_socket close
+#define os_shutdown_socket shutdown
+#define OS_SHUTDOWN_BOTH SHUT_RDWR
 #define SOCKET_PRINT_ERROR(msg) \
     pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed: %s", msg, strerror(errno))
 #endif
@@ -34,6 +38,7 @@
 #include "portable/socket.h"
 
 int connect_with_timeout(os_socket_fd fd, const struct sockaddr *addr, socklen_t addrlen, bool blocking, int timeout_ms);
+static void pp_socket_close_impl(pp_socket sock);
 
 /* Host a file descriptor with the specific platform type. POSIX systems
  * use int, whereas Windows uses SOCKET.  */
@@ -125,61 +130,136 @@ failure:
     return NULL;
 }
 
-/* Free the socket. */
+/* Close the native file descriptor without freeing the wrapper. */
+void pp_socket_shutdown(pp_socket sock) {
+    if (!sock || sock->fd == OS_INVALID_SOCKET) return;
+    (void)os_shutdown_socket(sock->fd, OS_SHUTDOWN_BOTH);
+}
+
+/* Close the native file descriptor without freeing the wrapper. */
+void pp_socket_close(pp_socket sock) {
+    if (!sock) return;
+    pp_socket_close_impl(sock);
+}
+
+/* Free the socket wrapper. */
 void pp_socket_free(pp_socket sock) {
     if (!sock) return;
-    if (sock->is_owned) os_close_socket(sock->fd);
+    pp_socket_close_impl(sock);
+    pp_free(sock);
 }
 
 /* Read up to dst_len bytes, and return the amount of the actually read
  * bytes. Returns < 0 on failure. */
 int pp_socket_read(pp_socket sock, uint8_t *dst, size_t dst_len) {
+    if (!sock || sock->fd == OS_INVALID_SOCKET) {
 #ifdef _WIN32
-    const int read_len = (int)recv(sock->fd, (void *)dst, dst_len, 0);
+        WSASetLastError(WSAENOTSOCK);
 #else
-    const int read_len = (int)read(sock->fd, (void *)dst, dst_len);
+        errno = EBADF;
 #endif
-    if (read_len < 0) {
-        /* If no messages are available at the socket, the receive call waits
-         * for a message to arrive, unless the socket is nonblocking (see fcntl(2))
-         * in which case the value -1 is returned and the external variable errno
-         * set to EAGAIN. */
-        if (errno == EAGAIN) {
-            return 0;
-        }
-        SOCKET_PRINT_ERROR("recv()");
+        return -1;
     }
-    return read_len;
+#ifdef _WIN32
+    while (true) {
+        const int read_len = (int)recv(sock->fd, (void *)dst, dst_len, 0);
+        if (read_len < 0 && WSAGetLastError() == WSAEINTR) {
+            continue;
+        }
+        if (read_len < 0) {
+            if (WSAGetLastError() == WSAEWOULDBLOCK) {
+                return 0;
+            }
+            SOCKET_PRINT_ERROR("recv()");
+        }
+        return read_len;
+    }
+#else
+    while (true) {
+        const int read_len = (int)read(sock->fd, (void *)dst, dst_len);
+        if (read_len < 0 && errno == EINTR) {
+            continue;
+        }
+        if (read_len < 0) {
+            /* If no messages are available at the socket, the receive call waits
+             * for a message to arrive, unless the socket is nonblocking (see fcntl(2))
+             * in which case the value -1 is returned and the external variable errno
+             * set to EAGAIN. */
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return 0;
+            }
+            SOCKET_PRINT_ERROR("recv()");
+        }
+        return read_len;
+    }
+#endif
 }
 
 /* Write src_len bytes, and repeat until fully written. Returns the amount
  * of written bytes, expected to always be src_len. Returns < 0 on failure. */
 int pp_socket_write(pp_socket sock, const uint8_t *src, size_t src_len) {
-    size_t remaining = src_len;
-    while (remaining > 0) {
+    if (!sock || sock->fd == OS_INVALID_SOCKET) {
 #ifdef _WIN32
-        const int written_len = (int)send(sock->fd, (void *)src, src_len, 0);
+        WSASetLastError(WSAENOTSOCK);
 #else
-        const int written_len = (int)write(sock->fd, (void *)src, src_len);
+        errno = EBADF;
+#endif
+        return -1;
+    }
+
+    size_t offset = 0;
+    while (offset < src_len) {
+        const uint8_t *current_src = src + offset;
+        const size_t remaining = src_len - offset;
+
+#ifdef _WIN32
+        const int written_len = (int)send(sock->fd, (const char *)current_src, (int)remaining, 0);
+#else
+        const int written_len = (int)write(sock->fd, current_src, remaining);
 #endif
         if (written_len < 0) {
-            if (errno == EAGAIN) {
-                return 0;
+#ifdef _WIN32
+            const int err = WSAGetLastError();
+            if (err == WSAEINTR || err == WSAEWOULDBLOCK) {
+                continue;
             }
+#else
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;
+            }
+#endif
             SOCKET_PRINT_ERROR("send()");
             return written_len;
         }
-        remaining -= written_len;
+        if (written_len == 0) {
+#ifdef _WIN32
+            WSASetLastError(WSAECONNRESET);
+#else
+            errno = EPIPE;
+#endif
+            SOCKET_PRINT_ERROR("send()");
+            return -1;
+        }
+        offset += (size_t)written_len;
     }
-    // Expect to write all data
-    pp_assert(remaining == 0);
-    return (int)src_len;
+    return (int)offset;
 }
 
 /* Return the native file descriptor. */
 uint64_t pp_socket_fd(const pp_socket sock) {
     pp_assert(sock && sock->fd != OS_INVALID_SOCKET);
     return sock->fd;
+}
+
+static void pp_socket_close_impl(pp_socket sock) {
+    if (!sock || sock->fd == OS_INVALID_SOCKET) {
+        return;
+    }
+    if (sock->is_owned) {
+        os_close_socket(sock->fd);
+    }
+    sock->fd = OS_INVALID_SOCKET;
+    sock->is_owned = false;
 }
 
 int connect_with_timeout(os_socket_fd fd, const struct sockaddr *addr, socklen_t addrlen,

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -44,15 +44,13 @@ static void pp_socket_close_impl(pp_socket sock);
  * use int, whereas Windows uses SOCKET.  */
 struct _pp_socket {
     os_socket_fd fd;
-    bool is_owned;
 };
 
 /* Create a socket from a formerly opened file descriptor. Use uint64_t to
  * cover the whole range of possible platform values. */
-pp_socket pp_socket_create(uint64_t fd, bool is_owned) {
+pp_socket pp_socket_create(uint64_t fd) {
     pp_socket sock = pp_alloc(sizeof(*sock));
     sock->fd = (os_socket_fd)fd;
-    sock->is_owned = is_owned;
     return sock;
 }
 
@@ -123,7 +121,7 @@ pp_socket pp_socket_open(const char *ip_addr,
     }
 
     // Success
-    return pp_socket_create(new_fd, true);
+    return pp_socket_create(new_fd);
 
 failure:
     if (new_fd != OS_INVALID_SOCKET) os_close_socket(new_fd);
@@ -255,11 +253,8 @@ static void pp_socket_close_impl(pp_socket sock) {
     if (!sock || sock->fd == OS_INVALID_SOCKET) {
         return;
     }
-    if (sock->is_owned) {
-        os_close_socket(sock->fd);
-    }
+    os_close_socket(sock->fd);
     sock->fd = OS_INVALID_SOCKET;
-    sock->is_owned = false;
 }
 
 int connect_with_timeout(os_socket_fd fd, const struct sockaddr *addr, socklen_t addrlen,

--- a/Tests/PartoutCoreTests/POSIXBlockingSocketTests.swift
+++ b/Tests/PartoutCoreTests/POSIXBlockingSocketTests.swift
@@ -29,7 +29,7 @@ struct POSIXBlockingSocketTests {
             _ = close(peerFD)
         }
 
-        let sock = pp_socket_create(UInt64(fds[0]), true)
+        let sock = pp_socket_create(UInt64(fds[0]))
         let sut = POSIXBlockingSocket(
             .global,
             sock: sock,

--- a/Tests/PartoutCoreTests/POSIXBlockingSocketTests.swift
+++ b/Tests/PartoutCoreTests/POSIXBlockingSocketTests.swift
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+@testable import PartoutCore
+import Foundation
+internal import _PartoutCore_C
+import Testing
+
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+struct POSIXBlockingSocketTests {
+    @Test
+    func givenPendingRead_whenShutdown_thenUnblocksWithoutBadDescriptor() async throws {
+        var fds = [Int32](repeating: 0, count: 2)
+#if canImport(Darwin)
+        let socketType = SOCK_STREAM
+#else
+        let socketType = Int32(SOCK_STREAM.rawValue)
+#endif
+        #expect(socketpair(AF_UNIX, socketType, 0, &fds) == 0)
+
+        let peerFD = fds[1]
+        defer {
+            _ = close(peerFD)
+        }
+
+        let sock = pp_socket_create(UInt64(fds[0]), true)
+        let sut = POSIXBlockingSocket(
+            .global,
+            sock: sock,
+            closesOnEmptyRead: true,
+            maxReadLength: 16
+        )
+
+        let readTask = Task<Result<[Data], Error>, Never> {
+            do {
+                return .success(try await sut.readPackets())
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+        await sut.shutdown()
+
+        #expect(sut.fileDescriptor == nil)
+
+        let result = await readTask.value
+        switch result {
+        case .success:
+            #expect(Bool(false), "Expected shutdown to stop the pending read")
+        case .failure(let error):
+            #expect(PartoutError(error) == PartoutError(.linkNotActive))
+        }
+    }
+}


### PR DESCRIPTION
- Shut down gracefully before close
- Code was also crashing on pp_socket_free() due to a double free
- Consider the pp_socket file descriptor to be always owned

Fixes #352 