### PR TITLE
Core/Android: Add NativeTunnel and AndroidTunnel

### DIFF
--- a/Sources/Partout/NativeHelpers.swift
+++ b/Sources/Partout/NativeHelpers.swift
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+internal import _PartoutCore_C
+
+final class NativeCompletion {
+    static let callback: pp_completion = { ctx, code in
+        guard let ctx else { return }
+        let box = Unmanaged<NativeCompletion>.fromOpaque(ctx).takeRetainedValue()
+        guard code == 0 else {
+            box.continuation.resume(throwing: NativeError(code: code))
+            return
+        }
+        box.continuation.resume()
+    }
+
+    let continuation: CheckedContinuation<Void, Error>
+
+    init(continuation: CheckedContinuation<Void, Error>) {
+        self.continuation = continuation
+    }
+}
+
+struct NativeError: Error, CustomDebugStringConvertible, Sendable {
+    let code: Int32
+
+    var debugDescription: String {
+        "Native C layer failed with code \(code)"
+    }
+}

--- a/Sources/Partout/NativeTunnel.swift
+++ b/Sources/Partout/NativeTunnel.swift
@@ -30,7 +30,13 @@ public final class NativeTunnel: TunnelProtocol, @unchecked Sendable {
     }
 
     public func uninstall(profileId: Profile.ID) async throws {
-//        fatalError()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let box = NativeCompletion(continuation: continuation)
+            let ctx = Unmanaged.passRetained(box).toOpaque()
+            profileId.uuidString.withCString {
+                pp_tun_strg_uninstall(ref, $0, ctx, NativeCompletion.callback)
+            }
+        }
     }
 
     public func disconnect(from profileId: Profile.ID) async throws {

--- a/Sources/Partout/NativeTunnel.swift
+++ b/Sources/Partout/NativeTunnel.swift
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+internal import _PartoutCore_C
+
+// FIXME: #1656, Forward pp_tun_strg
+public final class NativeTunnel: TunnelProtocol, @unchecked Sendable {
+    nonisolated(unsafe)
+    private let ref: UnsafeMutableRawPointer?
+
+    public init(ref: UnsafeMutableRawPointer?) {
+        self.ref = ref
+    }
+
+    public func prepare(purge: Bool) async throws {
+//        fatalError()
+    }
+
+    public func install(_ profile: Profile, connect: Bool, options: (any Sendable)?, title: @escaping (Profile) -> String) async throws {
+        let profileJSON = try Self.encode(profile)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let box = NativeCompletion(continuation: continuation)
+            let ctx = Unmanaged.passRetained(box).toOpaque()
+            // FIXME: #1656, Ignore options
+            profileJSON.withCString {
+                pp_tun_strg_install(ref, $0, connect, nil, ctx, NativeCompletion.callback)
+            }
+        }
+    }
+
+    public func uninstall(profileId: Profile.ID) async throws {
+//        fatalError()
+    }
+
+    public func disconnect(from profileId: Profile.ID) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let box = NativeCompletion(continuation: continuation)
+            let ctx = Unmanaged.passRetained(box).toOpaque()
+            profileId.uuidString.withCString {
+                pp_tun_strg_disconnect(ref, $0, ctx, NativeCompletion.callback)
+            }
+        }
+    }
+
+    public func sendMessage(_ message: Data, to profileId: Profile.ID) async throws -> Data? {
+//        fatalError()
+        nil
+    }
+
+    public var snapshots: [Profile.ID: TunnelSnapshot] {
+//        fatalError()
+        [:]
+    }
+
+    public var snapshotsStream: AsyncStream<[Profile.ID: TunnelSnapshot]> {
+//        fatalError()
+        AsyncStream { nil }
+    }
+
+    public func allEnvironments() async -> [Profile.ID: TunnelEnvironmentReader] {
+//        fatalError()
+        [:]
+    }
+
+    public func environment(for profileId: Profile.ID) async -> TunnelEnvironmentReader? {
+//        fatalError()
+        nil
+    }
+}
+
+private extension NativeTunnel {
+    static func encode(_ profile: Profile) throws -> String {
+        let data = try JSONEncoder().encode(profile.asTaggedProfile)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw PartoutError(.encoding)
+        }
+        return json
+    }
+}

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -54,7 +54,7 @@ public final class NativeTunnelController: TunnelController {
                 pp_tun_ctrl_set_tunnel(ref, uuid, info)
             }
         }) else {
-            throw PartoutError(.linkNotActive)
+            throw PartoutError(.tunNotAvailable)
         }
 
         // FIXME: #188, add better codes for PartoutError

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -7,28 +7,28 @@
 internal import _PartoutCore_C
 
 /// A controller that operates on a virtual tun interface.
