### PR TITLE
Core: Do not free pp_tun_ctrl

### DIFF
--- a/Sources/Partout/VirtualTunnelController.swift
+++ b/Sources/Partout/VirtualTunnelController.swift
@@ -30,9 +30,6 @@ public final class VirtualTunnelController: TunnelController {
     }
 
     deinit {
-        if let impl {
-            pp_tun_ctrl_free(impl)
-        }
         pp_log(ctx, .core, .debug, "Deinit VirtualTunnelController")
     }
 

--- a/Sources/PartoutCore_C/include/portable/tunctrl.h
+++ b/Sources/PartoutCore_C/include/portable/tunctrl.h
@@ -12,4 +12,3 @@ void pp_tun_ctrl_test_working(void *ref);
 void *pp_tun_ctrl_set_tunnel(void *ref, const char *info_json);
 void pp_tun_ctrl_configure_sockets(void *ref, const int *fds, const size_t fds_len);
 void pp_tun_ctrl_clear_tunnel(void *ref, void *tun_impl);
-void pp_tun_ctrl_free(void *ref);

--- a/Sources/PartoutCore_C/tunctrl.c
+++ b/Sources/PartoutCore_C/tunctrl.c
@@ -186,18 +186,6 @@ cleanup:
     if (did_attach) (*jvm)->DetachCurrentThread(jvm);
 }
 
-void pp_tun_ctrl_free(void *jni_ref) {
-    assert(jni_ref);
-    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "pp_tun_ctrl_free(%p)", jni_ref);
-
-    bool did_attach;
-    JNIEnv *env = pp_jni_attach_thread(&did_attach);
-    if (!env) return;
-
-    (*env)->DeleteGlobalRef(env, jni_ref);
-    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
-}
-
 #else
 
 void pp_tun_ctrl_test_working(void *ref) {
@@ -223,11 +211,6 @@ void pp_tun_ctrl_clear_tunnel(void *ref, void *tun_impl) {
     (void)ref;
     (void)tun_impl;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "[dummy] clear_tunnel(%p)", ref);
-}
-
-void pp_tun_ctrl_free(void *ref) {
-    (void)ref;
-    pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "[dummy] free(%p)", ref);
 }
 
 #endif


### PR DESCRIPTION
Rely on external lifecycle, do not acquire ownership. Revert bit of #361