### PR TITLE
WireGuard: Fix DNS64 regression in v2

### DIFF
--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -8,17 +8,10 @@ internal import _PartoutCore_C
 public actor POSIXDNSStrategy: SimpleDNSStrategy {
     private let hostname: String
 
-    private let flags: Int32
-
     private var task: Task<[DNSRecord]?, Error>?
 
     public init(hostname: String) {
-        self.init(hostname: hostname, flags: 0)
-    }
-
-    public init(hostname: String, flags: Int32) {
         self.hostname = hostname
-        self.flags = flags
     }
 
     public func startResolution() async throws {
@@ -30,9 +23,8 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
             records = try await task.value
         } else {
             let hostname = self.hostname
-            let flags = self.flags
             let newTask = Task.detached { @Sendable in
-                try Self.resolveAndBlock(hostname: hostname, flags: flags)
+                try Self.resolveAndBlock(hostname: hostname)
             }
             task = newTask
             records = try await newTask.value
@@ -50,10 +42,11 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
 }
 
 private extension POSIXDNSStrategy {
-    static func resolveAndBlock(hostname: String, flags: Int32) throws -> [DNSRecord]? {
+    static func resolveAndBlock(hostname: String) throws -> [DNSRecord]? {
         let addr = hostname.cString(using: .utf8)
         var hints = addrinfo()
-        hints.ai_flags = flags
+        // We set this to ALL so that we get v4 addresses even on DNS64 networks
+        hints.ai_flags = AI_ALL
         hints.ai_family = AF_UNSPEC // IPv4/IPv6
         var infoPointer: UnsafeMutablePointer<addrinfo>?
         let result = getaddrinfo(addr, nil, &hints, &infoPointer)

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -8,10 +8,17 @@ internal import _PartoutCore_C
 public actor POSIXDNSStrategy: SimpleDNSStrategy {
     private let hostname: String
 
+    private let flags: Int32
+
     private var task: Task<[DNSRecord]?, Error>?
 
     public init(hostname: String) {
+        self.init(hostname: hostname, flags: 0)
+    }
+
+    public init(hostname: String, flags: Int32) {
         self.hostname = hostname
+        self.flags = flags
     }
 
     public func startResolution() async throws {
@@ -23,8 +30,9 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
             records = try await task.value
         } else {
             let hostname = self.hostname
+            let flags = self.flags
             let newTask = Task.detached { @Sendable in
-                try Self.resolveAndBlock(hostname: hostname)
+                try Self.resolveAndBlock(hostname: hostname, flags: flags)
             }
             task = newTask
             records = try await newTask.value
@@ -42,9 +50,10 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
 }
 
 private extension POSIXDNSStrategy {
-    static func resolveAndBlock(hostname: String) throws -> [DNSRecord]? {
+    static func resolveAndBlock(hostname: String, flags: Int32) throws -> [DNSRecord]? {
         let addr = hostname.cString(using: .utf8)
         var hints = addrinfo()
+        hints.ai_flags = flags
         hints.ai_family = AF_UNSPEC // IPv4/IPv6
         var infoPointer: UnsafeMutablePointer<addrinfo>?
         let result = getaddrinfo(addr, nil, &hints, &infoPointer)

--- a/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
@@ -49,15 +49,32 @@ extension WireGuard.Configuration {
         timeout: Int,
         logHandler: @escaping WireGuardAdapter.LogHandler
     ) async throws -> [Endpoint: Endpoint] {
-        let endpoints = peers.compactMap(\.endpoint)
         let resolver = SimpleDNSResolver {
-            POSIXDNSStrategy(hostname: $0)
+            POSIXDNSStrategy(hostname: $0, flags: Self.dnsResolverFlags)
         }
+        return try await resolvePeers(
+            timeout: timeout,
+            logHandler: logHandler,
+            resolver: resolver
+        )
+    }
+
+    func resolvePeers(
+        timeout: Int,
+        logHandler: @escaping WireGuardAdapter.LogHandler,
+        resolver: DNSResolver
+    ) async throws -> [Endpoint: Endpoint] {
+        let endpoints = peers.compactMap(\.endpoint)
         return try await withThrowingTaskGroup(of: Void.self, returning: [Endpoint: Endpoint].self) { group in
             let allResolved = ResolvedMap()
             for endpoint in endpoints {
                 group.addTask { @Sendable in
                     do {
+                        if endpoint.address.isIPAddress {
+                            logHandler(.verbose, "DNS64: mapped \(endpoint.address) to itself.")
+                            await allResolved.setEndpoints([endpoint], for: endpoint)
+                            return
+                        }
                         let resolvedRecords = try await resolver.resolve(
                             endpoint.address.rawValue,
                             timeout: timeout
@@ -91,5 +108,13 @@ extension WireGuard.Configuration {
             }
             return await allResolved.toMap()
         }
+    }
+
+    private static var dnsResolverFlags: Int32 {
+#if canImport(Darwin)
+        AI_ALL
+#else
+        0
+#endif
     }
 }

--- a/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
@@ -53,16 +53,16 @@ extension WireGuard.Configuration {
             POSIXDNSStrategy(hostname: $0)
         }
         return try await resolvePeers(
+            resolver: resolver,
             timeout: timeout,
-            logHandler: logHandler,
-            resolver: resolver
+            logHandler: logHandler
         )
     }
 
     func resolvePeers(
+        resolver: DNSResolver,
         timeout: Int,
-        logHandler: @escaping WireGuardAdapter.LogHandler,
-        resolver: DNSResolver
+        logHandler: @escaping WireGuardAdapter.LogHandler
     ) async throws -> [Endpoint: Endpoint] {
         let endpoints = peers.compactMap(\.endpoint)
         return try await withThrowingTaskGroup(of: Void.self, returning: [Endpoint: Endpoint].self) { group in

--- a/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
@@ -111,10 +111,6 @@ extension WireGuard.Configuration {
     }
 
     private static var dnsResolverFlags: Int32 {
-#if canImport(Darwin)
         AI_ALL
-#else
-        0
-#endif
     }
 }

--- a/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
@@ -50,7 +50,7 @@ extension WireGuard.Configuration {
         logHandler: @escaping WireGuardAdapter.LogHandler
     ) async throws -> [Endpoint: Endpoint] {
         let resolver = SimpleDNSResolver {
-            POSIXDNSStrategy(hostname: $0, flags: Self.dnsResolverFlags)
+            POSIXDNSStrategy(hostname: $0)
         }
         return try await resolvePeers(
             timeout: timeout,
@@ -108,9 +108,5 @@ extension WireGuard.Configuration {
             }
             return await allResolved.toMap()
         }
-    }
-
-    private static var dnsResolverFlags: Int32 {
-        AI_ALL
     }
 }

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -47,6 +47,48 @@ struct TunnelRemoteInfoGeneratorTests {
     }
 
     @Test
+    func givenIPAddressEndpoint_whenResolved_thenBypassesDNS64Cache() async throws {
+        let sourceEndpoint = try Endpoint("77.160.28.16", 51830)
+        let configuration = try makeConfiguration(endpoint: sourceEndpoint.rawValue)
+        let dns = RecordingDNSResolver()
+        await dns.setResolvedRecords([
+            DNSRecord(address: "64:ff9b::4da0:1c10", isIPv6: true)
+        ], for: sourceEndpoint.address.rawValue)
+
+        let map = try await configuration.resolvePeers(
+            timeout: 1000,
+            logHandler: { _, _ in },
+            resolver: dns
+        )
+
+        #expect(map[sourceEndpoint] == sourceEndpoint)
+        let requestedHostnames = await dns.requestedHostnames
+        #expect(requestedHostnames.isEmpty)
+    }
+
+    @Test
+    func givenHostnameEndpointWithDNS64AndIPv4_whenResolved_thenCachesIPv4BaseAddress() async throws {
+        let sourceEndpoint = try Endpoint("foobar.com", 51830)
+        let ipv4Endpoint = try Endpoint("77.160.28.16", sourceEndpoint.port)
+        let configuration = try makeConfiguration(endpoint: sourceEndpoint.rawValue)
+        let dns = RecordingDNSResolver()
+        await dns.setResolvedRecords([
+            DNSRecord(address: "64:ff9b::4da0:1c10", isIPv6: true),
+            DNSRecord(address: ipv4Endpoint.address.rawValue, isIPv6: false)
+        ], for: sourceEndpoint.address.rawValue)
+
+        let map = try await configuration.resolvePeers(
+            timeout: 1000,
+            logHandler: { _, _ in },
+            resolver: dns
+        )
+
+        #expect(map[sourceEndpoint] == ipv4Endpoint)
+        let requestedHostnames = await dns.requestedHostnames
+        #expect(requestedHostnames == [sourceEndpoint.address.rawValue])
+    }
+
+    @Test
     func givenCachedResolution_whenGeneratingEndpointUpdate_thenDoesNotResolveAgainUntilReset() async throws {
         let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
         let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
@@ -135,6 +177,37 @@ struct TunnelRemoteInfoGeneratorTests {
         #expect(ipModule.ipv4?.includedRoutes.first?.gateway?.rawValue == "10.0.0.2")
         #expect(ipModule.ipv6?.includedRoutes.first?.destination?.rawValue == "fd00::/64")
         #expect(ipModule.ipv6?.includedRoutes.first?.gateway?.rawValue == "fd00::2")
+    }
+}
+
+private func makeConfiguration(endpoint: String) throws -> WireGuard.Configuration {
+    let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
+    let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
+
+    var builder = WireGuard.Configuration.Builder(privateKey: pvtkey)
+    var peer = WireGuard.RemoteInterface.Builder(publicKey: pubkey)
+    peer.endpoint = endpoint
+    peer.allowedIPs = ["0.0.0.0/0"]
+    builder.peers = [peer]
+    return try builder.build()
+}
+
+private actor RecordingDNSResolver: DNSResolver {
+    private var resolvedRecords: [String: [DNSRecord]] = [:]
+
+    private var hostnames: [String] = []
+
+    func setResolvedRecords(_ records: [DNSRecord], for hostname: String) {
+        resolvedRecords[hostname] = records
+    }
+
+    func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord] {
+        hostnames.append(hostname)
+        return resolvedRecords[hostname] ?? []
+    }
+
+    var requestedHostnames: [String] {
+        hostnames
     }
 }
 

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -56,9 +56,9 @@ struct TunnelRemoteInfoGeneratorTests {
         ], for: sourceEndpoint.address.rawValue)
 
         let map = try await configuration.resolvePeers(
+            resolver: dns,
             timeout: 1000,
-            logHandler: { _, _ in },
-            resolver: dns
+            logHandler: { _, _ in }
         )
 
         #expect(map[sourceEndpoint] == sourceEndpoint)
@@ -78,9 +78,9 @@ struct TunnelRemoteInfoGeneratorTests {
         ], for: sourceEndpoint.address.rawValue)
 
         let map = try await configuration.resolvePeers(
+            resolver: dns,
             timeout: 1000,
-            logHandler: { _, _ in },
-            resolver: dns
+            logHandler: { _, _ in }
         )
 
         #expect(map[sourceEndpoint] == ipv4Endpoint)


### PR DESCRIPTION
`AI_ALL` was lost in the translation, and it's required to get IPv4 addresses in DNS64 networks.

Concern raised here: https://github.com/partout-io/passepartout/issues/1809