### PR TITLE
Core: Fix slow tun shutdown

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -85,7 +85,11 @@ public final class NativeTunnelController: TunnelController {
         await tunnel.shutdown()
 
         // Release tun implementation if necessary
-        pp_tun_ctrl_clear_tunnel(ref, tunnel.tun)
+        let controllerRef = ref
+        Task.detached { [tunnel] in
+            await tunnel.waitUntilIdle()
+            pp_tun_ctrl_clear_tunnel(controllerRef, tunnel.tun)
+        }
     }
 
     public func setReasserting(_ reasserting: Bool) {

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -83,6 +83,10 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         continuation.resume(throwing: PartoutError(.releasedObject))
                         return
                     }
+                    guard self.isActive else {
+                        continuation.resume(throwing: PartoutError(.tunNotActive))
+                        return
+                    }
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
                     guard readCount > 0 else {
                         continuation.resume(throwing: PartoutError(.linkFailure))
@@ -113,8 +117,16 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         continuation.resume(throwing: PartoutError(.releasedObject))
                         return
                     }
+                    guard self.isActive else {
+                        continuation.resume(throwing: PartoutError(.tunNotActive))
+                        return
+                    }
                     for toWrite in packets {
                         guard !toWrite.isEmpty else { continue }
+                        guard self.isActive else {
+                            continuation.resume(throwing: PartoutError(.tunNotActive))
+                            return
+                        }
                         let writtenCount = toWrite.withUnsafeBytes {
                             pp_tun_write(self.tun, $0.bytePointer, toWrite.count)
                         }
@@ -145,6 +157,9 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         guard shouldShutdown else { return }
         pp_log(ctx, .core, .info, "Shut down TUN")
         pp_tun_shutdown(tun)
+    }
+
+    func waitUntilIdle() async {
         await readQueue.waitUntilIdle()
         await writeQueue.waitUntilIdle()
     }


### PR DESCRIPTION
Perform the wait to not release an active pp_tun instance prematurely, but defer the wait in a detached Task.