### PR TITLE
Core: Restrict AI_ALL to Apple platforms

### DIFF
--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -45,8 +45,11 @@ private extension POSIXDNSStrategy {
     static func resolveAndBlock(hostname: String) throws -> [DNSRecord]? {
         let addr = hostname.cString(using: .utf8)
         var hints = addrinfo()
+#if canImport(Darwin)
         // We set this to ALL so that we get v4 addresses even on DNS64 networks
+        // However, DNS breaks on Android when AI_ALL + AF_UNSPEC is set
         hints.ai_flags = AI_ALL
+#endif
         hints.ai_family = AF_UNSPEC // IPv4/IPv6
         var infoPointer: UnsafeMutablePointer<addrinfo>?
         let result = getaddrinfo(addr, nil, &hints, &infoPointer)

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -53,7 +53,13 @@ private extension POSIXDNSStrategy {
         hints.ai_family = AF_UNSPEC // IPv4/IPv6
         var infoPointer: UnsafeMutablePointer<addrinfo>?
         let result = getaddrinfo(addr, nil, &hints, &infoPointer)
-        if result != 0 {
+        guard result == 0 else {
+            switch result {
+            case EAI_BADFLAGS:
+                pp_log_g(.core, .fault, "getaddrinfo() failed with bad flags")
+            default:
+                pp_log_g(.core, .fault, "getaddrinfo() failed with result \(result)")
+            }
             throw PartoutError(.dnsFailure)
         }
 


### PR DESCRIPTION
`AI_ALL` is rejected with `EAI_BADFLAGS` on Android, causing `getaddrinfo()` to fail systematically. On other platforms, the `AF_UNSPEC` / `AI_ALL` combination should not fail, but its behavior is undefined at most.

See #391 