### PR TITLE
Android: Observe service events with BroadcastReceiver

### DIFF
--- a/cross/android/io/partout/jni/PartoutTunnel.kt
+++ b/cross/android/io/partout/jni/PartoutTunnel.kt
@@ -37,7 +37,7 @@ class PartoutTunnel(
             .launchIn(scope)
     }
 
-    // JNI
+    // Swift -> JNI
     fun connect(profileJSON: String, ctx: Long, completion: Long) {
         val profile = json.decodeFromString<TaggedProfile>(profileJSON)
         connect(profile) { code ->
@@ -45,14 +45,14 @@ class PartoutTunnel(
         }
     }
 
-    // JNI
+    // Swift -> JNI
     fun disconnect(ctx: Long, completion: Long) {
         disconnect { code ->
             callback(ctx, completion, code)
         }
     }
 
-    // JNI
+    // JNI -> Swift
     private external fun submitSnapshots(snapshots: String)
     private external fun callback(ctx: Long, completion: Long, errorCode: Int)
 

--- a/cross/android/io/partout/jni/PartoutTunnel.kt
+++ b/cross/android/io/partout/jni/PartoutTunnel.kt
@@ -4,37 +4,41 @@
 
 package io.partout.jni
 
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.net.VpnService
 import androidx.core.content.ContextCompat
 import io.partout.abi.TaggedProfile
-import io.partout.abi.TunnelSnapshot
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import java.io.Closeable
 import kotlinx.serialization.json.Json
 
 class PartoutTunnel(
     context: Context,
     private val vpnServiceClass: Class<out VpnService>,
-    private val channel: PartoutVpnServiceRuntime.Channel,
     private val requestVpnPermission: (Intent) -> Unit,
-    private val coroutineScope: CoroutineScope
-) {
+) : Closeable {
     private val appContext = context.applicationContext
     private var pendingPermission: PendingPermission? = null
-    private val scope = CoroutineScope(
-        coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job])
-    )
+    private val snapshotsReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != PartoutVpnServiceRuntime.ACTION_SNAPSHOTS) {
+                return
+            }
+            intent.getStringExtra(PartoutVpnServiceRuntime.EXTRA_SNAPSHOTS_JSON)?.let {
+                submitSnapshots(it)
+            }
+        }
+    }
 
     init {
-        channel
-            .activeSnapshot
-            .onEach(::onSnapshot)
-            .launchIn(scope)
+        ContextCompat.registerReceiver(
+            appContext,
+            snapshotsReceiver,
+            IntentFilter(PartoutVpnServiceRuntime.ACTION_SNAPSHOTS),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
     }
 
     // Swift -> JNI
@@ -55,16 +59,6 @@ class PartoutTunnel(
     // JNI -> Swift
     private external fun submitSnapshots(snapshots: String)
     private external fun callback(ctx: Long, completion: Long, errorCode: Int)
-
-    fun onSnapshot(snapshot: TunnelSnapshot?) {
-        val snapshots: Map<String, TunnelSnapshot> = if (snapshot == null || !snapshot.isEnabled) {
-            emptyMap()
-        } else {
-            mapOf(Pair(snapshot.id, snapshot))
-        }
-        val json = json.encodeToString(snapshots)
-        submitSnapshots(json)
-    }
 
     fun onVpnPermissionResult(granted: Boolean) {
         val permission = pendingPermission ?: return
@@ -111,6 +105,10 @@ class PartoutTunnel(
             }
         }
         ContextCompat.startForegroundService(appContext, stopIntent)
+    }
+
+    override fun close() {
+        appContext.unregisterReceiver(snapshotsReceiver)
     }
 
     companion object {

--- a/cross/android/io/partout/jni/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/jni/PartoutVpnServiceRuntime.kt
@@ -5,6 +5,7 @@
 package io.partout.jni
 
 import android.app.Service
+import android.content.Context
 import android.content.Intent
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
@@ -23,9 +24,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -239,28 +237,37 @@ class PartoutVpnServiceRuntime(
         val payload: String?
     )
 
-    class Channel {
-        private val _activeSnapshot = MutableStateFlow<TunnelSnapshot?>(null)
-
-        val activeSnapshot: StateFlow<TunnelSnapshot?> = _activeSnapshot.asStateFlow()
-
+    class Channel(private val context: Context) {
         @Volatile
         private var enabledProfileId: String? = null
 
         internal fun setEnabledProfile(profileId: String?) {
             enabledProfileId = profileId
             if (profileId == null) {
-                _activeSnapshot.value = null
+                sendSnapshot(null)
             }
         }
 
         internal fun updateStatus(event: OnConnectionStatus) {
-            _activeSnapshot.value = TunnelSnapshot(
+            sendSnapshot(TunnelSnapshot(
                 id = event.profileId,
                 isEnabled = enabledProfileId == event.profileId,
                 onDemand = false,
                 status = event.status.toTunnelStatus()
-            )
+            ))
+        }
+
+        private fun sendSnapshot(snapshot: TunnelSnapshot?) {
+            val snapshots = if (snapshot == null || !snapshot.isEnabled) {
+                emptyMap()
+            } else {
+                mapOf(snapshot.id to snapshot)
+            }
+            val intent = Intent(ACTION_SNAPSHOTS).apply {
+                setPackage(context.packageName)
+                putExtra(EXTRA_SNAPSHOTS_JSON, json.encodeToString(snapshots))
+            }
+            context.sendBroadcast(intent)
         }
 
         private fun ConnectionStatus.toTunnelStatus(): TunnelStatus = when (this) {
@@ -273,8 +280,10 @@ class PartoutVpnServiceRuntime(
 
     companion object {
         const val ACTION_STOP_VPN = "io.partout.jni.action.STOP_VPN"
+        const val ACTION_SNAPSHOTS = "io.partout.jni.action.SNAPSHOTS"
         const val EXTRA_PROFILE_ID = "io.partout.jni.extra.PROFILE_ID"
         const val EXTRA_PROFILE_JSON = "io.partout.jni.extra.PROFILE_JSON"
+        const val EXTRA_SNAPSHOTS_JSON = "io.partout.jni.extra.SNAPSHOTS_JSON"
 
         private val json = Json {
             ignoreUnknownKeys = true

--- a/cross/android/io/partout/jni/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/jni/PartoutVpnServiceRuntime.kt
@@ -45,6 +45,7 @@ class PartoutVpnServiceRuntime(
     private var isRunning = false
     private var profileId: String? = null
 
+    @Suppress("UNUSED_PARAMETER")
     fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_STOP_VPN) {
             disconnect()


### PR DESCRIPTION
The static channel/flow method only worked when UI and service lived in the same process. The BroadcastReceiver approach allows the service to run in a separate process, thus outliving a crash in the UI.