### PR TITLE
NE: Fix profile enabled condition

### DIFF
--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -527,10 +527,12 @@ private extension NETunnelProviderManager {
         guard let profileId else {
             return nil
         }
+        let status = connection.status.asTunnelStatus
+        let isEnabled = isEnabled && (isOnDemandEnabled || status != .inactive)
         return TunnelSnapshot(
             id: profileId,
             isEnabled: isEnabled,
-            status: connection.status.asTunnelStatus,
+            status: status,
             onDemand: isEnabled && isOnDemandEnabled
         )
     }


### PR DESCRIPTION
The meaning of NETunnelProviderManager.isEnabled is flaky. A tunnel should actually appear enabled in a user interface under these conditions:

- If the manager is on-demand (`isOnDemandEnabled`), then being enabled is sufficient for the tunnel to appear enabled
- If the manager is not on-demand, then it must be enabled, and its NEVPNStatus must not be `.inactive`, i.e., the app extension must be alive

Regression from #364 