### PR TITLE
Fix CMake build issues with connection aliases

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -91,8 +91,9 @@ if(USE_COMPAT)
     set(EXCLUDED_PATTERNS
         partout-codegen.*
         PartoutCodegen.*
+        PartoutOpenVPNConnection\/V1
         PartoutOS\/Apple.*
-        PartoutWireGuardConnection\/Legacy.*
+        PartoutWireGuardConnection\/V1
     )
 endif()
 

--- a/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
@@ -11,7 +11,7 @@ final class Negotiator {
 
         let withLocalOptions: Bool
 
-        let sessionOptions: _OpenVPNConnectionV1.Options
+        let sessionOptions: OpenVPNConnection.Options
 
         let onConnected: (UInt8, DataChannel, PushReply) async -> Void
 

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
@@ -27,7 +27,7 @@ final class OpenVPNSession {
 
     let cachesURL: URL
 
-    let options: _OpenVPNConnectionV1.Options
+    let options: OpenVPNConnection.Options
 
     private let tlsFactory: TLSFactory
 
@@ -100,7 +100,7 @@ final class OpenVPNSession {
         credentials: OpenVPN.Credentials?,
         prng: PRNGProtocol,
         cachesURL: URL,
-        options: _OpenVPNConnectionV1.Options = .init(),
+        options: OpenVPNConnection.Options = .init(),
         tlsFactory: @escaping TLSFactory,
         dpFactory: @escaping DataPathFactory
     ) throws {

--- a/Sources/PartoutOpenVPNConnection/OpenVPNConnection+Alias.swift
+++ b/Sources/PartoutOpenVPNConnection/OpenVPNConnection+Alias.swift
@@ -2,4 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+#if !USE_CMAKE
 public typealias OpenVPNConnection = _OpenVPNConnectionV1
+#else
+public typealias OpenVPNConnection = _OpenVPNConnectionV2
+#endif

--- a/Sources/PartoutOpenVPNConnection/OpenVPNConnection+Options.swift
+++ b/Sources/PartoutOpenVPNConnection/OpenVPNConnection+Options.swift
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-extension _OpenVPNConnectionV1 {
+extension OpenVPNConnection {
     /// Intervals are expressed in seconds.
     public struct Options: Sendable {
         public var maxPackets: Int = 100

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
@@ -8,7 +8,7 @@ extension _OpenVPNConnectionV2 {
         parameters: ConnectionParameters,
         module: OpenVPNModule,
         cachesURL: URL,
-        options baseOptions: _OpenVPNConnectionV1.Options = .init()
+        options baseOptions: OpenVPNConnection.Options = .init()
     ) throws {
         guard let configuration = module.configuration else {
             fatalError("Creating session without OpenVPN configuration?")

--- a/Sources/PartoutWireGuardConnection/WireGuardConnection+Alias.swift
+++ b/Sources/PartoutWireGuardConnection/WireGuardConnection+Alias.swift
@@ -8,7 +8,11 @@
 //  SPDX-License-Identifier: MIT
 //  Copyright © 2018-2024 WireGuard LLC. All Rights Reserved.
 
+#if !USE_CMAKE
 public typealias WireGuardConnection = _WireGuardConnectionV1
+#else
+public typealias WireGuardConnection = _WireGuardConnectionV2
+#endif
 
 enum WireGuardConnectionError: Error {
     case dnsResolutionFailure


### PR DESCRIPTION
Default to V2 in CMake, because:

- OpenVPN V2 is a refactoring of V1, which we want to leave behind.
- WireGuard V1 is not cross-platform. It doesn't build on non-Apple.

Broken after #365