-public final class VirtualTunnelController: TunnelController {
+public final class NativeTunnelController: TunnelController {
     private let ctx: PartoutLoggerContext
 
     nonisolated(unsafe)
-    private let impl: UnsafeMutableRawPointer?
+    private let ref: UnsafeMutableRawPointer?
 
     private let maxReadLength: Int
 
     public init(
         _ ctx: PartoutLoggerContext,
-        impl: UnsafeMutableRawPointer?,
+        ref: UnsafeMutableRawPointer?,
         maxReadLength: Int = 128 * 1024
     ) throws {
         self.ctx = ctx
-        self.impl = impl
+        self.ref = ref
         self.maxReadLength = maxReadLength
 
-        pp_tun_ctrl_test_working(impl)
+        pp_tun_ctrl_test_working(ref)
     }
 
     deinit {
-        pp_log(ctx, .core, .debug, "Deinit VirtualTunnelController")
+        pp_log(ctx, .core, .debug, "Deinit NativeTunnelController")
     }
 
     public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface {
@@ -51,7 +51,7 @@ public final class VirtualTunnelController: TunnelController {
         // Create tun with optional implementation from controller
         guard let tun = info.originalModuleId.uuidString.withCString({ uuid in
             infoJSON.withCString { info in
-                pp_tun_ctrl_set_tunnel(impl, uuid, info)
+                pp_tun_ctrl_set_tunnel(ref, uuid, info)
             }
         }) else {
             throw PartoutError(.linkNotActive)
@@ -89,7 +89,7 @@ public final class VirtualTunnelController: TunnelController {
 
     public func configureSockets(with descriptors: [UInt64]) {
         descriptors.map(Int32.init).withUnsafeBufferPointer {
-            pp_tun_ctrl_configure_sockets(impl, $0.baseAddress, $0.count)
+            pp_tun_ctrl_configure_sockets(ref, $0.baseAddress, $0.count)
         }
     }
 
@@ -103,7 +103,7 @@ public final class VirtualTunnelController: TunnelController {
         await tunnel.shutdown()
 
         // Release tun implementation if necessary
-        pp_tun_ctrl_clear_tunnel(impl, tunnel.tun)
+        pp_tun_ctrl_clear_tunnel(ref, tunnel.tun)
     }
 
     public func setReasserting(_ reasserting: Bool) {

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -76,7 +76,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 
     func readPackets() async throws -> [Data] {
         guard isActive else {
-            throw PartoutError(.linkNotActive)
+            throw PartoutError(.tunNotActive)
         }
         do {
             return try await withCheckedThrowingContinuation { continuation in
@@ -96,7 +96,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
             }
         } catch {
             guard isActive else {
-                throw PartoutError(.linkNotActive)
+                throw PartoutError(.tunNotActive)
             }
             pp_log(ctx, .core, .fault, "Unable to read TUN packets: \(error)")
             await shutdown()
@@ -106,7 +106,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 
     func writePackets(_ packets: [Data]) async throws {
         guard isActive else {
-            throw PartoutError(.linkNotActive)
+            throw PartoutError(.tunNotActive)
         }
         do {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
@@ -130,7 +130,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
             }
         } catch {
             guard isActive else {
-                throw PartoutError(.linkNotActive)
+                throw PartoutError(.tunNotActive)
             }
             pp_log(ctx, .core, .fault, "Unable to write TUN packets: \(error)")
             await shutdown()

--- a/Sources/PartoutCore/Docs.docc/ManagingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/ManagingTunnel.md
@@ -13,6 +13,7 @@ Control the daemon started in <doc:StartingTunnel> and be informed about its cur
 - ``Tunnel``
 - ``TunnelStrategy``
 - ``TunnelObservableStrategy``
+- ``TunnelProtocol``
 - ``TunnelStatus``
 - ``TunnelSnapshot``
 - ``FakeTunnelStrategy``

--- a/Sources/PartoutCore/Partout+Core.swift
+++ b/Sources/PartoutCore/Partout+Core.swift
@@ -93,7 +93,7 @@ extension PartoutError.Code {
     /// No more endpoints available to try.
     public static let exhaustedEndpoints = Self("exhaustedEndpoints")
 
-    /// Link could not be activated.
+    /// Link device is not active.
     public static let linkNotActive = Self("linkNotActive")
 
     /// Link I/O failure.
@@ -104,6 +104,12 @@ extension PartoutError.Code {
 
     /// Network is unreachable.
     public static let networkUnreachable = Self("networkUnreachable")
+
+    /// TUN device is not active.
+    public static let tunNotActive = Self("tunNotActive")
+
+    /// TUN device is not available for I/O.
+    public static let tunNotAvailable = Self("tunNotAvailable")
 }
 
 // MARK: Serialization

--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /// Manages a tunnel and observes its status.
-public actor Tunnel {
+public actor Tunnel: TunnelProtocol {
     private let ctx: PartoutLoggerContext
 
     private let strategy: TunnelObservableStrategy
@@ -99,17 +99,12 @@ extension Tunnel {
     ) async throws {
         try await install(profile, connect: connect, options: nil, title: title)
     }
-
-    public func sendMessage(_ message: Message.Input) async throws -> Message.Output? {
-        guard let profileId = snapshots.keys.first else { return nil }
-        return try await sendMessage(message, to: profileId)
-    }
 }
 
 // MARK: - State
 
 extension Tunnel {
-    public private(set) var snapshots: [Profile.ID: TunnelSnapshot] {
+    public private(set) nonisolated var snapshots: [Profile.ID: TunnelSnapshot] {
         get {
             snapshotsSubject.value
         }

--- a/Sources/PartoutCore/Tunnel/TunnelProtocol.swift
+++ b/Sources/PartoutCore/Tunnel/TunnelProtocol.swift
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+// The abstract protocol of a tunnel.
+public protocol TunnelProtocol: TunnelStrategy {
+    nonisolated var snapshots: [Profile.ID: TunnelSnapshot] { get }
+
+    nonisolated var snapshotsStream: AsyncStream<[Profile.ID: TunnelSnapshot]> { get }
+
+    func allEnvironments() async -> [Profile.ID: TunnelEnvironmentReader]
+
+    func environment(for profileId: Profile.ID) async -> TunnelEnvironmentReader?
+}
+
+extension TunnelProtocol {
+    public func sendMessage(_ message: Message.Input) async throws -> Message.Output? {
+        guard let profileId = snapshots.keys.first else { return nil }
+        return try await sendMessage(message, to: profileId)
+    }
+}

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -106,3 +106,5 @@ FILE *_Nullable pp_fopen(const char *_Nonnull filename, const char *_Nonnull mod
 extern _Nullable JavaVM *_Nullable jvm;
 _Nullable JNIEnv *_Nullable pp_jni_attach_thread(bool *_Nonnull did_attach);
 #endif
+
+typedef void (*pp_completion)(void *_Nullable ctx, const int error_code);

--- a/Sources/PartoutCore_C/include/portable/conditionals.h
+++ b/Sources/PartoutCore_C/include/portable/conditionals.h
@@ -36,7 +36,7 @@
 #endif
 
 #if PARTOUT_MACOS || PARTOUT_LINUX || PARTOUT_WINDOWS || PARTOUT_ANDROID
-#define PARTOUT_ABI         1
+#define PARTOUT_HAS_TUN     1
 #else
-#define PARTOUT_ABI         0
+#define PARTOUT_HAS_TUN     0
 #endif

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -7,11 +7,13 @@
 #pragma once
 #include "portable/conditionals.h"
 
+#if PARTOUT_HAS_TUN
+
+#include <stdint.h>
+#include "portable/common.h"
+
 /* Opaque tun device. */
 typedef struct __pp_tun_struct *pp_tun;
-
-#if PARTOUT_ABI
-#include <stdint.h>
 
 /* Platform-specific implementations. */
 int pp_tun_read(const pp_tun _Nonnull tun, uint8_t *_Nonnull dst, size_t dst_len);
@@ -32,13 +34,26 @@ pp_tun _Nullable pp_tun_ctrl_set_tunnel(void *_Nullable ref,
 void pp_tun_ctrl_configure_sockets(void *_Nullable ref,
                                    const int *_Nullable fds,
                                    const size_t fds_len);
-void pp_tun_ctrl_clear_tunnel(void *_Nullable ref, pp_tun _Nullable tun_impl);
+void pp_tun_ctrl_clear_tunnel(void *_Nullable ref,
+                              pp_tun _Nullable tun_impl);
 
 /* Tunnel strategy. */
+void pp_tun_strg_install(void *_Nullable ref,
+                         const char *_Nonnull profile_json,
+                         bool connect,
+                         const char *_Nullable options_json,
+                         void *_Nullable ctx,
+                         _Nullable pp_completion completion);
+void pp_tun_strg_uninstall(void *_Nullable ref,
+                           const char *_Nonnull profile_id,
+                           void *_Nullable ctx,
+                           _Nullable pp_completion completion);
+void pp_tun_strg_disconnect(void *_Nullable ref,
+                            const char *_Nonnull profile_id,
+                            void *_Nullable ctx,
+                            _Nullable pp_completion completion);
+
 //void pp_tun_strg_prepare(void *ref);
-//void pp_tun_strg_install(void *ref);
-//void pp_tun_strg_uninstall(void *ref);
-//void pp_tun_strg_disconnect(void *ref);
 //void pp_tun_strg_send_msg(void *ref);
 //void pp_tun_strg_on_active(void *ref, callback);
 

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -8,15 +8,14 @@
 #include "portable/tun.h"
 
 #if PARTOUT_ANDROID
-
 #include <jni.h>
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-/* Expect this struct from pp_tun_ctrl_set_tunnel(). */
 struct __pp_tun_struct {
     int fd;
 };
@@ -54,27 +53,49 @@ typedef struct {
     const char *signature;
 } kotlin_sig;
 
+#define JNI_ATTACH_OR_RETURN(env_name, return_value) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) return return_value
+
+#define JNI_ATTACH_OR_RETURN_VOID(env_name) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) return
+
+#define JNI_ATTACH_OR_COMPLETE(env_name, completion, ctx) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) { \
+        if (completion) completion(ctx, -1); \
+        return; \
+    }
+
+#define JNI_DETACH(env_name) \
+    do { \
+        if (env_name##_did_attach) (*jvm)->DetachCurrentThread(jvm); \
+    } while (0)
+
 /* Tunnel controller (AndroidTunnelController) */
 
 static const kotlin_sig sig_ctrl_testWorking = {
     "testWorking",
     "()V"
 };
-static const kotlin_sig sig_ctrl_setTunnelSettings = {
-    "setTunnelSettings",
+static const kotlin_sig sig_ctrl_setTunnel = {
+    "setTunnel",
     "(Ljava/lang/String;)I"
 };
 static const kotlin_sig sig_ctrl_configureSockets = {
     "configureSockets",
     "([I)V"
 };
+
 void pp_tun_ctrl_test_working(void *jni_ref) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_test_working(%p)", jni_ref);
 
-    bool did_attach;
-    JNIEnv *env = pp_jni_attach_thread(&did_attach);
-    if (!env) return;
+    JNI_ATTACH_OR_RETURN_VOID(env);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -92,7 +113,7 @@ void pp_tun_ctrl_test_working(void *jni_ref) {
 
 cleanup:
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
+    JNI_DETACH(env);
 }
 
 pp_tun pp_tun_ctrl_set_tunnel(void *jni_ref, const char *uuid, const char *info_json) {
@@ -100,9 +121,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *jni_ref, const char *uuid, const char *info_
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_set_tunnel(%p)", jni_ref);
 
-    bool did_attach;
-    JNIEnv *env = pp_jni_attach_thread(&did_attach);
-    if (!env) return NULL;
+    JNI_ATTACH_OR_RETURN(env, NULL);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -121,7 +140,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *jni_ref, const char *uuid, const char *info_
         pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_set_tunnel(), NULL cls");
         goto cleanup;
     }
-    method = (*env)->GetMethodID(env, cls, sig_ctrl_setTunnelSettings.name, sig_ctrl_setTunnelSettings.signature);
+    method = (*env)->GetMethodID(env, cls, sig_ctrl_setTunnel.name, sig_ctrl_setTunnel.signature);
     if (method == NULL) {
         pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_set_tunnel(), NULL method");
         goto cleanup;
@@ -146,7 +165,7 @@ cleanup:
     }
     if (j_info_json != NULL) (*env)->DeleteLocalRef(env, j_info_json);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
+    JNI_DETACH(env);
     return tun_impl;
 }
 
@@ -155,9 +174,7 @@ void pp_tun_ctrl_configure_sockets(void *jni_ref, const int *fds, const size_t f
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_configure_sockets(%p)", jni_ref);
     if (!fds || fds_len == 0) return;
 
-    bool did_attach;
-    JNIEnv *env = pp_jni_attach_thread(&did_attach);
-    if (!env) return;
+    JNI_ATTACH_OR_RETURN_VOID(env);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -184,7 +201,7 @@ void pp_tun_ctrl_configure_sockets(void *jni_ref, const int *fds, const size_t f
 cleanup:
     if (j_fds != NULL) (*env)->DeleteLocalRef(env, j_fds);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
+    JNI_DETACH(env);
 }
 
 void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
@@ -193,6 +210,147 @@ void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
     if (!tun_impl) return;
     pp_tun_shutdown(tun_impl);
     free(tun_impl);
+}
+
+/* Tunnel strategy (AndroidTunnel) */
+
+static const kotlin_sig sig_strg_connect = {
+    "connect",
+    "(Ljava/lang/String;JJ)V"
+};
+static const kotlin_sig sig_strg_disconnect = {
+    "disconnect",
+    "(JJ)V"
+};
+
+void pp_tun_strg_install(void *jni_ref,
+                         const char *profile_json,
+                         bool connect,
+                         const char *options_json,
+                         void *ctx,
+                         pp_completion completion) {
+    (void)options_json;
+    assert(jni_ref);
+    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: strg_install(%p, %d)", jni_ref, connect);
+
+    /* Install-only is nop on Android. */
+    if (!connect) {
+        if (completion) completion(ctx, 0);
+        return;
+    }
+
+    JNI_ATTACH_OR_COMPLETE(env, completion, ctx);
+
+    jclass cls = NULL;
+    jmethodID method = NULL;
+    jstring j_profile_json = NULL;
+
+    cls = (*env)->GetObjectClass(env, jni_ref);
+    if (cls == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: strg_install(), NULL cls");
+        if (completion) completion(ctx, -1);
+        goto cleanup;
+    }
+    method = (*env)->GetMethodID(env, cls, sig_strg_connect.name, sig_strg_connect.signature);
+    if (method == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: strg_install(), NULL method");
+        if (completion) completion(ctx, -1);
+        goto cleanup;
+    }
+    j_profile_json = (*env)->NewStringUTF(env, profile_json);
+    if (j_profile_json == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: strg_install(), NULL j_profile_json");
+        if (completion) completion(ctx, -1);
+        goto cleanup;
+    }
+    (*env)->CallVoidMethod(
+        env,
+        jni_ref,
+        method,
+        j_profile_json,
+        (jlong)(intptr_t)ctx,
+        (jlong)(intptr_t)completion
+    );
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: strg_install(), Kotlin exception");
+        if (completion) completion(ctx, -1);
+        goto cleanup;
+    }
+
+cleanup:
+    if (j_profile_json != NULL) (*env)->DeleteLocalRef(env, j_profile_json);
+    if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
+    JNI_DETACH(env);
+}
+
+void pp_tun_strg_uninstall(void *jni_ref,
+                           const char *profile_id,
+                           void *ctx,
+                           pp_completion completion) {
+    (void)jni_ref;
+    (void)profile_id;
+    /* Uninstall is nop on Android. */
+    if (completion) completion(ctx, 0);
+}
+
+void pp_tun_strg_disconnect(void *jni_ref,
+                            const char *profile_id,
+                            void *ctx,
+                            pp_completion completion) {
+    (void)profile_id;
+    assert(jni_ref);
+    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: strg_disconnect(%p)", jni_ref);
+
+    JNI_ATTACH_OR_COMPLETE(env, completion, ctx);
+
+    jclass cls = NULL;
+    jmethodID method = NULL;
+
+    cls = (*env)->GetObjectClass(env, jni_ref);
+    if (cls == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: strg_disconnect(), NULL cls");
+        if (completion) completion(ctx, -1);
+        goto cleanup;
+    }
+    method = (*env)->GetMethodID(env, cls, sig_strg_disconnect.name, sig_strg_disconnect.signature);
+    if (method == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: strg_disconnect(), NULL method");
+        if (completion) completion(ctx, -1);
+        goto cleanup;
+    }
+    (*env)->CallVoidMethod(
+        env,
+        jni_ref,
+        method,
+        (jlong)(intptr_t)ctx,
+        (jlong)(intptr_t)completion
+    );
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: strg_disconnect(), Kotlin exception");
+        if (completion) completion(ctx, -1);
+        goto cleanup;
+    }
+
+cleanup:
+    if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
+    JNI_DETACH(env);
+}
+
+JNIEXPORT void JNICALL
+Java_io_partout_jni_AndroidTunnel_callback(JNIEnv *env,
+                                           jobject thiz,
+                                           jlong completion_ctx,
+                                           jlong completion,
+                                           jint error_code) {
+    (void)env;
+    (void)thiz;
+    void *ctx = (void *)(intptr_t)completion_ctx;
+    pp_completion cb = (pp_completion)(intptr_t)completion;
+    if (cb) cb(ctx, (int)error_code);
 }
 
 #endif

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -9,7 +9,7 @@
 
 // FIXME: ###, Implement macOS, Linux, and Windows (placeholder now)
 
-#if !PARTOUT_ANDROID
+#if PARTOUT_HAS_TUN && !PARTOUT_ANDROID
 void pp_tun_ctrl_test_working(void *ref) {
     (void)ref;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_test_working(%p), ref");
@@ -34,5 +34,41 @@ void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
     (void)ref;
     (void)tun_impl;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_clear_tunnel(%p)", ref);
+}
+
+void pp_tun_strg_install(void *ref,
+                         const char *profile_json,
+                         bool connect,
+                         const char *options_json,
+                         void *ctx,
+                         pp_completion completion) {
+    (void)ref;
+    (void)profile_json;
+    (void)options_json;
+    (void)ctx;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: strg_install(%p, %d)", ref, connect);
+    if (completion) completion(0, NULL);
+}
+
+void pp_tun_strg_uninstall(void *ref,
+                           const char *profile_id,
+                           void *ctx,
+                           pp_completion completion) {
+    (void)ref;
+    (void)profile_id;
+    (void)ctx;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: strg_uninstall(%p)", ref);
+    if (completion) completion(0, NULL);
+}
+
+void pp_tun_strg_disconnect(void *ref,
+                            const char *profile_id,
+                            void *ctx,
+                            pp_completion completion) {
+    (void)ref;
+    (void)profile_id;
+    (void)ctx;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: strg_disconnect(%p)", ref);
+    if (completion) completion(0, NULL);
 }
 #endif

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -47,7 +47,7 @@ void pp_tun_strg_install(void *ref,
     (void)options_json;
     (void)ctx;
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: strg_install(%p, %d)", ref, connect);
-    if (completion) completion(0, NULL);
+    if (completion) completion(NULL, 0);
 }
 
 void pp_tun_strg_uninstall(void *ref,
@@ -58,7 +58,7 @@ void pp_tun_strg_uninstall(void *ref,
     (void)profile_id;
     (void)ctx;
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: strg_uninstall(%p)", ref);
-    if (completion) completion(0, NULL);
+    if (completion) completion(NULL, 0);
 }
 
 void pp_tun_strg_disconnect(void *ref,
@@ -69,6 +69,6 @@ void pp_tun_strg_disconnect(void *ref,
     (void)profile_id;
     (void)ctx;
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: strg_disconnect(%p)", ref);
-    if (completion) completion(0, NULL);
+    if (completion) completion(NULL, 0);
 }
 #endif

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -37,6 +37,9 @@ set(PARTOUT_SOURCES
 ./Partout/Modules/ModuleType+Extensions.swift
 ./Partout/Modules/TaggedModule.swift
 ./Partout/Modules/TaggedProfile.swift
+./Partout/NativeHelpers.swift
+./Partout/NativeTunnel.swift
+./Partout/NativeTunnelController.swift
 ./Partout/PartoutExports.swift
 ./Partout/Registry+Support.swift
 ./Partout/Registry.swift
@@ -44,7 +47,6 @@ set(PARTOUT_SOURCES
 ./Partout/Serialization/LegacyProfileEncoderV1.swift
 ./Partout/Serialization/LegacyProfileEncoderV2.swift
 ./Partout/Serialization/ProfileEncoderV3.swift
-./Partout/VirtualTunnelController.swift
 ./Partout/VirtualTunnelInterface.swift
 ./PartoutCore/Connection/BSDSocket.swift
 ./PartoutCore/Connection/BSDSocketFactory.swift
@@ -161,6 +163,7 @@ set(PARTOUT_SOURCES
 ./PartoutCore/Tunnel/FakeTunnelStrategy.swift
 ./PartoutCore/Tunnel/MessageHandler.swift
 ./PartoutCore/Tunnel/Tunnel.swift
+./PartoutCore/Tunnel/TunnelProtocol.swift
 ./PartoutCore/Tunnel/TunnelStatus.swift
 ./PartoutCore/Tunnel/TunnelStrategy.swift
 ./PartoutOS/Apple/AppleJavaScriptEngine.swift

--- a/cross/android/io/partout/jni/AndroidTunnel.kt
+++ b/cross/android/io/partout/jni/AndroidTunnel.kt
@@ -9,48 +9,48 @@ import android.content.Intent
 import android.net.VpnService
 import androidx.core.content.ContextCompat
 import io.partout.abi.TaggedProfile
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.serialization.json.Json
 
-class AndroidTunnelStrategy(
+class AndroidTunnel(
     context: Context,
     private val vpnServiceClass: Class<out VpnService>,
     private val requestVpnPermission: (Intent) -> Unit
 ) {
     private val appContext = context.applicationContext
-    private var pendingPermission: CompletableDeferred<Boolean>? = null
+    private var pendingPermission: PendingPermission? = null
 
-    suspend fun connect(profile: TaggedProfile): Boolean {
+    fun connect(profileJSON: String, ctx: Long, completion: Long) {
+        val profile = json.decodeFromString<TaggedProfile>(profileJSON)
+        val complete: (Int) -> Unit = { code ->
+            callback(ctx, completion, code)
+        }
         val permissionIntent = VpnService.prepare(appContext)
         if (permissionIntent != null) {
-            pendingPermission?.complete(false)
-            val permission = CompletableDeferred<Boolean>()
-            pendingPermission = permission
+            pendingPermission?.completion?.invoke(-1)
+            pendingPermission = PendingPermission(profile, complete)
             requestVpnPermission(permissionIntent)
-            val isGranted = try {
-                permission.await()
-            } finally {
-                if (pendingPermission === permission) {
-                    pendingPermission = null
-                }
-            }
-            if (!isGranted) {
-                return false
-            }
+            return
         }
         startVpnService(profile)
-        return true
+        complete(0)
     }
 
-    suspend fun disconnect() {
-        pendingPermission?.complete(false)
+    fun disconnect(ctx: Long, completion: Long) {
+        pendingPermission?.completion?.invoke(-1)
         pendingPermission = null
         stopVpnService()
+        callback(ctx, completion, 0)
     }
 
     fun onVpnPermissionResult(granted: Boolean) {
-        pendingPermission?.complete(granted)
+        val permission = pendingPermission ?: return
         pendingPermission = null
+        if (!granted) {
+            permission.completion(-1)
+            return
+        }
+        startVpnService(permission.profile)
+        permission.completion(0)
     }
 
     private fun startVpnService(profile: TaggedProfile) {
@@ -75,4 +75,11 @@ class AndroidTunnelStrategy(
             ignoreUnknownKeys = true
         }
     }
+
+    private external fun callback(ctx: Long, completion: Long, errorCode: Int)
+
+    private data class PendingPermission(
+        val profile: TaggedProfile,
+        val completion: (Int) -> Unit
+    )
 }

--- a/cross/android/io/partout/jni/AndroidTunnelController.kt
+++ b/cross/android/io/partout/jni/AndroidTunnelController.kt
@@ -31,7 +31,7 @@ class AndroidTunnelController {
     }
 
     // FIXME: Pass Profile
-    fun setTunnelSettings(infoJSON: String): Int {
+    fun setTunnel(infoJSON: String): Int {
         assert(descriptor == null)
         val builder = service.Builder()
 


### PR DESCRIPTION
The idea is to generalize Tunnel via the TunnelProtocol so that a NativeTunnel class may implement the app functionality via C functions rather than Swift. NativeTunnel calls the `pp_tun_strg_*` C/JNI functions similarly to how NativeTunnelController (formerly VirtualTunnelController) calls the `pp_tun_ctrl_*` functions on the daemon end.

About Android:

- Use `pp_tun_strg_*` to call AndroidTunnel via JNI
- Replace coroutines with completion callbacks in AndroidTunnel to simplify JNI bridging
- Implement connect/disconnect, install/uninstall are nop on Android
- Use macros for JNI attach/detach

Some NativeTunnel things remain to be implemented:

- Options in install() (Sendable → Codable)
- sendMessage()
- Snapshots
- Environments