### PR TITLE
Core: Encode dates as UNIX milliseconds

### DIFF
--- a/Sources/MiniFoundation/FoundationEssentials/Dictionary+Extensions.swift
+++ b/Sources/MiniFoundation/FoundationEssentials/Dictionary+Extensions.swift
@@ -5,10 +5,10 @@
 extension Dictionary where Key == String, Value == Data {
     public func decode<T>(_ type: T.Type, forKey key: String) throws -> T? where T: Decodable {
         guard let data = self[key] else { return nil }
-        return try JSONDecoder().decode(T.self, from: data)
+        return try JSONDecoder.new().decode(T.self, from: data)
     }
 
     public mutating func encode<T>(_ value: T, forKey key: String) throws where T: Encodable {
-        self[key] = try JSONEncoder().encode(value)
+        self[key] = try JSONEncoder.new().encode(value)
     }
 }

--- a/Sources/MiniFoundation/FoundationEssentials/Dictionary+Extensions.swift
+++ b/Sources/MiniFoundation/FoundationEssentials/Dictionary+Extensions.swift
@@ -5,10 +5,10 @@
 extension Dictionary where Key == String, Value == Data {
     public func decode<T>(_ type: T.Type, forKey key: String) throws -> T? where T: Decodable {
         guard let data = self[key] else { return nil }
-        return try JSONDecoder.new().decode(T.self, from: data)
+        return try JSONDecoder.shared().decode(T.self, from: data)
     }
 
     public mutating func encode<T>(_ value: T, forKey key: String) throws where T: Encodable {
-        self[key] = try JSONEncoder.new().encode(value)
+        self[key] = try JSONEncoder.shared().encode(value)
     }
 }

