### PR TITLE
Optimize CMake toolchain for Swift

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -108,7 +108,6 @@ add_dependencies(partout partout_c)
 target_sources(partout PRIVATE ${PARTOUT_SOURCES})
 target_link_libraries(partout PRIVATE partout_c)
 target_compile_options(partout PRIVATE
-    -emit-module-interface
     -language-mode 5
 )
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -59,7 +59,7 @@ endforeach()
 
 # Add computed files
 target_sources(partout_c PRIVATE ${PARTOUT_C_SOURCES})
-target_include_directories(partout_c PRIVATE ${PARTOUT_C_INCLUDE_DIRS})
+target_include_directories(partout_c PUBLIC ${PARTOUT_C_INCLUDE_DIRS})
 if(LINUX OR ANDROID)
     target_compile_options(partout_c PRIVATE -fPIC)
 endif()
@@ -100,7 +100,7 @@ endforeach()
 
 # Look for modulemaps in C "include" dirs
 foreach(dir ${PARTOUT_C_INCLUDE_DIRS})
-    target_include_directories(partout PRIVATE ${dir})
+    target_include_directories(partout PUBLIC ${dir})
 endforeach()
 
 # Depend on C target (include before)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -70,10 +70,7 @@ endif()
 add_library(partout STATIC "")
 
 # Define symbols to skip Swift imports and legacy code
-target_compile_options(partout PRIVATE
-    -DUSE_CMAKE
-    -enable-library-evolution
-)
+target_compile_options(partout PRIVATE -DUSE_CMAKE)
 
 # Use Foundation on Apple, compatible otherwise
 if(NOT APPLE)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@ build_dir=.cmake
 bin_dir=bin
 
 #export ANDROID_NDK_ROOT=
-export SWIFT_ANDROID_SDK=~/.swiftpm/swift-sdks/swift-6.2-RELEASE-android-0.1.artifactbundle
+export SWIFT_ANDROID_SDK=~/.swiftpm/swift-sdks/swift-6.3.1-RELEASE_android.artifactbundle
 export ANDROID_NDK_API=28
 export ANDROID_NDK_ARCH=aarch64
 ANDROID_NDK_TARGET=darwin-x86_64

--- a/toolchains/android.toolchain.cmake
+++ b/toolchains/android.toolchain.cmake
@@ -8,7 +8,7 @@ set(CMAKE_CXX_COMPILER_TARGET $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{A
 set(CMAKE_Swift_COMPILER ${CMAKE_CURRENT_LIST_DIR}/swiftc-wrapper.sh)
 set(CMAKE_Swift_COMPILER_TARGET $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{ANDROID_NDK_API})
 set(CMAKE_C_FLAGS "-fPIC")
-set(CMAKE_Swift_FLAGS "-target $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{ANDROID_NDK_API} -tools-directory $ENV{ANDROID_NDK_TOOLCHAIN} -sdk $ENV{ANDROID_NDK_SYSROOT} -resource-dir $ENV{SWIFT_RESOURCE_DIR} -enable-library-evolution -disallow-use-new-driver -lc++_shared -llog -lm -lFoundationEssentials -l_FoundationCollections -l_FoundationCShims -lswiftSynchronization")
+set(CMAKE_Swift_FLAGS "-target $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{ANDROID_NDK_API} -tools-directory $ENV{ANDROID_NDK_TOOLCHAIN} -sdk $ENV{ANDROID_NDK_SYSROOT} -resource-dir $ENV{SWIFT_RESOURCE_DIR} -disallow-use-new-driver -lc++_shared -llog -lm -lFoundationEssentials -l_FoundationCollections -l_FoundationCShims -lswiftSynchronization")
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/toolchains/android.toolchain.cmake
+++ b/toolchains/android.toolchain.cmake
@@ -8,7 +8,7 @@ set(CMAKE_CXX_COMPILER_TARGET $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{A
 set(CMAKE_Swift_COMPILER ${CMAKE_CURRENT_LIST_DIR}/swiftc-wrapper.sh)
 set(CMAKE_Swift_COMPILER_TARGET $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{ANDROID_NDK_API})
 set(CMAKE_C_FLAGS "-fPIC")
-set(CMAKE_Swift_FLAGS "-target $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{ANDROID_NDK_API} -tools-directory $ENV{ANDROID_NDK_TOOLCHAIN} -sdk $ENV{ANDROID_NDK_SYSROOT} -resource-dir $ENV{SWIFT_RESOURCE_DIR} -disallow-use-new-driver -lc++_shared -llog -lm -lFoundationEssentials -l_FoundationCollections -l_FoundationCShims -lswiftSynchronization")
+set(CMAKE_Swift_FLAGS "-target $ENV{ANDROID_NDK_ARCH}-unknown-linux-android$ENV{ANDROID_NDK_API} -tools-directory $ENV{ANDROID_NDK_TOOLCHAIN} -sdk $ENV{SWIFT_SDK}/swift-android/ndk-sysroot -resource-dir $ENV{SWIFT_RESOURCE_DIR} -lc++_shared -llog -lm -lFoundationEssentials -l_FoundationCollections -l_FoundationCShims -lswiftSynchronization")
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)


### PR DESCRIPTION
- Disable library evolution
- Do not emit module interfaces
- Export C modulemaps transitively
- Use new driver in Android toolchain by fixing SDK path