### PR TITLE
Use Swift 6 conditionally in CMake

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Foundation is required by ProcessInfo

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Foundation is required by ProcessInfo

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -108,7 +108,7 @@ add_dependencies(partout partout_c)
 target_sources(partout PRIVATE ${PARTOUT_SOURCES})
 target_link_libraries(partout PRIVATE partout_c)
 target_compile_options(partout PRIVATE
-    -language-mode 5
+    -language-mode 6
 )
 
 ################################################

--- a/Sources/Partout/VirtualTunnelController.swift
+++ b/Sources/Partout/VirtualTunnelController.swift
@@ -56,9 +56,6 @@ public final class VirtualTunnelController: TunnelController {
             tunImpl = infoJSON.withCString {
                 pp_tun_ctrl_set_tunnel(impl, $0)
             }
-            guard let tunImpl else {
-                throw PartoutError(.linkNotActive)
-            }
         } else {
             tunImpl = nil
         }

--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -28,9 +28,6 @@ public actor Tunnel {
         self.environmentFactory = environmentFactory
         snapshotsSubject = CurrentValueStream([:])
         environments = [:]
-        Task {
-            await observeObjects()
-        }
     }
 }
 
@@ -38,6 +35,7 @@ public actor Tunnel {
 
 extension Tunnel: TunnelStrategy {
     public func prepare(purge: Bool) async throws {
+        observeObjects()
         pp_log(ctx, .core, .info, "Prepare tunnel (purge: \(purge))...")
         try await strategy.prepare(purge: purge)
     }
@@ -146,6 +144,8 @@ extension Tunnel {
 
 private extension Tunnel {
     func observeObjects() {
+        // Subscribe once
+        guard strategySubscription == nil else { return }
         strategySubscription?.cancel()
         strategySubscription = Task { [weak self] in
             guard let stream = self?.strategy.didUpdateActiveProfiles else { return }

--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -28,6 +28,9 @@ public actor Tunnel {
         self.environmentFactory = environmentFactory
         snapshotsSubject = CurrentValueStream([:])
         environments = [:]
+#if swift(<6.0)
+        observeObjects()
+#endif
     }
 }
 
@@ -35,7 +38,9 @@ public actor Tunnel {
 
 extension Tunnel: TunnelStrategy {
     public func prepare(purge: Bool) async throws {
+#if swift(>=6.0)
         observeObjects()
+#endif
         pp_log(ctx, .core, .info, "Prepare tunnel (purge: \(purge))...")
         try await strategy.prepare(purge: purge)
     }
@@ -144,8 +149,10 @@ extension Tunnel {
 
 private extension Tunnel {
     func observeObjects() {
+#if swift(>=6.0)
         // Subscribe once
         guard strategySubscription == nil else { return }
+#endif
         strategySubscription?.cancel()
         strategySubscription = Task { [weak self] in
             guard let stream = self?.strategy.didUpdateActiveProfiles else { return }

--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -28,7 +28,9 @@ public actor Tunnel {
         self.environmentFactory = environmentFactory
         snapshotsSubject = CurrentValueStream([:])
         environments = [:]
-        observeObjects()
+        Task {
+            await observeObjects()
+        }
     }
 }
 

--- a/Sources/PartoutOpenVPNConnection/Internal/NegotiationHistory.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/NegotiationHistory.swift
@@ -2,6 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-struct NegotiationHistory {
+struct NegotiationHistory: Sendable {
     let pushReply: PushReply
 }

--- a/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
@@ -652,10 +652,15 @@ private extension Negotiator {
     func completeConnection(pushReply: PushReply) throws {
         pp_log(ctx, .openvpn, .info, "Complete connection of key \(key)")
         let history = NegotiationHistory(pushReply: pushReply)
+#if swift(<6.0)
+        let dataChannel = try newDataChannel(with: history)
+#endif
         self.history = history
         authenticator?.reset()
         Task {
+#if swift(>=6.0)
             nonisolated(unsafe) let dataChannel = try newDataChannel(with: history)
+#endif
             await options.onConnected(key, dataChannel, pushReply)
         }
     }

--- a/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
@@ -652,10 +652,10 @@ private extension Negotiator {
     func completeConnection(pushReply: PushReply) throws {
         pp_log(ctx, .openvpn, .info, "Complete connection of key \(key)")
         let history = NegotiationHistory(pushReply: pushReply)
-        let dataChannel = try newDataChannel(with: history)
         self.history = history
         authenticator?.reset()
         Task {
+            nonisolated(unsafe) let dataChannel = try newDataChannel(with: history)
             await options.onConnected(key, dataChannel, pushReply)
         }
     }

--- a/Sources/PartoutOpenVPNConnection/Internal/PushReply.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/PushReply.swift
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-struct PushReply {
+struct PushReply: Sendable {
     private let original: String
 
     let options: OpenVPN.Configuration


### PR DESCRIPTION
Leave Swift 5 level in SwiftPM for access to NE sockets, but enforce Swift 6 in CMake. Be conservative about conditionals.

Mitigates #171