--- a/Sources/MiniFoundation/FoundationEssentials/JSONCoder+Extensions.swift
+++ b/Sources/MiniFoundation/FoundationEssentials/JSONCoder+Extensions.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 extension JSONEncoder {
-    public static func new() -> JSONEncoder {
+    public static func shared() -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .millisecondsSince1970
         return encoder
@@ -16,7 +16,7 @@ extension JSONEncoder {
 }
 
 extension JSONDecoder {
-    public static func new() -> JSONDecoder {
+    public static func shared() -> JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         return decoder

--- a/Sources/MiniFoundation/FoundationEssentials/JSONCoder+Extensions.swift
+++ b/Sources/MiniFoundation/FoundationEssentials/JSONCoder+Extensions.swift
@@ -2,14 +2,24 @@
 //
 // SPDX-License-Identifier: MIT
 
-extension JSONDecoder {
+extension JSONEncoder {
+    public static func new() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        return encoder
+    }
+
     public convenience init(userInfo: [CodingUserInfoKey: Sendable] = [:]) {
         self.init()
         self.userInfo = userInfo
     }
 }
 
-extension JSONEncoder {
+extension JSONDecoder {
+    public static func new() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        return decoder
+    }
+
     public convenience init(userInfo: [CodingUserInfoKey: Sendable] = [:]) {
         self.init()
         self.userInfo = userInfo

--- a/Sources/MiniFoundation/FoundationEssentials/JSONCoder+Extensions.swift
+++ b/Sources/MiniFoundation/FoundationEssentials/JSONCoder+Extensions.swift
@@ -5,6 +5,7 @@
 extension JSONEncoder {
     public static func new() -> JSONEncoder {
         let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
         return encoder
     }
 
@@ -17,6 +18,7 @@ extension JSONEncoder {
 extension JSONDecoder {
     public static func new() -> JSONDecoder {
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
         return decoder
     }
 

--- a/Sources/MiniFoundation/JSON/Initialization.swift
+++ b/Sources/MiniFoundation/JSON/Initialization.swift
@@ -61,8 +61,8 @@ extension JSON {
     /// Create a JSON value from an `Encodable`. This will give you access to the “raw”
     /// encoded JSON value the `Encodable` is serialized into.
     public init<T: Encodable>(encodable: T) throws {
-        let encoded = try JSONEncoder.new().encode(encodable)
-        self = try JSONDecoder.new().decode(JSON.self, from: encoded)
+        let encoded = try JSONEncoder.shared().encode(encodable)
+        self = try JSONDecoder.shared().decode(JSON.self, from: encoded)
     }
 }
 

--- a/Sources/MiniFoundation/JSON/Initialization.swift
+++ b/Sources/MiniFoundation/JSON/Initialization.swift
@@ -61,8 +61,8 @@ extension JSON {
     /// Create a JSON value from an `Encodable`. This will give you access to the “raw”
     /// encoded JSON value the `Encodable` is serialized into.
     public init<T: Encodable>(encodable: T) throws {
-        let encoded = try JSONEncoder().encode(encodable)
-        self = try JSONDecoder().decode(JSON.self, from: encoded)
+        let encoded = try JSONEncoder.new().encode(encodable)
+        self = try JSONDecoder.new().decode(JSON.self, from: encoded)
     }
 }
 

--- a/Sources/MiniFoundation/JSON/JSON.swift
+++ b/Sources/MiniFoundation/JSON/JSON.swift
@@ -73,7 +73,7 @@ extension JSON: CustomDebugStringConvertible {
         case .null:
             return "null"
         default:
-            let encoder = JSONEncoder.new()
+            let encoder = JSONEncoder.shared()
             encoder.outputFormatting = [.prettyPrinted]
             return try! String(data: encoder.encode(self), encoding: .utf8)!
         }

--- a/Sources/MiniFoundation/JSON/JSON.swift
+++ b/Sources/MiniFoundation/JSON/JSON.swift
@@ -73,7 +73,7 @@ extension JSON: CustomDebugStringConvertible {
         case .null:
             return "null"
         default:
-            let encoder = JSONEncoder()
+            let encoder = JSONEncoder.new()
             encoder.outputFormatting = [.prettyPrinted]
             return try! String(data: encoder.encode(self), encoding: .utf8)!
         }

--- a/Sources/Partout/NativeTunnel.swift
+++ b/Sources/Partout/NativeTunnel.swift
@@ -77,7 +77,7 @@ public final class NativeTunnel: TunnelProtocol, @unchecked Sendable {
 
 private extension NativeTunnel {
     static func encode(_ profile: Profile) throws -> String {
-        let data = try JSONEncoder.new().encode(profile.asTaggedProfile)
+        let data = try JSONEncoder.shared().encode(profile.asTaggedProfile)
         guard let json = String(data: data, encoding: .utf8) else {
             throw PartoutError(.encoding)
         }

--- a/Sources/Partout/NativeTunnel.swift
+++ b/Sources/Partout/NativeTunnel.swift
@@ -77,7 +77,7 @@ public final class NativeTunnel: TunnelProtocol, @unchecked Sendable {
 
 private extension NativeTunnel {
     static func encode(_ profile: Profile) throws -> String {
-        let data = try JSONEncoder().encode(profile.asTaggedProfile)
+        let data = try JSONEncoder.new().encode(profile.asTaggedProfile)
         guard let json = String(data: data, encoding: .utf8) else {
             throw PartoutError(.encoding)
         }

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -41,7 +41,7 @@ public final class NativeTunnelController: TunnelController {
 
         let infoJSON: String = try {
             let wrapped = TunnelRemoteInfoWrapper(info)
-            let data = try JSONEncoder().encode(wrapped)
+            let data = try JSONEncoder.new().encode(wrapped)
             guard let json = String(data: data, encoding: .utf8) else {
                 throw PartoutError(.notFound)
             }

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -41,7 +41,7 @@ public final class NativeTunnelController: TunnelController {
 
         let infoJSON: String = try {
             let wrapped = TunnelRemoteInfoWrapper(info)
-            let data = try JSONEncoder.new().encode(wrapped)
+            let data = try JSONEncoder.shared().encode(wrapped)
             guard let json = String(data: data, encoding: .utf8) else {
                 throw PartoutError(.notFound)
             }

--- a/Sources/Partout/Serialization/LegacyProfileEncoderV1.swift
+++ b/Sources/Partout/Serialization/LegacyProfileEncoderV1.swift
@@ -18,7 +18,7 @@ extension LegacyProfileEncoderV1 {
         guard let data = Data(base64Encoded: base64Encoded) else {
             throw PartoutError(.decoding)
         }
-        let decodable = try JSONDecoder().decode(LegacyCodableProfile.self, from: data)
+        let decodable = try JSONDecoder.new().decode(LegacyCodableProfile.self, from: data)
         let handlers = decodable.modules.compactMap { wrapper in
             registry.handler(withId: wrapper.id)
         }
@@ -29,7 +29,7 @@ extension LegacyProfileEncoderV1 {
 
     @available(*, deprecated, message: "#273")
     func decodedModule(from data: Data, with registry: Registry) throws -> Module {
-        let decoder = JSONDecoder()
+        let decoder = JSONDecoder.new()
         let wrapper = try decoder.decode(LegacyModuleWrapper.self, from: data)
         guard let handler = registry.handler(withId: wrapper.id) else {
             throw PartoutError(.decoding)
@@ -53,7 +53,7 @@ private enum Serialization {
     typealias ModuleHandlersMap = [ModuleType: ModuleHandler]
 
     static func decodedProfile(from encoded: LegacyCodableProfile, with handlers: ModuleHandlersMap) throws -> Profile {
-        let decoder = JSONDecoder()
+        let decoder = JSONDecoder.new()
         let userInfoMap = try encoded.userInfo.map {
             try JSONSerialization.jsonObject(with: $0)
         } ?? nil
@@ -103,7 +103,7 @@ struct LegacyModuleWrapper: Codable {
 
     init(_ module: Module & Encodable) throws {
         id = module.moduleType
-        data = try JSONEncoder().encode(module)
+        data = try JSONEncoder.new().encode(module)
     }
 }
 

--- a/Sources/Partout/Serialization/LegacyProfileEncoderV1.swift
+++ b/Sources/Partout/Serialization/LegacyProfileEncoderV1.swift
@@ -18,7 +18,7 @@ extension LegacyProfileEncoderV1 {
         guard let data = Data(base64Encoded: base64Encoded) else {
             throw PartoutError(.decoding)
         }
-        let decodable = try JSONDecoder.new().decode(LegacyCodableProfile.self, from: data)
+        let decodable = try JSONDecoder.shared().decode(LegacyCodableProfile.self, from: data)
         let handlers = decodable.modules.compactMap { wrapper in
             registry.handler(withId: wrapper.id)
         }
@@ -29,7 +29,7 @@ extension LegacyProfileEncoderV1 {
 
     @available(*, deprecated, message: "#273")
     func decodedModule(from data: Data, with registry: Registry) throws -> Module {
-        let decoder = JSONDecoder.new()
+        let decoder = JSONDecoder.shared()
         let wrapper = try decoder.decode(LegacyModuleWrapper.self, from: data)
         guard let handler = registry.handler(withId: wrapper.id) else {
             throw PartoutError(.decoding)
@@ -53,7 +53,7 @@ private enum Serialization {
     typealias ModuleHandlersMap = [ModuleType: ModuleHandler]
 
     static func decodedProfile(from encoded: LegacyCodableProfile, with handlers: ModuleHandlersMap) throws -> Profile {
-        let decoder = JSONDecoder.new()
+        let decoder = JSONDecoder.shared()
         let userInfoMap = try encoded.userInfo.map {
             try JSONSerialization.jsonObject(with: $0)
         } ?? nil
@@ -103,7 +103,7 @@ struct LegacyModuleWrapper: Codable {
 
     init(_ module: Module & Encodable) throws {
         id = module.moduleType
-        data = try JSONEncoder.new().encode(module)
+        data = try JSONEncoder.shared().encode(module)
     }
 }
 

--- a/Sources/Partout/Serialization/ProfileEncoderV3.swift
+++ b/Sources/Partout/Serialization/ProfileEncoderV3.swift
@@ -5,7 +5,7 @@
 // TaggedProfile/TaggedModule don't need any .userInfo
 final class ProfileEncoderV3 {
     func encode(_ value: TaggedProfile) throws -> String {
-        let encoder = JSONEncoder()
+        let encoder = JSONEncoder.new()
         let data = try encoder.encode(value)
         guard let json = String(data: data, encoding: .utf8) else {
             throw PartoutError(.encoding, "Not a UTF-8 output")
@@ -14,7 +14,7 @@ final class ProfileEncoderV3 {
     }
 
     func decode(_ string: String) throws -> TaggedProfile {
-        let decoder = JSONDecoder()
+        let decoder = JSONDecoder.new()
         guard let json = string.data(using: .utf8) else {
             throw PartoutError(.decoding, "Not a UTF-8 input")
         }

--- a/Sources/Partout/Serialization/ProfileEncoderV3.swift
+++ b/Sources/Partout/Serialization/ProfileEncoderV3.swift
@@ -5,7 +5,7 @@
 // TaggedProfile/TaggedModule don't need any .userInfo
 final class ProfileEncoderV3 {
     func encode(_ value: TaggedProfile) throws -> String {
-        let encoder = JSONEncoder.new()
+        let encoder = JSONEncoder.shared()
         let data = try encoder.encode(value)
         guard let json = String(data: data, encoding: .utf8) else {
             throw PartoutError(.encoding, "Not a UTF-8 output")
@@ -14,7 +14,7 @@ final class ProfileEncoderV3 {
     }
 
     func decode(_ string: String) throws -> TaggedProfile {
-        let decoder = JSONDecoder.new()
+        let decoder = JSONDecoder.shared()
         guard let json = string.data(using: .utf8) else {
             throw PartoutError(.decoding, "Not a UTF-8 input")
         }

--- a/Sources/PartoutCore/Logging/Encoder+Sensitive.swift
+++ b/Sources/PartoutCore/Logging/Encoder+Sensitive.swift
@@ -28,7 +28,7 @@ extension PartoutLogger {
 extension Encodable {
     public func asJSON(_ ctx: PartoutLoggerContext, withSensitiveData: Bool, sortingKeys: Bool = false) -> String? {
         do {
-            let encoder = JSONEncoder.new()
+            let encoder = JSONEncoder.shared()
             if !withSensitiveData {
                 encoder.userInfo = [.redactingSensitiveData: true]
             }

--- a/Sources/PartoutCore/Logging/Encoder+Sensitive.swift
+++ b/Sources/PartoutCore/Logging/Encoder+Sensitive.swift
@@ -28,7 +28,7 @@ extension PartoutLogger {
 extension Encodable {
     public func asJSON(_ ctx: PartoutLoggerContext, withSensitiveData: Bool, sortingKeys: Bool = false) -> String? {
         do {
-            let encoder = JSONEncoder()
+            let encoder = JSONEncoder.new()
             if !withSensitiveData {
                 encoder.userInfo = [.redactingSensitiveData: true]
             }

--- a/Sources/PartoutCore/Tunnel/TunnelStrategy.swift
+++ b/Sources/PartoutCore/Tunnel/TunnelStrategy.swift
@@ -82,10 +82,10 @@ extension TunnelStrategy {
 
 extension TunnelStrategy {
     public func sendMessage(_ input: Message.Input, to profileId: Profile.ID) async throws -> Message.Output? {
-        let encoded = try JSONEncoder().encode(input)
+        let encoded = try JSONEncoder.new().encode(input)
         guard let output = try await sendMessage(encoded, to: profileId) else {
             return nil
         }
-        return try JSONDecoder().decode(Message.Output.self, from: output)
+        return try JSONDecoder.new().decode(Message.Output.self, from: output)
     }
 }

--- a/Sources/PartoutCore/Tunnel/TunnelStrategy.swift
+++ b/Sources/PartoutCore/Tunnel/TunnelStrategy.swift
@@ -82,10 +82,10 @@ extension TunnelStrategy {
 
 extension TunnelStrategy {
     public func sendMessage(_ input: Message.Input, to profileId: Profile.ID) async throws -> Message.Output? {
-        let encoded = try JSONEncoder.new().encode(input)
+        let encoded = try JSONEncoder.shared().encode(input)
         guard let output = try await sendMessage(encoded, to: profileId) else {
             return nil
         }
-        return try JSONDecoder.new().decode(Message.Output.self, from: output)
+        return try JSONDecoder.shared().decode(Message.Output.self, from: output)
     }
 }

--- a/Sources/PartoutOS/Apple/AppleJavaScriptEngine.swift
+++ b/Sources/PartoutOS/Apple/AppleJavaScriptEngine.swift
@@ -33,7 +33,7 @@ public final class AppleJavaScriptEngine: ScriptingEngine, @unchecked Sendable {
             guard let data = value.toString().data(using: .utf8) else {
                 throw PartoutError(.parsing, value)
             }
-            return try JSONDecoder.new().decode(O.self, from: data)
+            return try JSONDecoder.shared().decode(O.self, from: data)
         }.value
     }
 }

--- a/Sources/PartoutOS/Apple/AppleJavaScriptEngine.swift
+++ b/Sources/PartoutOS/Apple/AppleJavaScriptEngine.swift
@@ -33,7 +33,7 @@ public final class AppleJavaScriptEngine: ScriptingEngine, @unchecked Sendable {
             guard let data = value.toString().data(using: .utf8) else {
                 throw PartoutError(.parsing, value)
             }
-            return try JSONDecoder().decode(O.self, from: data)
+            return try JSONDecoder.new().decode(O.self, from: data)
         }.value
     }
 }

--- a/Sources/PartoutOS/Apple/UserDefaultsEnvironment.swift
+++ b/Sources/PartoutOS/Apple/UserDefaultsEnvironment.swift
@@ -21,7 +21,7 @@ public final class UserDefaultsEnvironment: TunnelEnvironment, @unchecked Sendab
     public func setEnvironmentValue<T>(_ value: T, forKey key: TunnelEnvironmentKey<T>) where T: Encodable {
         let fullKey = key.keyString.rawKey(prefix: prefix)
         do {
-            let data = try JSONEncoder.new().encode(value)
+            let data = try JSONEncoder.shared().encode(value)
             defaults.set(data, forKey: fullKey)
             pp_log_id(profileId, .core, .debug, "UserDefaultsEnvironment.set(\(fullKey)) -> \(value)")
         } catch {
@@ -35,7 +35,7 @@ public final class UserDefaultsEnvironment: TunnelEnvironment, @unchecked Sendab
             guard let data = defaults.data(forKey: fullKey) else {
                 return nil
             }
-            return try JSONDecoder.new().decode(T.self, from: data)
+            return try JSONDecoder.shared().decode(T.self, from: data)
         } catch {
             pp_log_id(profileId, .core, .error, "Unable to get environment key: \(fullKey) -> \(error)")
             return nil

--- a/Sources/PartoutOS/Apple/UserDefaultsEnvironment.swift
+++ b/Sources/PartoutOS/Apple/UserDefaultsEnvironment.swift
@@ -21,7 +21,7 @@ public final class UserDefaultsEnvironment: TunnelEnvironment, @unchecked Sendab
     public func setEnvironmentValue<T>(_ value: T, forKey key: TunnelEnvironmentKey<T>) where T: Encodable {
         let fullKey = key.keyString.rawKey(prefix: prefix)
         do {
-            let data = try JSONEncoder().encode(value)
+            let data = try JSONEncoder.new().encode(value)
             defaults.set(data, forKey: fullKey)
             pp_log_id(profileId, .core, .debug, "UserDefaultsEnvironment.set(\(fullKey)) -> \(value)")
         } catch {
@@ -35,7 +35,7 @@ public final class UserDefaultsEnvironment: TunnelEnvironment, @unchecked Sendab
             guard let data = defaults.data(forKey: fullKey) else {
                 return nil
             }
-            return try JSONDecoder().decode(T.self, from: data)
+            return try JSONDecoder.new().decode(T.self, from: data)
         } catch {
             pp_log_id(profileId, .core, .error, "Unable to get environment key: \(fullKey) -> \(error)")
             return nil

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -81,9 +81,9 @@ public actor NEPTPForwarder {
     public func handleAppMessage(_ messageData: Data) async -> Data? {
         pp_log(ctx, .os, .debug, "Handle PTP message")
         do {
-            let input = try JSONDecoder().decode(Message.Input.self, from: messageData)
+            let input = try JSONDecoder.new().decode(Message.Input.self, from: messageData)
             let output = try await daemon.sendMessage(input)
-            let encodedOutput = try JSONEncoder().encode(output)
+            let encodedOutput = try JSONEncoder.new().encode(output)
             switch input {
             case .environment:
                 break

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -81,9 +81,9 @@ public actor NEPTPForwarder {
     public func handleAppMessage(_ messageData: Data) async -> Data? {
         pp_log(ctx, .os, .debug, "Handle PTP message")
         do {
-            let input = try JSONDecoder.new().decode(Message.Input.self, from: messageData)
+            let input = try JSONDecoder.shared().decode(Message.Input.self, from: messageData)
             let output = try await daemon.sendMessage(input)
-            let encodedOutput = try JSONEncoder.new().encode(output)
+            let encodedOutput = try JSONEncoder.shared().encode(output)
             switch input {
             case .environment:
                 break

--- a/Tests/PartoutCoreTests/DNSModuleTests.swift
+++ b/Tests/PartoutCoreTests/DNSModuleTests.swift
@@ -97,21 +97,21 @@ struct DNSModuleTests {
     @Test
     func givenLegacyHTTPSPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"https":{"url":"https://1.2.3.4/"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(DNSModule.ProtocolType.self, from: data)
+        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
         #expect(decoded == .https(url: try #require(URL(string: "https://1.2.3.4/"))))
     }
 
     @Test
     func givenLegacyCleartextPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"cleartext":{}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(DNSModule.ProtocolType.self, from: data)
+        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
         #expect(decoded == .cleartext)
     }
 
     @Test
     func givenLegacyTLSPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"tls":{"hostname":"example.com"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(DNSModule.ProtocolType.self, from: data)
+        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
         #expect(decoded == .tls(hostname: "example.com"))
     }
 
@@ -119,7 +119,7 @@ struct DNSModuleTests {
     func givenMalformedTaggedHTTPSPayload_whenDecode_thenFailsWithoutLegacyFallback() {
         let data = #"{"type":"https","hostname":"example.com"}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder().decode(DNSModule.ProtocolType.self, from: data)
+            try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
         }
     }
 
@@ -127,15 +127,15 @@ struct DNSModuleTests {
     func givenMalformedLegacyHTTPSPayload_whenDecode_thenFailsWithoutTryingOtherLegacyCases() {
         let data = #"{"https":{"hostname":"example.com"}}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder().decode(DNSModule.ProtocolType.self, from: data)
+            try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
         }
     }
 }
 
 private extension DNSModuleTests {
     func assertRoundTrip(_ value: DNSModule.ProtocolType) throws {
-        let encoded = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(DNSModule.ProtocolType.self, from: encoded)
+        let encoded = try JSONEncoder.new().encode(value)
+        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: encoded)
         #expect(decoded == value)
     }
 }

--- a/Tests/PartoutCoreTests/DNSModuleTests.swift
+++ b/Tests/PartoutCoreTests/DNSModuleTests.swift
@@ -97,21 +97,21 @@ struct DNSModuleTests {
     @Test
     func givenLegacyHTTPSPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"https":{"url":"https://1.2.3.4/"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(DNSModule.ProtocolType.self, from: data)
         #expect(decoded == .https(url: try #require(URL(string: "https://1.2.3.4/"))))
     }
 
     @Test
     func givenLegacyCleartextPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"cleartext":{}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(DNSModule.ProtocolType.self, from: data)
         #expect(decoded == .cleartext)
     }
 
     @Test
     func givenLegacyTLSPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"tls":{"hostname":"example.com"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(DNSModule.ProtocolType.self, from: data)
         #expect(decoded == .tls(hostname: "example.com"))
     }
 
@@ -119,7 +119,7 @@ struct DNSModuleTests {
     func givenMalformedTaggedHTTPSPayload_whenDecode_thenFailsWithoutLegacyFallback() {
         let data = #"{"type":"https","hostname":"example.com"}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
+            try JSONDecoder.shared().decode(DNSModule.ProtocolType.self, from: data)
         }
     }
 
@@ -127,15 +127,15 @@ struct DNSModuleTests {
     func givenMalformedLegacyHTTPSPayload_whenDecode_thenFailsWithoutTryingOtherLegacyCases() {
         let data = #"{"https":{"hostname":"example.com"}}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: data)
+            try JSONDecoder.shared().decode(DNSModule.ProtocolType.self, from: data)
         }
     }
 }
 
 private extension DNSModuleTests {
     func assertRoundTrip(_ value: DNSModule.ProtocolType) throws {
-        let encoded = try JSONEncoder.new().encode(value)
-        let decoded = try JSONDecoder.new().decode(DNSModule.ProtocolType.self, from: encoded)
+        let encoded = try JSONEncoder.shared().encode(value)
+        let decoded = try JSONDecoder.shared().decode(DNSModule.ProtocolType.self, from: encoded)
         #expect(decoded == value)
     }
 }

--- a/Tests/PartoutCoreTests/MessageHandlerTests.swift
+++ b/Tests/PartoutCoreTests/MessageHandlerTests.swift
@@ -16,19 +16,19 @@ struct MessageHandlerTests {
         ])
         let output = Message.Output.debugLog(log: log)
         let strategy = FakeTunnelStrategy { _ in
-            (try? JSONEncoder.new().encode(output)) ?? Data()
+            (try? JSONEncoder.shared().encode(output)) ?? Data()
         }
         let sut = Tunnel(.global, strategy: strategy) { _ in
             SharedTunnelEnvironment(profileId: nil)
         }
 
         let inputMessage = Message.Input.debugLog(sinceLast: 60.0, maxLevel: .debug)
-        let input = try JSONEncoder.new().encode(inputMessage)
+        let input = try JSONEncoder.shared().encode(inputMessage)
         let expOutputMessage = try #require(try await sut.sendMessage(
             input,
             to: UniqueID() // unused
         ))
-        let expOutput = try JSONDecoder.new().decode(Message.Output.self, from: expOutputMessage)
+        let expOutput = try JSONDecoder.shared().decode(Message.Output.self, from: expOutputMessage)
         #expect(expOutput == output)
     }
 }

--- a/Tests/PartoutCoreTests/MessageHandlerTests.swift
+++ b/Tests/PartoutCoreTests/MessageHandlerTests.swift
@@ -8,10 +8,11 @@ import Testing
 struct MessageHandlerTests {
     @Test
     func givenTunnel_whenSendMessage_thenTranslatesDataToInputOutput() async throws {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000.123)
         let log = DebugLog(lines: [
-            .init(timestamp: Date(), level: .notice, message: "one"),
-            .init(timestamp: Date(), level: .notice, message: "two"),
-            .init(timestamp: Date(), level: .notice, message: "three")
+            .init(timestamp: timestamp, level: .notice, message: "one"),
+            .init(timestamp: timestamp, level: .notice, message: "two"),
+            .init(timestamp: timestamp, level: .notice, message: "three")
         ])
         let output = Message.Output.debugLog(log: log)
         let strategy = FakeTunnelStrategy { _ in

--- a/Tests/PartoutCoreTests/MessageHandlerTests.swift
+++ b/Tests/PartoutCoreTests/MessageHandlerTests.swift
@@ -16,19 +16,19 @@ struct MessageHandlerTests {
         ])
         let output = Message.Output.debugLog(log: log)
         let strategy = FakeTunnelStrategy { _ in
-            (try? JSONEncoder().encode(output)) ?? Data()
+            (try? JSONEncoder.new().encode(output)) ?? Data()
         }
         let sut = Tunnel(.global, strategy: strategy) { _ in
             SharedTunnelEnvironment(profileId: nil)
         }
 
         let inputMessage = Message.Input.debugLog(sinceLast: 60.0, maxLevel: .debug)
-        let input = try JSONEncoder().encode(inputMessage)
+        let input = try JSONEncoder.new().encode(inputMessage)
         let expOutputMessage = try #require(try await sut.sendMessage(
             input,
             to: UniqueID() // unused
         ))
-        let expOutput = try JSONDecoder().decode(Message.Output.self, from: expOutputMessage)
+        let expOutput = try JSONDecoder.new().decode(Message.Output.self, from: expOutputMessage)
         #expect(expOutput == output)
     }
 }

--- a/Tests/PartoutCoreTests/SecureDataTests.swift
+++ b/Tests/PartoutCoreTests/SecureDataTests.swift
@@ -9,9 +9,9 @@ struct SecureDataTests {
     @Test
     func givenData_whenEncode_thenDecodes() throws {
         let sut = SecureData("123456")
-        let encoder = JSONEncoder()
+        let encoder = JSONEncoder.new()
         let data = try encoder.encode(sut)
-        let expected = try JSONDecoder().decode(SecureData.self, from: data)
+        let expected = try JSONDecoder.new().decode(SecureData.self, from: data)
         #expect(expected == sut)
     }
 }

--- a/Tests/PartoutCoreTests/SecureDataTests.swift
+++ b/Tests/PartoutCoreTests/SecureDataTests.swift
@@ -9,9 +9,9 @@ struct SecureDataTests {
     @Test
     func givenData_whenEncode_thenDecodes() throws {
         let sut = SecureData("123456")
-        let encoder = JSONEncoder.new()
+        let encoder = JSONEncoder.shared()
         let data = try encoder.encode(sut)
-        let expected = try JSONDecoder.new().decode(SecureData.self, from: data)
+        let expected = try JSONDecoder.shared().decode(SecureData.self, from: data)
         #expect(expected == sut)
     }
 }

--- a/Tests/PartoutCoreTests/SensitiveEncoderTests.swift
+++ b/Tests/PartoutCoreTests/SensitiveEncoderTests.swift
@@ -7,12 +7,12 @@ import Testing
 
 struct SensitiveEncoderTests {
     private let sut: JSONEncoder = {
-        let encoder = JSONEncoder.new()
+        let encoder = JSONEncoder.shared()
         encoder.userInfo = [.redactingSensitiveData: true]
         return encoder
     }()
 
-    private let decoder = JSONDecoder.new()
+    private let decoder = JSONDecoder.shared()
 
     @Test
     func givenSecureData_whenEncodeSensitive_thenIsRedacted() throws {

--- a/Tests/PartoutCoreTests/SensitiveEncoderTests.swift
+++ b/Tests/PartoutCoreTests/SensitiveEncoderTests.swift
@@ -7,12 +7,12 @@ import Testing
 
 struct SensitiveEncoderTests {
     private let sut: JSONEncoder = {
-        let encoder = JSONEncoder()
+        let encoder = JSONEncoder.new()
         encoder.userInfo = [.redactingSensitiveData: true]
         return encoder
     }()
 
-    private let decoder = JSONDecoder()
+    private let decoder = JSONDecoder.new()
 
     @Test
     func givenSecureData_whenEncodeSensitive_thenIsRedacted() throws {

--- a/Tests/PartoutOpenVPNTests/ObfuscationMethodTests.swift
+++ b/Tests/PartoutOpenVPNTests/ObfuscationMethodTests.swift
@@ -31,56 +31,56 @@ struct ObfuscationMethodTests {
     @Test
     func givenTaggedXormaskPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"xormask","mask":"AQID"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xormask(mask: SecureData(Data([1, 2, 3]))))
     }
 
     @Test
     func givenTaggedXorptrposPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"xorptrpos"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xorptrpos)
     }
 
     @Test
     func givenTaggedReversePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"reverse"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .reverse)
     }
 
     @Test
     func givenTaggedObfuscatePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"obfuscate","mask":"AQID"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .obfuscate(mask: SecureData(Data([1, 2, 3]))))
     }
 
     @Test
     func givenLegacyXormaskPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"xormask":{"mask":"AQID"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xormask(mask: SecureData(Data([1, 2, 3]))))
     }
 
     @Test
     func givenLegacyXorptrposPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"xorptrpos":{}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xorptrpos)
     }
 
     @Test
     func givenLegacyReversePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"reverse":{}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .reverse)
     }
 
     @Test
     func givenLegacyObfuscatePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"obfuscate":{"mask":"AQID"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .obfuscate(mask: SecureData(Data([1, 2, 3]))))
     }
 
@@ -88,7 +88,7 @@ struct ObfuscationMethodTests {
     func givenMalformedTaggedXormaskPayload_whenDecode_thenFailsWithoutLegacyFallback() {
         let data = #"{"type":"xormask"}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 
@@ -96,7 +96,7 @@ struct ObfuscationMethodTests {
     func givenMalformedLegacyXormaskPayload_whenDecode_thenFailsWithoutTryingOtherLegacyCases() {
         let data = #"{"xormask":{}}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 
@@ -104,7 +104,7 @@ struct ObfuscationMethodTests {
     func givenMalformedTaggedObfuscatePayload_whenDecode_thenFailsWithoutLegacyFallback() {
         let data = #"{"type":"obfuscate"}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 
@@ -112,15 +112,15 @@ struct ObfuscationMethodTests {
     func givenMalformedLegacyObfuscatePayload_whenDecode_thenFailsWithoutTryingOtherLegacyCases() {
         let data = #"{"obfuscate":{}}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 }
 
 private extension ObfuscationMethodTests {
     func assertRoundTrip(_ value: OpenVPN.ObfuscationMethod) throws {
-        let encoded = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(OpenVPN.ObfuscationMethod.self, from: encoded)
+        let encoded = try JSONEncoder.new().encode(value)
+        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: encoded)
         #expect(decoded == value)
     }
 }

--- a/Tests/PartoutOpenVPNTests/ObfuscationMethodTests.swift
+++ b/Tests/PartoutOpenVPNTests/ObfuscationMethodTests.swift
@@ -31,56 +31,56 @@ struct ObfuscationMethodTests {
     @Test
     func givenTaggedXormaskPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"xormask","mask":"AQID"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xormask(mask: SecureData(Data([1, 2, 3]))))
     }
 
     @Test
     func givenTaggedXorptrposPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"xorptrpos"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xorptrpos)
     }
 
     @Test
     func givenTaggedReversePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"reverse"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .reverse)
     }
 
     @Test
     func givenTaggedObfuscatePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"type":"obfuscate","mask":"AQID"}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .obfuscate(mask: SecureData(Data([1, 2, 3]))))
     }
 
     @Test
     func givenLegacyXormaskPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"xormask":{"mask":"AQID"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xormask(mask: SecureData(Data([1, 2, 3]))))
     }
 
     @Test
     func givenLegacyXorptrposPayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"xorptrpos":{}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .xorptrpos)
     }
 
     @Test
     func givenLegacyReversePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"reverse":{}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .reverse)
     }
 
     @Test
     func givenLegacyObfuscatePayload_whenDecode_thenRestoresValue() throws {
         let data = #"{"obfuscate":{"mask":"AQID"}}"#.data(using: .utf8)!
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         #expect(decoded == .obfuscate(mask: SecureData(Data([1, 2, 3]))))
     }
 
@@ -88,7 +88,7 @@ struct ObfuscationMethodTests {
     func givenMalformedTaggedXormaskPayload_whenDecode_thenFailsWithoutLegacyFallback() {
         let data = #"{"type":"xormask"}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 
@@ -96,7 +96,7 @@ struct ObfuscationMethodTests {
     func givenMalformedLegacyXormaskPayload_whenDecode_thenFailsWithoutTryingOtherLegacyCases() {
         let data = #"{"xormask":{}}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 
@@ -104,7 +104,7 @@ struct ObfuscationMethodTests {
     func givenMalformedTaggedObfuscatePayload_whenDecode_thenFailsWithoutLegacyFallback() {
         let data = #"{"type":"obfuscate"}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 
@@ -112,15 +112,15 @@ struct ObfuscationMethodTests {
     func givenMalformedLegacyObfuscatePayload_whenDecode_thenFailsWithoutTryingOtherLegacyCases() {
         let data = #"{"obfuscate":{}}"#.data(using: .utf8)!
         #expect(throws: Error.self) {
-            try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: data)
+            try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: data)
         }
     }
 }
 
 private extension ObfuscationMethodTests {
     func assertRoundTrip(_ value: OpenVPN.ObfuscationMethod) throws {
-        let encoded = try JSONEncoder.new().encode(value)
-        let decoded = try JSONDecoder.new().decode(OpenVPN.ObfuscationMethod.self, from: encoded)
+        let encoded = try JSONEncoder.shared().encode(value)
+        let decoded = try JSONDecoder.shared().decode(OpenVPN.ObfuscationMethod.self, from: encoded)
         #expect(decoded == value)
     }
 }

--- a/Tests/PartoutTests/CodingRegistryTests+Legacy.swift
+++ b/Tests/PartoutTests/CodingRegistryTests+Legacy.swift
@@ -87,9 +87,9 @@ private extension CodingRegistryLegacyTests {
             modules: modules,
             activeModulesIds: profile.activeModulesIds,
             behavior: profile.behavior,
-            userInfo: try profile.userInfo.map { try JSONEncoder.new().encode($0) }
+            userInfo: try profile.userInfo.map { try JSONEncoder.shared().encode($0) }
         )
-        let data = try JSONEncoder.new().encode(payload)
+        let data = try JSONEncoder.shared().encode(payload)
         let encoded = data.base64EncodedString()
         return LegacyProfileFixture(profile: profile, encoded: encoded)
     }

--- a/Tests/PartoutTests/CodingRegistryTests+Legacy.swift
+++ b/Tests/PartoutTests/CodingRegistryTests+Legacy.swift
@@ -87,9 +87,9 @@ private extension CodingRegistryLegacyTests {
             modules: modules,
             activeModulesIds: profile.activeModulesIds,
             behavior: profile.behavior,
-            userInfo: try profile.userInfo.map { try JSONEncoder().encode($0) }
+            userInfo: try profile.userInfo.map { try JSONEncoder.new().encode($0) }
         )
-        let data = try JSONEncoder().encode(payload)
+        let data = try JSONEncoder.new().encode(payload)
         let encoded = data.base64EncodedString()
         return LegacyProfileFixture(profile: profile, encoded: encoded)
     }

--- a/Tests/PartoutTests/TaggedModuleTests.swift
+++ b/Tests/PartoutTests/TaggedModuleTests.swift
@@ -40,7 +40,7 @@ private extension TaggedModuleTests {
     }
 
     func encoder(withLegacyEncoding: Bool) -> JSONEncoder {
-        let encoder = JSONEncoder()
+        let encoder = JSONEncoder.new()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
         encoder.userInfo = [.legacySwiftEncoding: withLegacyEncoding]
         return encoder

--- a/Tests/PartoutTests/TaggedModuleTests.swift
+++ b/Tests/PartoutTests/TaggedModuleTests.swift
@@ -40,7 +40,7 @@ private extension TaggedModuleTests {
     }
 
     func encoder(withLegacyEncoding: Bool) -> JSONEncoder {
-        let encoder = JSONEncoder.new()
+        let encoder = JSONEncoder.shared()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
         encoder.userInfo = [.legacySwiftEncoding: withLegacyEncoding]
         return encoder


### PR DESCRIPTION
Enforce a cross-platform encoding for dates by moving JSONEncoder/JSONDecoder instances to factory methods.

The change is serialization-safe because profiles do not use dates at the time being.