### PR TITLE
Fix retain cycles in for await loops

### DIFF
--- a/Sources/PartoutCore/Connection/CyclingConnection.swift
+++ b/Sources/PartoutCore/Connection/CyclingConnection.swift
@@ -221,10 +221,8 @@ private extension CyclingConnection {
     func observeBetterPath(on link: LinkInterface) {
         pathSubscription?.cancel()
         pathSubscription = Task { [weak self] in
-            guard let self else {
-                return
-            }
             for await _ in link.hasBetterPath {
+                guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled CyclingConnection.pathSubscription")
                     return

--- a/Sources/PartoutCore/Connection/NetworkObserver.swift
+++ b/Sources/PartoutCore/Connection/NetworkObserver.swift
@@ -50,7 +50,8 @@ public final class NetworkObserver: @unchecked Sendable {
 
     public func startObserving() {
         let signalSubscription = Task { [weak self] in
-            for await signal in signalSubject.subscribe() {
+            guard let stream = self?.signalSubject.subscribe() else { return }
+            for await signal in stream {
                 guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled NetworkObserver.signalSubject")
@@ -64,7 +65,8 @@ public final class NetworkObserver: @unchecked Sendable {
             pp_log(ctx, .core, .debug, "NetworkObserver.signalSubject terminated")
         }
         let reachabilitySubscription = Task { [weak self] in
-            for await isNetworkAvailable in reachabilityStream {
+            guard let stream = self?.reachabilityStream else { return }
+            for await isNetworkAvailable in stream {
                 guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled NetworkObserver.reachabilityStream")
@@ -78,7 +80,8 @@ public final class NetworkObserver: @unchecked Sendable {
             pp_log(ctx, .core, .debug, "NetworkObserver.reachabilityStream terminated")
         }
         let statusSubscription = Task { [weak self] in
-            for await connectionStatus in statusStream {
+            guard let stream = self?.statusStream else { return }
+            for await connectionStatus in stream {
                 guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled NetworkObserver.statusStream")

--- a/Sources/PartoutCore/Connection/NetworkObserver.swift
+++ b/Sources/PartoutCore/Connection/NetworkObserver.swift
@@ -50,8 +50,8 @@ public final class NetworkObserver: @unchecked Sendable {
 
     public func startObserving() {
         let signalSubscription = Task { [weak self] in
-            guard let self else { return }
             for await signal in signalSubject.subscribe() {
+                guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled NetworkObserver.signalSubject")
                     break
@@ -64,8 +64,8 @@ public final class NetworkObserver: @unchecked Sendable {
             pp_log(ctx, .core, .debug, "NetworkObserver.signalSubject terminated")
         }
         let reachabilitySubscription = Task { [weak self] in
-            guard let self else { return }
             for await isNetworkAvailable in reachabilityStream {
+                guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled NetworkObserver.reachabilityStream")
                     break
@@ -78,8 +78,8 @@ public final class NetworkObserver: @unchecked Sendable {
             pp_log(ctx, .core, .debug, "NetworkObserver.reachabilityStream terminated")
         }
         let statusSubscription = Task { [weak self] in
-            guard let self else { return }
             for await connectionStatus in statusStream {
+                guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled NetworkObserver.statusStream")
                     break

--- a/Sources/PartoutCore/Connection/NetworkObserver.swift
+++ b/Sources/PartoutCore/Connection/NetworkObserver.swift
@@ -62,7 +62,7 @@ public final class NetworkObserver: @unchecked Sendable {
                 }
                 tryReady(newState)
             }
-            pp_log(ctx, .core, .debug, "NetworkObserver.signalSubject terminated")
+            pp_log(self?.ctx ?? .global, .core, .debug, "NetworkObserver.signalSubject terminated")
         }
         let reachabilitySubscription = Task { [weak self] in
             guard let stream = self?.reachabilityStream else { return }
@@ -77,7 +77,7 @@ public final class NetworkObserver: @unchecked Sendable {
                 }
                 tryReady(newState)
             }
-            pp_log(ctx, .core, .debug, "NetworkObserver.reachabilityStream terminated")
+            pp_log(self?.ctx ?? .global, .core, .debug, "NetworkObserver.reachabilityStream terminated")
         }
         let statusSubscription = Task { [weak self] in
             guard let stream = self?.statusStream else { return }
@@ -92,7 +92,7 @@ public final class NetworkObserver: @unchecked Sendable {
                 }
                 tryReady(newState)
             }
-            pp_log(ctx, .core, .debug, "NetworkObserver.statusStream terminated")
+            pp_log(self?.ctx ?? .global, .core, .debug, "NetworkObserver.statusStream terminated")
         }
         subscriptions = [signalSubscription, reachabilitySubscription, statusSubscription]
     }

--- a/Sources/PartoutCore/Connection/NetworkObserver.swift
+++ b/Sources/PartoutCore/Connection/NetworkObserver.swift
@@ -50,6 +50,7 @@ public final class NetworkObserver: @unchecked Sendable {
 
     public func startObserving() {
         let signalSubscription = Task { [weak self] in
+            guard let ctx = self?.ctx else { return }
             guard let stream = self?.signalSubject.subscribe() else { return }
             for await signal in stream {
                 guard let self else { return }
@@ -62,9 +63,10 @@ public final class NetworkObserver: @unchecked Sendable {
                 }
                 tryReady(newState)
             }
-            pp_log(self?.ctx ?? .global, .core, .debug, "NetworkObserver.signalSubject terminated")
+            pp_log(ctx, .core, .debug, "NetworkObserver.signalSubject terminated")
         }
         let reachabilitySubscription = Task { [weak self] in
+            guard let ctx = self?.ctx else { return }
             guard let stream = self?.reachabilityStream else { return }
             for await isNetworkAvailable in stream {
                 guard let self else { return }
@@ -77,9 +79,10 @@ public final class NetworkObserver: @unchecked Sendable {
                 }
                 tryReady(newState)
             }
-            pp_log(self?.ctx ?? .global, .core, .debug, "NetworkObserver.reachabilityStream terminated")
+            pp_log(ctx, .core, .debug, "NetworkObserver.reachabilityStream terminated")
         }
         let statusSubscription = Task { [weak self] in
+            guard let ctx = self?.ctx else { return }
             guard let stream = self?.statusStream else { return }
             for await connectionStatus in stream {
                 guard let self else { return }
@@ -92,7 +95,7 @@ public final class NetworkObserver: @unchecked Sendable {
                 }
                 tryReady(newState)
             }
-            pp_log(self?.ctx ?? .global, .core, .debug, "NetworkObserver.statusStream terminated")
+            pp_log(ctx, .core, .debug, "NetworkObserver.statusStream terminated")
         }
         subscriptions = [signalSubscription, reachabilitySubscription, statusSubscription]
     }

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -252,9 +252,9 @@ extension SimpleConnectionDaemon {
         // Observe the connection status (except the initial .disconnected)
         statusSubscription?.cancel()
         statusSubscription = Task { [weak self] in
-            guard let self else { return }
             do {
                 for try await status in connectionStatusStream {
+                    guard let self else { return }
                     guard !Task.isCancelled else {
                         pp_log_id(profile.id, .core, .debug, "Cancelled SimpleConnectionDaemon.statusStream")
                         return
@@ -269,9 +269,9 @@ extension SimpleConnectionDaemon {
         // Observe the network for starting the connection
         networkSubscription?.cancel()
         networkSubscription = Task { [weak self] in
-            guard let self else { return }
             pp_log_id(profile.id, .core, .debug, "Network subscription started")
             for await isReady in onNetworkReadyStream {
+                guard let self else { return }
                 guard isReady else { continue }
                 guard !Task.isCancelled else {
                     pp_log_id(profile.id, .core, .debug, "Cancelled NetworkObserver.onReady")

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -255,12 +255,11 @@ extension SimpleConnectionDaemon {
             guard let profileId = self?.profile.id else { return }
             do {
                 for try await status in connectionStatusStream {
-                    guard let self else { return }
                     guard !Task.isCancelled else {
                         pp_log_id(profileId, .core, .debug, "Cancelled SimpleConnectionDaemon.statusStream")
                         return
                     }
-                    await onConnectionStatus(status)
+                    await self?.onConnectionStatus(status)
                 }
             } catch {
                 await self?.onConnectionError(error)

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -252,35 +252,38 @@ extension SimpleConnectionDaemon {
         // Observe the connection status (except the initial .disconnected)
         statusSubscription?.cancel()
         statusSubscription = Task { [weak self] in
+            guard let profileId = self?.profile.id else { return }
             do {
                 for try await status in connectionStatusStream {
                     guard let self else { return }
                     guard !Task.isCancelled else {
-                        pp_log_id(profile.id, .core, .debug, "Cancelled SimpleConnectionDaemon.statusStream")
+                        pp_log_id(profileId, .core, .debug, "Cancelled SimpleConnectionDaemon.statusStream")
                         return
                     }
                     await onConnectionStatus(status)
                 }
             } catch {
-                await onConnectionError(error)
+                await self?.onConnectionError(error)
             }
+            pp_log_id(profileId, .core, .debug, "Status subscription terminated")
         }
 
         // Observe the network for starting the connection
         networkSubscription?.cancel()
         networkSubscription = Task { [weak self] in
-            pp_log_id(profile.id, .core, .debug, "Network subscription started")
+            guard let profileId = self?.profile.id else { return }
+            pp_log_id(profileId, .core, .debug, "Network subscription started")
             for await isReady in onNetworkReadyStream {
                 guard let self else { return }
                 guard isReady else { continue }
                 guard !Task.isCancelled else {
-                    pp_log_id(profile.id, .core, .debug, "Cancelled NetworkObserver.onReady")
+                    pp_log_id(profileId, .core, .debug, "Cancelled NetworkObserver.onReady")
                     break
                 }
-                pp_log_id(profile.id, .core, .notice, "Network is ready, start connection")
+                pp_log_id(profileId, .core, .notice, "Network is ready, start connection")
                 await evaluateConnection()
             }
-            pp_log_id(profile.id, .core, .debug, "Network subscription terminated")
+            pp_log_id(profileId, .core, .debug, "Network subscription terminated")
         }
 
         // Start monitoring

--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -146,7 +146,8 @@ private extension Tunnel {
     func observeObjects() {
         strategySubscription?.cancel()
         strategySubscription = Task { [weak self] in
-            for await snapshots in strategy.didUpdateActiveProfiles {
+            guard let stream = self?.strategy.didUpdateActiveProfiles else { return }
+            for await snapshots in stream {
                 guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled Tunnel.strategy.didUpdateActiveProfiles (observed)")

--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -146,8 +146,8 @@ private extension Tunnel {
     func observeObjects() {
         strategySubscription?.cancel()
         strategySubscription = Task { [weak self] in
-            guard let self else { return }
             for await snapshots in strategy.didUpdateActiveProfiles {
+                guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled Tunnel.strategy.didUpdateActiveProfiles (observed)")
                     return

--- a/Sources/PartoutOS/Apple/TunnelObservable.swift
+++ b/Sources/PartoutOS/Apple/TunnelObservable.swift
@@ -15,13 +15,12 @@ public final class TunnelObservable {
     public init(tunnel: Tunnel) {
         self.tunnel = tunnel
         snapshots = [:]
-        Task { [weak self] in
+        Task { [weak self, weak tunnel] in
             do {
-                let stream = tunnel.snapshotsStream
-                try await tunnel.prepare(purge: false)
+                guard let stream = tunnel?.snapshotsStream else { return }
+                try await tunnel?.prepare(purge: false)
                 for await newSnapshots in stream {
-                    guard let self else { return }
-                    snapshots = newSnapshots
+                    self?.snapshots = newSnapshots
                 }
             } catch {
                 pp_log_g(.core, .fault, "Unable to prepare tunnel: \(error)")

--- a/Sources/PartoutOS/Apple/TunnelObservable.swift
+++ b/Sources/PartoutOS/Apple/TunnelObservable.swift
@@ -20,6 +20,7 @@ public final class TunnelObservable {
                 let stream = tunnel.snapshotsStream
                 try await tunnel.prepare(purge: false)
                 for await newSnapshots in stream {
+                    guard let self else { return }
                     snapshots = newSnapshots
                 }
             } catch {

--- a/Sources/PartoutOS/Apple/TunnelObservable.swift
+++ b/Sources/PartoutOS/Apple/TunnelObservable.swift
@@ -16,7 +16,6 @@ public final class TunnelObservable {
         self.tunnel = tunnel
         snapshots = [:]
         Task { [weak self] in
-            guard let self else { return }
             do {
                 let stream = tunnel.snapshotsStream
                 try await tunnel.prepare(purge: false)

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -126,11 +126,11 @@ extension NETunnelStrategy: TunnelObservableStrategy {
     public nonisolated var didUpdateActiveProfiles: AsyncStream<[Profile.ID: TunnelSnapshot]> {
         AsyncStream { [weak self] continuation in
             Task { [weak self] in
-                guard let activeProfilesStream = self?.activeProfilesStream else {
+                guard let stream = self?.activeProfilesStream.dropFirst() else {
                     continuation.finish()
                     return
                 }
-                for await activeProfiles in activeProfilesStream.dropFirst() {
+                for await activeProfiles in stream {
                     guard let self else {
                         continuation.finish()
                         return

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -234,11 +234,11 @@ extension NETunnelStrategy: NETunnelManagerRepository {
     public nonisolated var managersStream: AsyncStream<[Profile.ID: NETunnelProviderManager]> {
         AsyncStream { [weak self] continuation in
             Task { [weak self] in
-                guard let managersSubject = self?.managersSubject else {
+                guard let stream = self?.managersSubject.subscribe().dropFirst() else {
                     continuation.finish()
                     return
                 }
-                for await value in managersSubject.subscribe().dropFirst() {
+                for await value in stream {
                     guard let self else {
                         continuation.finish()
                         return

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -126,16 +126,20 @@ extension NETunnelStrategy: TunnelObservableStrategy {
     public nonisolated var didUpdateActiveProfiles: AsyncStream<[Profile.ID: TunnelSnapshot]> {
         AsyncStream { [weak self] continuation in
             Task { [weak self] in
-                guard let self else {
+                guard let activeProfilesStream = self?.activeProfilesStream else {
                     continuation.finish()
                     return
                 }
-                for await activeProfiles in self.activeProfilesStream.dropFirst() {
+                for await activeProfiles in activeProfilesStream.dropFirst() {
+                    guard let self else {
+                        continuation.finish()
+                        return
+                    }
                     guard !Task.isCancelled else {
-                        pp_log(self.ctx, .os, .debug, "Cancelled NETunnelStrategy.didUpdateActiveProfiles")
+                        pp_log(ctx, .os, .debug, "Cancelled NETunnelStrategy.didUpdateActiveProfiles")
                         break
                     }
-                    pp_log(self.ctx, .os, .debug, "NETunnelStrategy.activeProfiles -> \(activeProfiles.values.description)")
+                    pp_log(ctx, .os, .debug, "NETunnelStrategy.activeProfiles -> \(activeProfiles.values.description)")
                     continuation.yield(activeProfiles)
                 }
                 continuation.finish()
@@ -230,11 +234,15 @@ extension NETunnelStrategy: NETunnelManagerRepository {
     public nonisolated var managersStream: AsyncStream<[Profile.ID: NETunnelProviderManager]> {
         AsyncStream { [weak self] continuation in
             Task { [weak self] in
-                guard let self else {
+                guard let managersSubject = self?.managersSubject else {
                     continuation.finish()
                     return
                 }
-                for await value in self.managersSubject.subscribe().dropFirst() {
+                for await value in managersSubject.subscribe().dropFirst() {
+                    guard let self else {
+                        continuation.finish()
+                        return
+                    }
                     guard !Task.isCancelled else {
                         pp_log(self.ctx, .os, .debug, "Cancelled NETunnelStrategy.managersStream")
                         break

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
@@ -52,14 +52,17 @@ extension NEObservablePath {
     public var isReachableStream: AsyncStream<Bool> {
         AsyncStream { [weak self] continuation in
             let relayTask = Task { [weak self] in
-                guard let self else {
+                guard let pathStream = self?.stream else {
                     continuation.finish()
                     return
                 }
-                let pathStream = self.stream
                 for await path in pathStream {
+                    guard let self else {
+                        continuation.finish()
+                        return
+                    }
                     guard !Task.isCancelled else {
-                        pp_log(self.ctx, .os, .debug, "Cancelled NEObservablePath.isReachableStream")
+                        pp_log(ctx, .os, .debug, "Cancelled NEObservablePath.isReachableStream")
                         break
                     }
                     let reachable = path.isSatisfiable

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -399,8 +399,9 @@ private extension _OpenVPNConnectionV2 {
     func observeBetterPath(on link: LinkInterface) {
         pathSubscription?.cancel()
         pathSubscription = Task { [weak self, weak link] in
-            guard let self, let link else { return }
+            guard let link else { return }
             for await _ in link.hasBetterPath {
+                guard let self else { return }
                 guard !Task.isCancelled else {
                     pp_log(ctx, .core, .debug, "Cancelled CyclingConnection.pathSubscription")
                     return


### PR DESCRIPTION
Retaining self before a `for await` loop may lead to a retain cycle despite the `weak` notation. Retain self inside the loop instead, because the loop has a predictable execution time. This is not the case for the `for await`, which is potentially infinite (hence the retain cycle).