### PR TITLE
Core: Track enabled status of TunnelSnapshot

### DIFF
--- a/Sources/PartoutCore/Tunnel/FakeTunnelStrategy.swift
+++ b/Sources/PartoutCore/Tunnel/FakeTunnelStrategy.swift
@@ -16,6 +16,7 @@ public actor FakeTunnelStrategy: TunnelObservableStrategy, Sendable {
             }
             activeProfileSubject.send(.init(
                 id: previous.id,
+                isEnabled: previous.isEnabled,
                 status: newValue,
                 onDemand: previous.onDemand
             ))
@@ -73,21 +74,14 @@ public actor FakeTunnelStrategy: TunnelObservableStrategy, Sendable {
         if connect, status != .inactive {
             await doDisconnect()
         }
-        if isOnDemand {
-            activeProfileSubject.send(TunnelSnapshot(
-                id: profile.id,
-                status: .inactive,
-                onDemand: true
-            ))
-        } else {
-            activeProfileSubject.send(TunnelSnapshot(
-                id: profile.id,
-                status: .inactive,
-                onDemand: false
-            ))
-            if connect {
-                await doConnect()
-            }
+        activeProfileSubject.send(TunnelSnapshot(
+            id: profile.id,
+            isEnabled: true,
+            status: .inactive,
+            onDemand: isOnDemand
+        ))
+        if !isOnDemand && connect {
+            await doConnect()
         }
     }
 
@@ -102,6 +96,7 @@ public actor FakeTunnelStrategy: TunnelObservableStrategy, Sendable {
         await doDisconnect()
         activeProfileSubject.send(TunnelSnapshot(
             id: profileId,
+            isEnabled: false,
             status: .inactive,
             onDemand: false
         ))

--- a/Sources/PartoutCore/Tunnel/TunnelStrategy.swift
+++ b/Sources/PartoutCore/Tunnel/TunnelStrategy.swift
@@ -6,18 +6,21 @@
 public struct TunnelSnapshot: Hashable, Sendable, CustomStringConvertible {
     public let id: Profile.ID
 
+    public let isEnabled: Bool
+
     public let status: TunnelStatus
 
     public let onDemand: Bool
 
-    public init(id: Profile.ID, status: TunnelStatus, onDemand: Bool) {
+    public init(id: Profile.ID, isEnabled: Bool, status: TunnelStatus, onDemand: Bool) {
         self.id = id
+        self.isEnabled = isEnabled
         self.status = status
         self.onDemand = onDemand
     }
 
     public var description: String {
-        "{\(id.uuidString), status=\(status), onDemand=\(onDemand)}"
+        "{\(id.uuidString), isEnabled=\(isEnabled), status=\(status), onDemand=\(onDemand)}"
     }
 }
 

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -358,7 +358,7 @@ private extension NETunnelStrategy {
                     $0.filter {
                         $0.value.rank > 0
                     }
-                    .compactMapValues(\.asActiveProfile)
+                    .compactMapValues(\.asSnapshot)
                 }
         } else {
             mappedStream = stream
@@ -378,7 +378,7 @@ private extension NETunnelStrategy {
                         $0.value.rank == maxRank
                     }
                     assert(filtered.count <= 1, "Max ranked manager must be at most one")
-                    return filtered.compactMapValues(\.asActiveProfile)
+                    return filtered.compactMapValues(\.asSnapshot)
                 }
         }
 
@@ -520,12 +520,13 @@ extension NETunnelProviderManager: @retroactive @unchecked Sendable {
 }
 
 private extension NETunnelProviderManager {
-    var asActiveProfile: TunnelSnapshot? {
+    var asSnapshot: TunnelSnapshot? {
         guard let profileId else {
             return nil
         }
         return TunnelSnapshot(
             id: profileId,
+            isEnabled: isEnabled,
             status: connection.status.asTunnelStatus,
             onDemand: isEnabled && isOnDemandEnabled
         )

--- a/Tests/PartoutCoreTests/TunnelTests.swift
+++ b/Tests/PartoutCoreTests/TunnelTests.swift
@@ -25,7 +25,7 @@ struct TunnelTests {
         let sut = newTunnel()
         let module = IPModule.Builder().build()
         let profile = try Profile.Builder(modules: [module], activatingModules: true).build()
-        let stream = sut.snapshotsStream.removeDuplicates()
+        let stream = sut.snapshotsStream
 
         let expected: [TunnelStatus] = [
             .inactive,
@@ -45,6 +45,10 @@ struct TunnelTests {
                     return emitted
                 }
                 guard let status = snapshots.first?.value.status else {
+                    continue
+                }
+                // Skip duplicates
+                guard status != emitted.last else {
                     continue
                 }
                 emitted.append(status)


### PR DESCRIPTION
True if the profile's associated tunnel is enabled in the system. A tunnel can be inactive while either enabled or disabled.