### PR TITLE
WireGuard: Fix v2 breaking occasionally

### DIFF
--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1+Default.swift
@@ -13,7 +13,7 @@ extension _OpenVPNConnectionV1 {
         guard let configuration = module.configuration else {
             fatalError("Creating session without OpenVPN configuration?")
         }
-        pp_log(ctx, .openvpn, .notice, "OpenVPN: Using cross-platform connection")
+        pp_log(ctx, .openvpn, .notice, "OpenVPN: Using v1 connection")
 
         // Hardcode portable implementations
         let prng = PlatformPRNG()

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
@@ -13,7 +13,7 @@ extension _OpenVPNConnectionV2 {
         guard let configuration = module.configuration else {
             fatalError("Creating session without OpenVPN configuration?")
         }
-        pp_log(ctx, .openvpn, .notice, "OpenVPN: Using cross-platform connection V2")
+        pp_log(ctx, .openvpn, .notice, "OpenVPN: Using v2 connection")
 
         // Override options with feature flags
         var options = baseOptions

--- a/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
+++ b/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
@@ -55,7 +55,7 @@ public final class _WireGuardConnectionV1: Connection, @unchecked Sendable {
         guard let configuration = module.configuration else {
             throw PartoutError(.incompleteModule)
         }
-        pp_log(ctx, .wireguard, .notice, "WireGuard: Using legacy connection")
+        pp_log(ctx, .wireguard, .notice, "WireGuard: Using v1 connection")
 
         let tweakedConfiguration = try configuration.withModules(from: parameters.profile)
         tunnelConfiguration = try tweakedConfiguration.toWireGuardConfiguration()

--- a/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
@@ -10,6 +10,8 @@ extension WireGuard.Configuration {
     actor ResolvedMap {
         private var map: [Endpoint: Endpoint] = [:]
 
+        private var failures: [Endpoint] = []
+
         func setEndpoints(_ endpoints: [Endpoint], for sourceEndpoint: Endpoint) {
             assert(!endpoints.isEmpty, "Assigning empty resolved endpoints")
             let targetEndpoint: Endpoint? = {
@@ -30,20 +32,28 @@ extension WireGuard.Configuration {
             map[sourceEndpoint] = targetEndpoint
         }
 
+        func setFailure(for endpoint: Endpoint) {
+            failures.append(endpoint)
+        }
+
         func toMap() -> [Endpoint: Endpoint] {
             map
+        }
+
+        func failedEndpoints() -> [Endpoint] {
+            failures
         }
     }
 
     func resolvePeers(
         timeout: Int,
         logHandler: @escaping WireGuardAdapter.LogHandler
-    ) async -> [Endpoint: Endpoint] {
+    ) async throws -> [Endpoint: Endpoint] {
         let endpoints = peers.compactMap(\.endpoint)
         let resolver = SimpleDNSResolver {
             POSIXDNSStrategy(hostname: $0)
         }
-        return await withTaskGroup(returning: [Endpoint: Endpoint].self) { group in
+        return try await withThrowingTaskGroup(of: Void.self, returning: [Endpoint: Endpoint].self) { group in
             let allResolved = ResolvedMap()
             for endpoint in endpoints {
                 group.addTask { @Sendable in
@@ -63,13 +73,22 @@ extension WireGuard.Configuration {
                                 logHandler(.verbose, "DNS64: mapped \(endpoint.address) to \(record.address)")
                             }
                         }
+                        guard !currentResolved.isEmpty else {
+                            await allResolved.setFailure(for: endpoint)
+                            return
+                        }
                         await allResolved.setEndpoints(currentResolved, for: endpoint)
                     } catch {
                         logHandler(.error, "Failed to resolve endpoint \(endpoint.address.asSensitiveAddress(.global)): \(error.localizedDescription)")
+                        await allResolved.setFailure(for: endpoint)
                     }
                 }
             }
-            await group.waitForAll()
+            try await group.waitForAll()
+            let failures = await allResolved.failedEndpoints()
+            guard failures.isEmpty else {
+                throw WireGuardAdapterError.dnsResolution(failures)
+            }
             return await allResolved.toMap()
         }
     }

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -17,21 +17,20 @@ final class TunnelRemoteInfoGenerator: Sendable {
 
     private let dnsTimeout: Int
 
+    private let resolvedEndpoints: ResolvedEndpointsCache
+
     init(_ ctx: PartoutLoggerContext, tunnelConfiguration: WireGuard.Configuration, dnsTimeout: Int) {
         self.ctx = ctx
         self.tunnelConfiguration = tunnelConfiguration
         self.dnsTimeout = dnsTimeout
+        resolvedEndpoints = ResolvedEndpointsCache()
     }
 
     // Only updates peer endpoints
     func endpointUapiConfiguration(logHandler: @escaping WireGuardAdapter.LogHandler) async -> String {
         var wgSettings = ""
 
-        // address: String -> resolvedEndpoints: [Endpoint]
-        let resolutionMap = await tunnelConfiguration.resolvePeers(
-            timeout: dnsTimeout,
-            logHandler: logHandler
-        )
+        let resolutionMap = await resolvePeers(logHandler: logHandler)
         for peer in tunnelConfiguration.peers {
             let publicKey: String
             do {
@@ -74,11 +73,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
             wgSettings.append("replace_peers=true\n")
         }
 
-        // address: String -> resolvedEndpoints: [Endpoint]
-        let resolutionMap = await tunnelConfiguration.resolvePeers(
-            timeout: dnsTimeout,
-            logHandler: logHandler
-        )
+        let resolutionMap = await resolvePeers(logHandler: logHandler)
         guard !resolutionMap.isEmpty else {
             throw PartoutError(.dnsFailure)
         }
@@ -176,6 +171,20 @@ final class TunnelRemoteInfoGenerator: Sendable {
 }
 
 private extension TunnelRemoteInfoGenerator {
+    func resolvePeers(logHandler: @escaping WireGuardAdapter.LogHandler) async -> [Endpoint: Endpoint] {
+        if let resolutionMap = await resolvedEndpoints.value {
+            return resolutionMap
+        }
+        let resolutionMap = await tunnelConfiguration.resolvePeers(
+            timeout: dnsTimeout,
+            logHandler: logHandler
+        )
+        if !resolutionMap.isEmpty {
+            await resolvedEndpoints.setValue(resolutionMap)
+        }
+        return resolutionMap
+    }
+
     func addresses() -> ([Subnet], [Subnet]) {
         var ipv4: [Subnet] = []
         var ipv6: [Subnet] = []
@@ -232,6 +241,18 @@ private extension TunnelRemoteInfoGenerator {
             }
         }
         return (ipv4IncludedRoutes, ipv6IncludedRoutes)
+    }
+}
+
+private actor ResolvedEndpointsCache {
+    private var resolutionMap: [Endpoint: Endpoint]?
+
+    var value: [Endpoint: Endpoint]? {
+        resolutionMap
+    }
+
+    func setValue(_ resolutionMap: [Endpoint: Endpoint]) {
+        self.resolutionMap = resolutionMap
     }
 }
 

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -34,7 +34,13 @@ final class TunnelRemoteInfoGenerator: Sendable {
     func endpointUapiConfiguration(logHandler: @escaping WireGuardAdapter.LogHandler) async -> String {
         var wgSettings = ""
 
-        let resolutionMap = await resolvePeers(logHandler: logHandler)
+        let resolutionMap: [Endpoint: Endpoint]
+        do {
+            resolutionMap = try await resolvePeers(logHandler: logHandler)
+        } catch {
+            logHandler(.error, "Unable to resolve peer endpoints: \(error.localizedDescription)")
+            return wgSettings
+        }
         for peer in tunnelConfiguration.peers {
             let publicKey: String
             do {
@@ -77,10 +83,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
             wgSettings.append("replace_peers=true\n")
         }
 
-        let resolutionMap = await resolvePeers(logHandler: logHandler)
-        guard !resolutionMap.isEmpty else {
-            throw PartoutError(.dnsFailure)
-        }
+        let resolutionMap = try await resolvePeers(logHandler: logHandler)
 
         for peer in tunnelConfiguration.peers {
             let publicKey = try peer.publicKey.rawValue.hexStringFromBase64()
@@ -89,21 +92,20 @@ final class TunnelRemoteInfoGenerator: Sendable {
                 let preSharedKey = try preSharedKeyBase64.hexStringFromBase64()
                 wgSettings.append("preshared_key=\(preSharedKey)\n")
             }
-            guard let endpoint = peer.endpoint,
-                  let resolvedEndpoint = resolutionMap[endpoint] else {
-                continue
+            if let endpoint = peer.endpoint,
+               let resolvedEndpoint = resolutionMap[endpoint] {
+                let reresolvedEndpoint: Endpoint
+                do {
+                    reresolvedEndpoint = try resolvedEndpoint.withReresolvedIP()
+                } catch {
+                    pp_log(ctx, .wireguard, .error, "Unable to re-resolve endpoint: \(error)")
+                    reresolvedEndpoint = resolvedEndpoint
+                }
+                if case .hostname = reresolvedEndpoint.address {
+                    assertionFailure("Endpoint is not resolved")
+                }
+                wgSettings.append("endpoint=\(reresolvedEndpoint.wgRepresentation)\n")
             }
-            let reresolvedEndpoint: Endpoint
-            do {
-                reresolvedEndpoint = try resolvedEndpoint.withReresolvedIP()
-            } catch {
-                pp_log(ctx, .wireguard, .error, "Unable to re-resolve endpoint: \(error)")
-                reresolvedEndpoint = resolvedEndpoint
-            }
-            if case .hostname = reresolvedEndpoint.address {
-                assertionFailure("Endpoint is not resolved")
-            }
-            wgSettings.append("endpoint=\(reresolvedEndpoint.wgRepresentation)\n")
             let persistentKeepAlive = peer.keepAlive ?? 0
             wgSettings.append("persistent_keepalive_interval=\(persistentKeepAlive)\n")
             if !peer.allowedIPs.isEmpty {
@@ -175,11 +177,11 @@ final class TunnelRemoteInfoGenerator: Sendable {
 }
 
 private extension TunnelRemoteInfoGenerator {
-    func resolvePeers(logHandler: @escaping WireGuardAdapter.LogHandler) async -> [Endpoint: Endpoint] {
+    func resolvePeers(logHandler: @escaping WireGuardAdapter.LogHandler) async throws -> [Endpoint: Endpoint] {
         if let resolutionMap = await resolvedEndpoints.value {
             return resolutionMap
         }
-        let resolutionMap = await tunnelConfiguration.resolvePeers(
+        let resolutionMap = try await tunnelConfiguration.resolvePeers(
             timeout: dnsTimeout,
             logHandler: logHandler
         )

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -26,6 +26,10 @@ final class TunnelRemoteInfoGenerator: Sendable {
         resolvedEndpoints = ResolvedEndpointsCache()
     }
 
+    func resetResolvedEndpoints() async {
+        await resolvedEndpoints.reset()
+    }
+
     // Only updates peer endpoints
     func endpointUapiConfiguration(logHandler: @escaping WireGuardAdapter.LogHandler) async -> String {
         var wgSettings = ""
@@ -253,6 +257,10 @@ private actor ResolvedEndpointsCache {
 
     func setValue(_ resolutionMap: [Endpoint: Endpoint]) {
         self.resolutionMap = resolutionMap
+    }
+
+    func reset() {
+        resolutionMap = nil
     }
 }
 

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -106,6 +106,8 @@ actor WireGuardAdapter {
         // can happen after deallocation.
         backend.setLogger(context: nil, logger_fn: nil)
 
+        reachabilityTask?.cancel()
+
         // Shutdown the tunnel
         if case .started(let handle, _) = state {
             backend.turnOff(handle)
@@ -183,11 +185,11 @@ actor WireGuardAdapter {
     // MARK: - Private methods
 
     private func setupReachabilityTask() {
+        let reachability = reachability
         reachabilityTask = Task { [weak self] in
-            guard let self else { return }
             for await isReachable in reachability.isReachableStream {
                 guard !Task.isCancelled else { return }
-                await didUpdateReachable(isReachable: isReachable)
+                await self?.didUpdateReachable(isReachable: isReachable)
             }
         }
     }

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -144,9 +144,17 @@ actor WireGuardAdapter {
             ))
             let handle = try startWireGuardBackend(wgConfig: wgConfig)
             state = .started(handle, settingsGenerator)
-        } catch let error as WireGuardAdapterError {
-            throw error
         } catch {
+            reachabilityTask?.cancel()
+            reachabilityTask = nil
+            if case .started(let handle, _) = state {
+                backend.turnOff(handle)
+            }
+            state = .stopped
+            if let tunnel {
+                await delegate?.adapterShouldClearNetworkSettings(self, tunnel: tunnel)
+                self.tunnel = nil
+            }
             pp_log(ctx, .wireguard, .fault, "Unable to start: \(error)")
             throw error
         }

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -288,6 +288,7 @@ actor WireGuardAdapter {
             guard isReachable else { return }
             logHandler(.verbose, "Connectivity online, resuming backend.")
             do {
+                await settingsGenerator.resetResolvedEndpoints()
                 let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
                 try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
                     moduleId: moduleId,

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapterError.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapterError.swift
@@ -2,10 +2,16 @@
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
 internal import _PartoutWireGuard_C
+#if !USE_CMAKE
+import PartoutCore
+#endif
 
 enum WireGuardAdapterError: Error, Sendable {
     /// Failure to locate tunnel file descriptor.
     case cannotLocateTunnelFileDescriptor
+
+    /// Failure to resolve peer endpoints.
+    case dnsResolution([Endpoint])
 
     /// Failure to perform an operation in such state.
     case invalidState

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -171,6 +171,11 @@ private extension _WireGuardConnectionV2 {
         case .cannotLocateTunnelFileDescriptor:
             pp_log(ctx, .wireguard, .error, "Starting tunnel failed: could not determine file descriptor")
             return WireGuardConnectionError.couldNotDetermineFileDescriptor
+        case .dnsResolution(let endpoints):
+            let hostnamesWithDnsResolutionFailure = endpoints.map(\.address.rawValue)
+                .joined(separator: ", ")
+            pp_log(ctx, .wireguard, .error, "DNS resolution failed for the following hostnames: \(hostnamesWithDnsResolutionFailure)")
+            return WireGuardConnectionError.dnsResolutionFailure
         case .setNetworkSettings(let error):
             pp_log(ctx, .wireguard, .error, "Starting tunnel failed with setTunnelNetworkSettings returning \(error.localizedDescription)")
             return WireGuardConnectionError.couldNotSetNetworkSettings

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -52,7 +52,7 @@ public actor _WireGuardConnectionV2: Connection {
         guard let configuration = module.configuration else {
             throw PartoutError(.incompleteModule)
         }
-        pp_log(ctx, .wireguard, .notice, "WireGuard: Using cross-platform connection")
+        pp_log(ctx, .wireguard, .notice, "WireGuard: Using v2 connection")
 
         tunnelConfiguration = try configuration.withModules(from: parameters.profile)
         dataCountTimerInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -103,24 +103,12 @@ public actor _WireGuardConnectionV2: Connection {
             pp_log(ctx, .wireguard, .info, "Tunnel interface is \(interfaceName)")
             return true
         } catch {
-            if let adapterError = error as? WireGuardAdapterError {
-                switch adapterError {
-                case .cannotLocateTunnelFileDescriptor:
-                    pp_log(ctx, .wireguard, .error, "Starting tunnel failed: could not determine file descriptor")
-                    throw WireGuardConnectionError.couldNotDetermineFileDescriptor
-                case .setNetworkSettings(let error):
-                    pp_log(ctx, .wireguard, .error, "Starting tunnel failed with setTunnelNetworkSettings returning \(error.localizedDescription)")
-                    throw WireGuardConnectionError.couldNotSetNetworkSettings
-                case .startWireGuardBackend(let errorCode):
-                    pp_log(ctx, .wireguard, .error, "Starting tunnel failed with wgTurnOn returning \(errorCode)")
-                    throw WireGuardConnectionError.couldNotStartBackend
-                case .invalidState:
-                    // Must never happen
-                    fatalError()
-                }
-            }
+            let startError = mapStartError(error)
+            dataCountTimer?.cancel()
+            dataCountTimer = nil
+            self.adapter = nil
             statusSubject.send(.disconnected)
-            throw error
+            throw startError
         }
     }
 
@@ -169,6 +157,30 @@ extension _WireGuardConnectionV2: WireGuardAdapterDelegate {
 
     func adapterShouldClearNetworkSettings(_ adapter: WireGuardAdapter, tunnel: IOInterface) async {
         await controller.clearTunnelSettings(tunnel)
+    }
+}
+
+// MARK: - Start errors
+
+private extension _WireGuardConnectionV2 {
+    func mapStartError(_ error: Error) -> Error {
+        guard let adapterError = error as? WireGuardAdapterError else {
+            return error
+        }
+        switch adapterError {
+        case .cannotLocateTunnelFileDescriptor:
+            pp_log(ctx, .wireguard, .error, "Starting tunnel failed: could not determine file descriptor")
+            return WireGuardConnectionError.couldNotDetermineFileDescriptor
+        case .setNetworkSettings(let error):
+            pp_log(ctx, .wireguard, .error, "Starting tunnel failed with setTunnelNetworkSettings returning \(error.localizedDescription)")
+            return WireGuardConnectionError.couldNotSetNetworkSettings
+        case .startWireGuardBackend(let errorCode):
+            pp_log(ctx, .wireguard, .error, "Starting tunnel failed with wgTurnOn returning \(errorCode)")
+            return WireGuardConnectionError.couldNotStartBackend
+        case .invalidState:
+            // Must never happen
+            fatalError()
+        }
     }
 }
 

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -47,6 +47,38 @@ struct TunnelRemoteInfoGeneratorTests {
     }
 
     @Test
+    func givenCachedResolution_whenGeneratingEndpointUpdate_thenDoesNotResolveAgain() async throws {
+        let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
+        let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
+
+        var builder = WireGuard.Configuration.Builder(privateKey: pvtkey)
+        var peer = WireGuard.RemoteInterface.Builder(publicKey: pubkey)
+        peer.endpoint = "127.0.0.1:12345"
+        peer.allowedIPs = ["0.0.0.0/0"]
+        builder.peers = [peer]
+
+        let configuration = try builder.build()
+        let sut = TunnelRemoteInfoGenerator(
+            .global,
+            tunnelConfiguration: configuration,
+            dnsTimeout: 1000
+        )
+        let logs = LogCollector()
+        let logHandler: WireGuardAdapter.LogHandler = { _, message in
+            logs.append(message)
+        }
+
+        _ = try await sut.uapiConfiguration(logHandler: logHandler)
+        let resolutionCountAfterFullConfiguration = logs.resolutionCount
+
+        _ = await sut.endpointUapiConfiguration(logHandler: logHandler)
+        let resolutionCountAfterEndpointUpdate = logs.resolutionCount
+
+        #expect(resolutionCountAfterFullConfiguration > 0)
+        #expect(resolutionCountAfterEndpointUpdate == resolutionCountAfterFullConfiguration)
+    }
+
+    @Test
     func givenInterfaceAddresses_whenGeneratingRemoteInfo_thenMasksInterfaceRoutes() throws {
         let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
         let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
@@ -71,5 +103,25 @@ struct TunnelRemoteInfoGeneratorTests {
         #expect(ipModule.ipv4?.includedRoutes.first?.gateway?.rawValue == "10.0.0.2")
         #expect(ipModule.ipv6?.includedRoutes.first?.destination?.rawValue == "fd00::/64")
         #expect(ipModule.ipv6?.includedRoutes.first?.gateway?.rawValue == "fd00::2")
+    }
+}
+
+private final class LogCollector: @unchecked Sendable {
+    private let lock = NSLock()
+
+    private var messages: [String] = []
+
+    func append(_ message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        messages.append(message)
+    }
+
+    var resolutionCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return messages.filter {
+            $0.hasPrefix("DNS64: mapped ")
+        }.count
     }
 }

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -47,7 +47,7 @@ struct TunnelRemoteInfoGeneratorTests {
     }
 
     @Test
-    func givenCachedResolution_whenGeneratingEndpointUpdate_thenDoesNotResolveAgain() async throws {
+    func givenCachedResolution_whenGeneratingEndpointUpdate_thenDoesNotResolveAgainUntilReset() async throws {
         let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
         let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
 
@@ -76,6 +76,12 @@ struct TunnelRemoteInfoGeneratorTests {
 
         #expect(resolutionCountAfterFullConfiguration > 0)
         #expect(resolutionCountAfterEndpointUpdate == resolutionCountAfterFullConfiguration)
+
+        await sut.resetResolvedEndpoints()
+        _ = try await sut.uapiConfiguration(logHandler: logHandler)
+        let resolutionCountAfterReset = logs.resolutionCount
+
+        #expect(resolutionCountAfterReset > resolutionCountAfterEndpointUpdate)
     }
 
     @Test

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -85,6 +85,32 @@ struct TunnelRemoteInfoGeneratorTests {
     }
 
     @Test
+    func givenPeerWithoutEndpoint_whenGeneratingUAPIConfiguration_thenKeepsPeerSettings() async throws {
+        let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
+        let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
+
+        var builder = WireGuard.Configuration.Builder(privateKey: pvtkey)
+        var peer = WireGuard.RemoteInterface.Builder(publicKey: pubkey)
+        peer.allowedIPs = ["10.0.0.0/24"]
+        peer.keepAlive = 25
+        builder.peers = [peer]
+
+        let configuration = try builder.build()
+        let sut = TunnelRemoteInfoGenerator(
+            .global,
+            tunnelConfiguration: configuration,
+            dnsTimeout: 1
+        )
+
+        let uapiConfiguration = try await sut.uapiConfiguration(logHandler: { _, _ in })
+
+        #expect(!uapiConfiguration.contains("endpoint="))
+        #expect(uapiConfiguration.contains("persistent_keepalive_interval=25"))
+        #expect(uapiConfiguration.contains("replace_allowed_ips=true"))
+        #expect(uapiConfiguration.contains("allowed_ip=10.0.0.0/24"))
+    }
+
+    @Test
     func givenInterfaceAddresses_whenGeneratingRemoteInfo_thenMasksInterfaceRoutes() throws {
         let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
         let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="


### PR DESCRIPTION
DNS resolution was performed on each path change, including while the WireGuard backend was live. If a hostname produced multiple IPs, and in a non-deterministic order, the path update might move the live peer to a different IP than the one the backend is connected to.

Therefore, only perform DNS resolution at safe boundaries: on start, on temporary shutdown.

Other than that:

- Fail atomically on any DNS failure
- Fix connection stuck on `.connecting` if it fails to start
- Fix a leak on reachability task

Fixes #330 
Should improve https://github.com/orgs/partout-io/discussions/1399