### PR TITLE
NE: Fix condition on manager ranking

### DIFF
--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -441,7 +441,7 @@ private extension NETunnelProviderManager {
     var rank: Int {
 #if os(iOS) || os(tvOS)
         // only one profile at a time is enabled on iOS/tvOS
-        if isEnabled {
+        if isEnabled && isOnDemandEnabled {
             return .max
         }
 #endif

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -377,7 +377,10 @@ private extension NETunnelStrategy {
                     let filtered = $0.filter {
                         $0.value.rank == maxRank
                     }
-                    assert(filtered.count <= 1, "Max ranked manager must be at most one")
+                    // There might be a moment where 2 managers may be enabled at the same
+                    // time, e.g., while switching from one to another one. We should
+                    // tolerate this scenario.
+                    assert(filtered.count <= 2, "Max ranked manager must be at most two")
                     return filtered.compactMapValues(\.asSnapshot)
                 }
         }

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -441,8 +441,8 @@ private extension NETunnelProviderManager {
     var rank: Int {
 #if os(iOS) || os(tvOS)
         // only one profile at a time is enabled on iOS/tvOS
-        if isEnabled && isOnDemandEnabled {
-            return .max
+        if isEnabled {
+            return isOnDemandEnabled ? .max : .max - 1
         }
 #endif
         if ![.disconnected, .invalid].contains(connection.status) {


### PR DESCRIPTION
Arguably a regression after #364.

TunnelSnapshot now has a new `isEnabled` field for the comparison, so the `filtered` map in `NETunnelStrategy.activeProfilesStream` might contain >1 profiles that differ on the `isEnabled` field. Add `onDemandEnabled` as the discriminator, because there seems to be a moment where >1 NETunnelProviderManager can be enabled.