### PR TITLE
Core: Fix daemon status reporting

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -97,7 +97,13 @@ public final class NativeTunnelController: TunnelController {
     }
 
     public func cancelTunnelConnection(with error: Error?) {
-        // Do nothing
+        guard let error else {
+            pp_tun_ctrl_cancel_tunnel(ref, nil)
+            return
+        }
+        String(describing: error).withCString {
+            pp_tun_ctrl_cancel_tunnel(ref, $0)
+        }
     }
 }
 

--- a/Sources/PartoutCore/Connection/ConnectionParameters.swift
+++ b/Sources/PartoutCore/Connection/ConnectionParameters.swift
@@ -17,11 +17,14 @@ public final class ConnectionParameters: Sendable {
     /// The ``ReachabilityObserver`` to observe network events.
     public let reachability: ReachabilityObserver
 
-    /// The ``TunnelEnvironment`` where to store shared values.
+    /// The ``TunnelEnvironment`` backing the connection state.
     public let environment: TunnelEnvironment
 
     /// The ``ConnectionParameters/Options-swift.struct`` to fine-tune (re)connection behavior.
     public let options: Options
+
+    /// The ``ConnectionReporter`` where connections can report to.
+    public let reporter: ConnectionReporter
 
     public init(
         profile: Profile,
@@ -37,6 +40,46 @@ public final class ConnectionParameters: Sendable {
         self.reachability = reachability
         self.environment = environment
         self.options = options
+        reporter = ConnectionReporter(.init(profile.id), environment: environment)
+    }
+}
+
+/// Reports connection-originated values without exposing the whole tunnel environment to connections.
+public final class ConnectionReporter: Sendable {
+    private let ctx: PartoutLoggerContext
+    private let environment: TunnelEnvironment
+
+    public init(_ ctx: PartoutLoggerContext, environment: TunnelEnvironment) {
+        self.ctx = ctx
+        self.environment = environment
+    }
+
+    deinit {
+        pp_log(ctx, .core, .debug, "Deinit ConnectionReporter")
+    }
+
+    public func reportDataCount(_ dataCount: DataCount) {
+        reportEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
+    }
+
+    public func clearDataCount() {
+        clearEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
+    }
+
+    public func reportEnvironmentValue<T>(_ value: T, forKey key: TunnelEnvironmentKey<T>) where T: Encodable {
+        environment.setEnvironmentValue(value, forKey: key)
+    }
+
+    public func clearEnvironmentValue<T>(forKey key: TunnelEnvironmentKey<T>) {
+        environment.removeEnvironmentValue(forKey: key)
+    }
+
+    public func reportLastError(_ error: Error) {
+        reportLastErrorCode(error.partoutErrorCode)
+    }
+
+    public func reportLastErrorCode(_ code: PartoutError.Code) {
+        reportEnvironmentValue(code, forKey: TunnelEnvironmentKeys.lastErrorCode)
     }
 }
 

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -32,8 +32,6 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let snapshotInterval: Int
 
-    private let minDataCountDelta: UInt64
-
     private var onSnapshot: OnTunnelSnapshotCallback?
 
     private var connection: Connection?
@@ -62,8 +60,6 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private var snapshotSubscription: Task<Void, Never>?
 
-    private var lastPublishedSnapshot: TunnelSnapshot?
-
     // MARK: Testing
 
     private var testEvaluateConnection: (() -> Void)?
@@ -83,7 +79,6 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         stopDelay = params.stopDelay
         reconnectionDelay = params.reconnectionDelay
         snapshotInterval = params.snapshotInterval
-        minDataCountDelta = params.minDataCountDelta
         onSnapshot = params.onSnapshot
 
         state = .initial
@@ -441,15 +436,15 @@ extension SimpleConnectionDaemon {
 
     func reportLastError(_ error: Error) {
         reporter.reportLastError(error)
-        publishSnapshot(force: true)
+        publishSnapshot()
     }
 
     func reportStatus(_ status: ConnectionStatus) {
         statusSubject.send(status)
-        publishSnapshot(with: status, force: true)
+        publishSnapshot(with: status)
     }
 
-    func publishSnapshot(with latestConnectionStatus: ConnectionStatus? = nil, force: Bool = false) {
+    func publishSnapshot(with latestConnectionStatus: ConnectionStatus? = nil) {
         let connectionStatus = latestConnectionStatus ?? statusSubject.value
         let status = connectionStatus.toTunnelStatus
         let env = environment.snapshot.with(connectionStatus: connectionStatus)
@@ -460,24 +455,8 @@ extension SimpleConnectionDaemon {
             onDemand: false,
             environment: env
         )
-        guard shouldPublishSnapshot(snapshot, force: force) else {
-            return
-        }
-        lastPublishedSnapshot = snapshot
         controller.reportSnapshots([snapshot])
         onSnapshot?(snapshot)
-    }
-
-    func shouldPublishSnapshot(_ snapshot: TunnelSnapshot, force: Bool) -> Bool {
-        guard !force, minDataCountDelta > 0, let lastPublishedSnapshot else {
-            return true
-        }
-        guard snapshot.isEquivalentExceptDataCount(to: lastPublishedSnapshot) else {
-            return true
-        }
-        let dataCount = snapshot.environment?.dataCount ?? DataCount()
-        let lastDataCount = lastPublishedSnapshot.environment?.dataCount ?? DataCount()
-        return dataCount.delta(from: lastDataCount) >= minDataCountDelta
     }
 }
 
@@ -489,32 +468,6 @@ private extension ConnectionStatus {
         case .disconnecting: .deactivating
         case .disconnected: .inactive
         }
-    }
-}
-
-private extension TunnelSnapshot {
-    func isEquivalentExceptDataCount(to other: Self) -> Bool {
-        id == other.id &&
-        isEnabled == other.isEnabled &&
-        status == other.status &&
-        onDemand == other.onDemand &&
-        environment?.connectionStatus == other.environment?.connectionStatus &&
-        environment?.lastErrorCode == other.environment?.lastErrorCode
-    }
-}
-
-private extension DataCount {
-    func delta(from other: Self) -> UInt64 {
-        let receivedDelta = received.delta(from: other.received)
-        let sentDelta = sent.delta(from: other.sent)
-        let (sum, overflow) = receivedDelta.addingReportingOverflow(sentDelta)
-        return overflow ? UInt64.max : sum
-    }
-}
-
-private extension UInt64 {
-    func delta(from other: Self) -> Self {
-        self >= other ? self - other : other - self
     }
 }
 
@@ -536,8 +489,6 @@ extension SimpleConnectionDaemon {
 
         let snapshotInterval: Int
 
-        let minDataCountDelta: UInt64
-
         let onSnapshot: OnTunnelSnapshotCallback?
 
         public init(
@@ -548,7 +499,6 @@ extension SimpleConnectionDaemon {
             stopDelay: Int? = nil,
             reconnectionDelay: Int? = nil,
             snapshotInterval: Int? = nil,
-            minDataCountDelta: UInt64? = nil,
             onSnapshot: OnTunnelSnapshotCallback? = nil
         ) {
             self.connectionFactory = connectionFactory
@@ -558,7 +508,6 @@ extension SimpleConnectionDaemon {
             self.stopDelay = stopDelay ?? 2000
             self.reconnectionDelay = reconnectionDelay ?? 2000
             self.snapshotInterval = snapshotInterval ?? 1000
-            self.minDataCountDelta = minDataCountDelta ?? 0
             self.onSnapshot = onSnapshot
         }
     }

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -436,6 +436,7 @@ extension SimpleConnectionDaemon {
     func onConnectionError(_ error: Error) {
         reportLastError(error)
         controller.setReasserting(false)
+        controller.cancelTunnelConnection(with: error)
     }
 
     func reportLastError(_ error: Error) {

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -152,7 +152,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
             pp_log_id(profile.id, .core, .notice, "Daemon started successfully")
         } catch {
             pp_log_id(profile.id, .core, .fault, "Unable to start daemon: \(error)")
-            environment.setEnvironmentValue(PartoutError(error).code, forKey: TunnelEnvironmentKeys.lastErrorCode)
+            reportLastError(error)
             controller.setReasserting(false)
             controller.cancelTunnelConnection(with: error)
         }
@@ -372,7 +372,7 @@ extension SimpleConnectionDaemon {
             didStart = try await connection.start()
         } catch {
             pp_log_id(profile.id, .core, .error, "Unable to start connection: \(error)")
-            environment.setEnvironmentValue(PartoutError(error).code, forKey: TunnelEnvironmentKeys.lastErrorCode)
+            reportLastError(error)
             return
         }
 
@@ -426,8 +426,13 @@ extension SimpleConnectionDaemon {
     }
 
     func onConnectionError(_ error: Error) {
-        environment.setEnvironmentValue(PartoutError(error).code, forKey: TunnelEnvironmentKeys.lastErrorCode)
+        reportLastError(error)
         controller.setReasserting(false)
+    }
+
+    func reportLastError(_ error: Error) {
+        environment.setEnvironmentValue(error.partoutErrorCode, forKey: TunnelEnvironmentKeys.lastErrorCode)
+        publishSnapshot()
     }
 
     func reportStatus(_ status: ConnectionStatus) {

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -32,6 +32,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let snapshotInterval: Int
 
+    private let minDataCountDelta: UInt64
+
     private var onSnapshot: OnTunnelSnapshotCallback?
 
     private var connection: Connection?
@@ -60,6 +62,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private var snapshotSubscription: Task<Void, Never>?
 
+    private var lastPublishedSnapshot: TunnelSnapshot?
+
     // MARK: Testing
 
     private var testEvaluateConnection: (() -> Void)?
@@ -79,6 +83,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         stopDelay = params.stopDelay
         reconnectionDelay = params.reconnectionDelay
         snapshotInterval = params.snapshotInterval
+        minDataCountDelta = params.minDataCountDelta
         onSnapshot = params.onSnapshot
 
         state = .initial
@@ -435,15 +440,15 @@ extension SimpleConnectionDaemon {
 
     func reportLastError(_ error: Error) {
         reporter.reportLastError(error)
-        publishSnapshot()
+        publishSnapshot(force: true)
     }
 
     func reportStatus(_ status: ConnectionStatus) {
         statusSubject.send(status)
-        publishSnapshot(with: status)
+        publishSnapshot(with: status, force: true)
     }
 
-    func publishSnapshot(with latestConnectionStatus: ConnectionStatus? = nil) {
+    func publishSnapshot(with latestConnectionStatus: ConnectionStatus? = nil, force: Bool = false) {
         let connectionStatus = latestConnectionStatus ?? statusSubject.value
         let status = connectionStatus.toTunnelStatus
         let env = environment.snapshot.with(connectionStatus: connectionStatus)
@@ -454,8 +459,24 @@ extension SimpleConnectionDaemon {
             onDemand: false,
             environment: env
         )
+        guard shouldPublishSnapshot(snapshot, force: force) else {
+            return
+        }
+        lastPublishedSnapshot = snapshot
         controller.reportSnapshots([snapshot])
         onSnapshot?(snapshot)
+    }
+
+    func shouldPublishSnapshot(_ snapshot: TunnelSnapshot, force: Bool) -> Bool {
+        guard !force, minDataCountDelta > 0, let lastPublishedSnapshot else {
+            return true
+        }
+        guard snapshot.isEquivalentExceptDataCount(to: lastPublishedSnapshot) else {
+            return true
+        }
+        let dataCount = snapshot.environment?.dataCount ?? DataCount()
+        let lastDataCount = lastPublishedSnapshot.environment?.dataCount ?? DataCount()
+        return dataCount.delta(from: lastDataCount) >= minDataCountDelta
     }
 }
 
@@ -467,6 +488,32 @@ private extension ConnectionStatus {
         case .disconnecting: .deactivating
         case .disconnected: .inactive
         }
+    }
+}
+
+private extension TunnelSnapshot {
+    func isEquivalentExceptDataCount(to other: Self) -> Bool {
+        id == other.id &&
+        isEnabled == other.isEnabled &&
+        status == other.status &&
+        onDemand == other.onDemand &&
+        environment?.connectionStatus == other.environment?.connectionStatus &&
+        environment?.lastErrorCode == other.environment?.lastErrorCode
+    }
+}
+
+private extension DataCount {
+    func delta(from other: Self) -> UInt64 {
+        let receivedDelta = received.delta(from: other.received)
+        let sentDelta = sent.delta(from: other.sent)
+        let (sum, overflow) = receivedDelta.addingReportingOverflow(sentDelta)
+        return overflow ? UInt64.max : sum
+    }
+}
+
+private extension UInt64 {
+    func delta(from other: Self) -> Self {
+        self >= other ? self - other : other - self
     }
 }
 
@@ -488,6 +535,8 @@ extension SimpleConnectionDaemon {
 
         let snapshotInterval: Int
 
+        let minDataCountDelta: UInt64
+
         let onSnapshot: OnTunnelSnapshotCallback?
 
         public init(
@@ -498,6 +547,7 @@ extension SimpleConnectionDaemon {
             stopDelay: Int? = nil,
             reconnectionDelay: Int? = nil,
             snapshotInterval: Int? = nil,
+            minDataCountDelta: UInt64? = nil,
             onSnapshot: OnTunnelSnapshotCallback? = nil
         ) {
             self.connectionFactory = connectionFactory
@@ -507,6 +557,7 @@ extension SimpleConnectionDaemon {
             self.stopDelay = stopDelay ?? 2000
             self.reconnectionDelay = reconnectionDelay ?? 2000
             self.snapshotInterval = snapshotInterval ?? 1000
+            self.minDataCountDelta = minDataCountDelta ?? 0
             self.onSnapshot = onSnapshot
         }
     }

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -44,6 +44,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let statusSubject: CurrentValueStream<ConnectionStatus>
 
+    private let reporter: ConnectionReporter
+
     private var isEvaluatingConnection: Bool
 
     private var onHold: Bool
@@ -81,6 +83,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
         state = .initial
         statusSubject = CurrentValueStream(.disconnected)
+        reporter = params.connectionParameters.reporter
         isEvaluatingConnection = false
         onHold = false
 
@@ -431,7 +434,7 @@ extension SimpleConnectionDaemon {
     }
 
     func reportLastError(_ error: Error) {
-        environment.setEnvironmentValue(error.partoutErrorCode, forKey: TunnelEnvironmentKeys.lastErrorCode)
+        reporter.reportLastError(error)
         publishSnapshot()
     }
 

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -16,6 +16,7 @@ Given the main app and the daemon:
 ### Starting a background service
 
 - ``ConnectionDaemon``
+- ``ConnectionReporter``
 - ``DefaultMessageHandler``
 - ``DummyReachabilityObserver``
 - ``MessageHandler``

--- a/Sources/PartoutCore/PartoutError.swift
+++ b/Sources/PartoutCore/PartoutError.swift
@@ -68,6 +68,19 @@ extension PartoutError: Equatable {
     }
 }
 
+extension Error {
+    public var partoutErrorCode: PartoutError.Code {
+        switch self {
+        case let pe as PartoutError:
+            return pe.code
+        case let me as PartoutErrorMappable:
+            return me.asPartoutError.code
+        default:
+            return .unhandled
+        }
+    }
+}
+
 // MARK: - Description
 
 extension PartoutError: CustomDebugStringConvertible {

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -36,3 +36,5 @@ void pp_tun_ctrl_report_snapshots(void *_Nullable ref,
                                   const char *_Nonnull snapshots_json);
 void pp_tun_ctrl_clear_tunnel(void *_Nullable ref,
                               pp_tun _Nullable tun_impl);
+void pp_tun_ctrl_cancel_tunnel(void *_Nullable ref,
+                               const char *_Nullable error_message);

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -95,6 +95,10 @@ static const kotlin_sig sig_ctrl_onSnapshots = {
     "onSnapshots",
     "(Ljava/lang/String;)V"
 };
+static const kotlin_sig sig_ctrl_cancelTunnel = {
+    "cancelTunnel",
+    "(Ljava/lang/String;)V"
+};
 
 void pp_tun_ctrl_test_working(void *jni_ref) {
     assert(jni_ref);
@@ -245,6 +249,41 @@ void pp_tun_ctrl_report_snapshots(void *_Nullable ref,
 
 cleanup:
     if (j_snapshots_json != NULL) (*env)->DeleteLocalRef(env, j_snapshots_json);
+    if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
+    JNI_DETACH(env);
+}
+
+void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
+    assert(jni_ref);
+    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_cancel_tunnel(%p)", jni_ref);
+
+    JNI_ATTACH_OR_RETURN_VOID(env);
+
+    jclass cls = NULL;
+    jmethodID method = NULL;
+    jstring j_error_message = NULL;
+
+    cls = (*env)->GetObjectClass(env, jni_ref);
+    if (cls == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_cancel_tunnel(), NULL cls");
+        goto cleanup;
+    }
+    method = (*env)->GetMethodID(env, cls, sig_ctrl_cancelTunnel.name, sig_ctrl_cancelTunnel.signature);
+    if (method == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_cancel_tunnel(), NULL method");
+        goto cleanup;
+    }
+    j_error_message = error_message ? (*env)->NewStringUTF(env, error_message) : NULL;
+    (*env)->CallVoidMethod(env, jni_ref, method, j_error_message);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_cancel_tunnel(), Kotlin exception");
+        goto cleanup;
+    }
+
+cleanup:
+    if (j_error_message != NULL) (*env)->DeleteLocalRef(env, j_error_message);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
     JNI_DETACH(env);
 }

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -181,4 +181,10 @@ void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_darwin: ctrl_clear_tunnel(%p)", ref);
 }
 
+void pp_tun_ctrl_cancel_tunnel(void *ref, const char *error_message) {
+    (void)ref;
+    (void)error_message;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_darwin: ctrl_cancel_tunnel(%p)", ref);
+}
+
 #endif

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -72,4 +72,10 @@ void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
     (void)tun_impl;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_clear_tunnel(%p)", ref);
 }
+
+void pp_tun_ctrl_cancel_tunnel(void *ref, const char *error_message) {
+    (void)ref;
+    (void)error_message;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_cancel_tunnel(%p)", ref);
+}
 #endif

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -120,4 +120,10 @@ void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: ctrl_clear_tunnel(%p)", ref);
 }
 
+void pp_tun_ctrl_cancel_tunnel(void *ref, const char *error_message) {
+    (void)ref;
+    (void)error_message;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: ctrl_cancel_tunnel(%p)", ref);
+}
+
 #endif

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -240,4 +240,10 @@ void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: ctrl_clear_tunnel(%p)", ref);
 }
 
+void pp_tun_ctrl_cancel_tunnel(void *ref, const char *error_message) {
+    (void)ref;
+    (void)error_message;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: ctrl_cancel_tunnel(%p)", ref);
+}
+
 #endif

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -27,7 +27,8 @@ public actor NEPTPForwarder {
         factoryOptions: NEInterfaceFactory.Options = .init(),
         connectionOptions: ConnectionParameters.Options = .init(),
         stopDelay: Int? = nil,
-        reconnectionDelay: Int? = nil
+        reconnectionDelay: Int? = nil,
+        minDataCountDelta: UInt64? = nil
     ) throws {
         guard let provider = controller.provider else {
             pp_log(ctx, .os, .info, "NEPTPForwarder: NEPacketTunnelProvider released")
@@ -51,7 +52,8 @@ public actor NEPTPForwarder {
             messageHandler: messageHandler,
             startsImmediately: true,
             stopDelay: stopDelay,
-            reconnectionDelay: reconnectionDelay
+            reconnectionDelay: reconnectionDelay,
+            minDataCountDelta: minDataCountDelta
         )
 
         self.ctx = ctx

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -35,7 +35,6 @@ public actor NEPTPForwarder {
         }
         let factory = NEInterfaceFactory(ctx, provider: provider, options: factoryOptions)
         let reachability = NEObservablePath(ctx)
-
         let connectionParameters = ConnectionParameters(
             profile: profile,
             controller: controller,

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -27,8 +27,7 @@ public actor NEPTPForwarder {
         factoryOptions: NEInterfaceFactory.Options = .init(),
         connectionOptions: ConnectionParameters.Options = .init(),
         stopDelay: Int? = nil,
-        reconnectionDelay: Int? = nil,
-        minDataCountDelta: UInt64? = nil
+        reconnectionDelay: Int? = nil
     ) throws {
         guard let provider = controller.provider else {
             pp_log(ctx, .os, .info, "NEPTPForwarder: NEPacketTunnelProvider released")
@@ -52,8 +51,7 @@ public actor NEPTPForwarder {
             messageHandler: messageHandler,
             startsImmediately: true,
             stopDelay: stopDelay,
-            reconnectionDelay: reconnectionDelay,
-            minDataCountDelta: minDataCountDelta
+            reconnectionDelay: reconnectionDelay
         )
 
         self.ctx = ctx

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionError+Mapping.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionError+Mapping.swift
@@ -15,7 +15,7 @@ extension OpenVPNSessionError: PartoutErrorMappable {
         case .negotiationTimeout, .pingTimeout, .writeTimeout:
             return .timeout
 
-        case .badCredentials:
+        case .badCredentials, .badCredentialsWithLocalOptions:
             return .authentication
 
         case .serverCompression:
@@ -47,6 +47,11 @@ extension OpenVPNSessionError: PartoutErrorMappable {
 
             default:
                 break
+            }
+
+        case .recoverable(let error):
+            if let error {
+                return error.partoutErrorCode
             }
 
         default:

--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
@@ -17,7 +17,7 @@ public actor _OpenVPNConnectionV1 {
 
     private let controller: TunnelController
 
-    private let environment: TunnelEnvironment
+    private let reporter: ConnectionReporter
 
     private let options: ConnectionParameters.Options
 
@@ -46,7 +46,7 @@ public actor _OpenVPNConnectionV1 {
         self.ctx = ctx
         moduleId = module.id
         controller = parameters.controller
-        environment = parameters.environment
+        reporter = parameters.reporter
         options = parameters.options
 
         guard let configuration = module.configuration else {
@@ -186,7 +186,7 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
         pp_log(ctx, .openvpn, .notice, "Remote options:")
         remoteOptions.print(ctx, isLocal: false)
 
-        environment.setEnvironmentValue(remoteOptions, forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+        reporter.reportEnvironmentValue(remoteOptions, forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
 
         let builder = NetworkSettingsBuilder(
             ctx,
@@ -242,10 +242,14 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
         }
 
         // If error is not recoverable, just fail
-        if let error, !error.isOpenVPNRecoverable {
-            pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
-            await backend.sendError(error)
-            return
+        if let error {
+            reporter.reportLastError(error)
+
+            guard error.isOpenVPNRecoverable else {
+                pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
+                await backend.sendError(error)
+                return
+            }
         }
 
         // Go back to the disconnected state (e.g. daemon will reconnect)
@@ -257,7 +261,7 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
             return
         }
         pp_log(ctx, .openvpn, .debug, "Updated data count: \(dataCount.debugDescription)")
-        environment.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
+        reporter.reportDataCount(dataCount)
     }
 }
 
@@ -310,8 +314,8 @@ private extension _OpenVPNConnectionV1 {
             break
 
         case .disconnected:
-            environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
-            environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+            reporter.clearDataCount()
+            reporter.clearEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
 
         default:
             break
@@ -319,8 +323,8 @@ private extension _OpenVPNConnectionV1 {
     }
 
     nonisolated func onError(_ connectionError: Error) {
-        environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
-        environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+        reporter.clearDataCount()
+        reporter.clearEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
     }
 }
 

--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
@@ -242,14 +242,10 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
         }
 
         // If error is not recoverable, just fail
-        if let error {
-            reporter.reportLastError(error)
-
-            guard error.isOpenVPNRecoverable else {
-                pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
-                await backend.sendError(error)
-                return
-            }
+        if let error, !error.isOpenVPNRecoverable {
+            pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
+            await backend.sendError(error)
+            return
         }
 
         // Go back to the disconnected state (e.g. daemon will reconnect)

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -318,7 +318,7 @@ private extension _OpenVPNConnectionV2 {
 
     func sendError(_ connectionError: Error) {
         pp_log(ctx, .core, .info, "Report link failure: \(connectionError)")
-        statusSubject.send(completion: .failure(connectionError))
+        statusSubject.send(.disconnected)
         onError(connectionError)
     }
 

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -230,11 +230,16 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
             return
         }
 
-        // If error is not recoverable, just fail
-        if let error, !error.isOpenVPNRecoverable {
-            pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
-            sendError(error)
-            return
+        // Store last error
+        if let error {
+            environment.setEnvironmentValue(error.partoutErrorCode, forKey: TunnelEnvironmentKeys.lastErrorCode)
+
+            // If error is not recoverable, just fail
+            guard error.isOpenVPNRecoverable else {
+                pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
+                sendError(error)
+                return
+            }
         }
 
         // Go back to the disconnected state (e.g. daemon will reconnect)

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -318,7 +318,7 @@ private extension _OpenVPNConnectionV2 {
 
     func sendError(_ connectionError: Error) {
         pp_log(ctx, .core, .info, "Report link failure: \(connectionError)")
-        statusSubject.send(.disconnected)
+        statusSubject.send(completion: .failure(connectionError))
         onError(connectionError)
     }
 

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -16,7 +16,7 @@ public actor _OpenVPNConnectionV2 {
 
     private let controller: TunnelController
 
-    private let environment: TunnelEnvironment
+    private let reporter: ConnectionReporter
 
     private let factory: NetworkInterfaceFactory
 
@@ -54,7 +54,7 @@ public actor _OpenVPNConnectionV2 {
         statusSubject = CurrentValueStream(.disconnected)
         moduleId = module.id
         controller = parameters.controller
-        environment = parameters.environment
+        reporter = parameters.reporter
         factory = parameters.factory
         options = parameters.options
 
@@ -175,7 +175,7 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
         pp_log(ctx, .openvpn, .notice, "Remote options:")
         remoteOptions.print(ctx, isLocal: false)
 
-        environment.setEnvironmentValue(remoteOptions, forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+        reporter.reportEnvironmentValue(remoteOptions, forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
 
         let builder = NetworkSettingsBuilder(
             ctx,
@@ -232,7 +232,7 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
 
         // Store last error
         if let error {
-            environment.setEnvironmentValue(error.partoutErrorCode, forKey: TunnelEnvironmentKeys.lastErrorCode)
+            reporter.reportLastError(error)
 
             // If error is not recoverable, just fail
             guard error.isOpenVPNRecoverable else {
@@ -251,7 +251,7 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
             return
         }
         pp_log(ctx, .openvpn, .debug, "Updated data count: \(dataCount.debugDescription)")
-        environment.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
+        reporter.reportDataCount(dataCount)
     }
 }
 
@@ -327,16 +327,16 @@ private extension _OpenVPNConnectionV2 {
         case .connected:
             break
         case .disconnected:
-            environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
-            environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+            reporter.clearDataCount()
+            reporter.clearEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
         default:
             break
         }
     }
 
     nonisolated func onError(_ connectionError: Error) {
-        environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.dataCount)
-        environment.removeEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
+        reporter.clearDataCount()
+        reporter.clearEnvironmentValue(forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
     }
 }
 

--- a/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
+++ b/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
@@ -25,7 +25,7 @@ public final class _WireGuardConnectionV1: Connection, @unchecked Sendable {
 
     private let controller: TunnelController
 
-    private let environment: TunnelEnvironment
+    private let reporter: ConnectionReporter
 
     private let tunnelConfiguration: TunnelConfiguration
 
@@ -50,7 +50,7 @@ public final class _WireGuardConnectionV1: Connection, @unchecked Sendable {
         statusSubject = CurrentValueStream(.disconnected)
         moduleId = module.id
         controller = parameters.controller
-        environment = parameters.environment
+        reporter = parameters.reporter
 
         guard let configuration = module.configuration else {
             throw PartoutError(.incompleteModule)
@@ -222,7 +222,7 @@ private extension _WireGuardConnectionV1 {
                   let dataCount = DataCount.from(wireGuardString: configurationString) else {
                 return
             }
-            self?.environment.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
+            self?.reporter.reportDataCount(dataCount)
         }
     }
 }

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -107,6 +107,7 @@ public actor _WireGuardConnectionV2: Connection {
             dataCountTimer?.cancel()
             dataCountTimer = nil
             self.adapter = nil
+            reporter.reportLastError(startError)
             statusSubject.send(.disconnected)
             throw startError
         }
@@ -146,6 +147,7 @@ extension _WireGuardConnectionV2: WireGuardAdapterDelegate {
             return tunnel
         } catch {
             pp_log(ctx, .wireguard, .error, "Unable to configure tunnel settings: \(error)")
+            reporter.reportLastError(error)
             statusSubject.send(.disconnected)
             throw error
         }

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -24,7 +24,7 @@ public actor _WireGuardConnectionV2: Connection {
 
     private let reachability: ReachabilityObserver
 
-    private let environment: TunnelEnvironment
+    private let reporter: ConnectionReporter
 
     private let dnsTimeout: Int
 
@@ -46,7 +46,7 @@ public actor _WireGuardConnectionV2: Connection {
         moduleId = module.id
         controller = parameters.controller
         reachability = parameters.reachability
-        environment = parameters.environment
+        reporter = parameters.reporter
         dnsTimeout = parameters.options.dnsTimeout
 
         guard let configuration = module.configuration else {
@@ -199,7 +199,7 @@ private extension _WireGuardConnectionV2 {
               let dataCount = DataCount.fromWireGuardString(configurationString) else {
             return
         }
-        environment.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
+        reporter.reportDataCount(dataCount)
     }
 }
 

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -63,7 +63,7 @@ struct SimpleConnectionDaemonTests {
     }
 
     @Test
-    func givenConnectionFailingToStart_whenStartDaemon_thenStarts() async throws {
+    func givenConnectionFailingToStart_whenStartDaemon_thenStartsAndPublishesLastErrorCode() async throws {
         var connectionModule = MockConnectionModule()
         connectionModule.options.startError = PartoutError(.dnsFailure)
         let profile = try Profile.Builder(
@@ -72,9 +72,19 @@ struct SimpleConnectionDaemonTests {
         ).build()
         #expect(profile.activeConnectionModule != nil)
 
-        let sut = try await newDaemon(with: profile)
+        let expLastError = Expectation()
+        let sut = try await newDaemon(
+            with: profile,
+            onSnapshot: { snapshot in
+                guard snapshot.environment?.lastErrorCode == .dnsFailure else { return }
+                Task {
+                    await expLastError.fulfill()
+                }
+            }
+        )
         do {
             try await sut.start()
+            try await expLastError.fulfillment(timeout: 500)
         } catch {
             #expect(Bool(false), error.localizedComment)
         }
@@ -113,6 +123,36 @@ struct SimpleConnectionDaemonTests {
         #expect(await stream.nextElement() == .disconnected)
         #expect(await stream.nextElement() == .connecting)
         #expect(await stream.nextElement() == .connected)
+    }
+
+    @Test
+    func givenStartedConnectionFailingAsynchronously_whenConnectionFails_thenPublishesLastErrorCode() async throws {
+        var connectionModule = MockConnectionModule()
+        connectionModule.options.failure = (50, PartoutError(.authentication))
+        let profile = try Profile.Builder(
+            modules: [connectionModule],
+            activeModulesIds: [connectionModule.id]
+        ).build()
+        #expect(profile.activeConnectionModule != nil)
+
+        let expLastError = Expectation()
+        let sut = try await newDaemon(
+            with: profile,
+            reconnectionDelay: 5000,
+            onSnapshot: { snapshot in
+                guard snapshot.environment?.lastErrorCode == .authentication else { return }
+                Task {
+                    await expLastError.fulfill()
+                }
+            }
+        )
+        let stream = sut.statusStream
+
+        try await sut.start()
+        #expect(await stream.nextElement() == .disconnected)
+        #expect(await stream.nextElement() == .connecting)
+        #expect(await stream.nextElement() == .connected)
+        try await expLastError.fulfillment(timeout: 500)
     }
 
     @Test
@@ -181,7 +221,8 @@ private extension SimpleConnectionDaemonTests {
         environment: TunnelEnvironment? = nil,
         onCancel: @escaping (Error?) -> Void = { _ in },
         stopDelay: Int = 1000,
-        reconnectionDelay: Int = 1000
+        reconnectionDelay: Int = 1000,
+        onSnapshot: OnTunnelSnapshotCallback? = nil
     ) async throws -> SimpleConnectionDaemon {
         let controller = MockTunnelController()
         controller.onCancelTunnelConnection = onCancel
@@ -200,7 +241,8 @@ private extension SimpleConnectionDaemonTests {
             messageHandler: DefaultMessageHandler(.global, environment: environment),
             startsImmediately: false,
             stopDelay: stopDelay,
-            reconnectionDelay: reconnectionDelay
+            reconnectionDelay: reconnectionDelay,
+            onSnapshot: onSnapshot
         ))
     }
 }

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -156,6 +156,36 @@ struct SimpleConnectionDaemonTests {
     }
 
     @Test
+    func givenStartedConnectionReportingRecoverableError_whenConnectionDisconnects_thenPublishesLastErrorCode() async throws {
+        var connectionModule = MockConnectionModule()
+        connectionModule.options.reportedError = (50, PartoutError(.timeout))
+        let profile = try Profile.Builder(
+            modules: [connectionModule],
+            activeModulesIds: [connectionModule.id]
+        ).build()
+        #expect(profile.activeConnectionModule != nil)
+
+        let expLastError = Expectation()
+        let sut = try await newDaemon(
+            with: profile,
+            reconnectionDelay: 5000,
+            onSnapshot: { snapshot in
+                guard snapshot.environment?.lastErrorCode == .timeout else { return }
+                Task {
+                    await expLastError.fulfill()
+                }
+            }
+        )
+        let stream = sut.statusStream
+
+        try await sut.start()
+        #expect(await stream.nextElement() == .disconnected)
+        #expect(await stream.nextElement() == .connecting)
+        #expect(await stream.nextElement() == .connected)
+        try await expLastError.fulfillment(timeout: 500)
+    }
+
+    @Test
     func givenStartedDaemon_whenStop_thenDisconnects() async throws {
         let connectionModule = MockConnectionModule()
         let profile = try Profile.Builder(
@@ -228,14 +258,16 @@ private extension SimpleConnectionDaemonTests {
         controller.onCancelTunnelConnection = onCancel
         let options = ConnectionParameters.Options()
         let environment = environment ?? SharedTunnelEnvironment(profileId: profile.id)
+        let reporter = ConnectionReporter(environment: environment)
         return try SimpleConnectionDaemon(params: .init(
             connectionFactory: MockConnectionFactory(),
+            environment: environment,
             connectionParameters: .init(
                 profile: profile,
                 controller: controller,
                 factory: MockNetworkInterfaceFactory(),
                 reachability: reachability,
-                environment: environment,
+                reporter: reporter,
                 options: options
             ),
             messageHandler: DefaultMessageHandler(.global, environment: environment),
@@ -283,7 +315,7 @@ private struct MockConnectionModule: ConnectionModule {
         if let creationError {
             throw creationError
         }
-        return MockConnection(options: options)
+        return MockConnection(options: options, reporter: parameters.reporter)
     }
 }
 
@@ -293,10 +325,14 @@ private final class MockConnection: Connection {
 
         var failure: (interval: Int, error: Error)?
 
+        var reportedError: (interval: Int, error: Error)?
+
         var shouldTimeout = false
     }
 
     let options: Options
+
+    let reporter: ConnectionReporter
 
     private let statusSubject = CurrentValueStream<ConnectionStatus>(.disconnected)
 
@@ -311,8 +347,9 @@ private final class MockConnection: Connection {
     nonisolated(unsafe)
     private var sleepTask: Task<Void, Never>?
 
-    init(options: Options) {
+    init(options: Options, reporter: ConnectionReporter) {
         self.options = options
+        self.reporter = reporter
     }
 
     func start() async throws -> Bool {
@@ -327,6 +364,13 @@ private final class MockConnection: Connection {
             Task {
                 try? await Task.sleep(milliseconds: failure.interval)
                 statusSubject.send(completion: .failure(failure.error))
+            }
+        }
+        if let reportedError = options.reportedError {
+            Task {
+                try? await Task.sleep(milliseconds: reportedError.interval)
+                reporter.reportLastError(reportedError.error)
+                statusSubject.send(.disconnected)
             }
         }
         return true

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -194,49 +194,6 @@ struct SimpleConnectionDaemonTests {
     }
 
     @Test
-    func givenStartedConnectionReportingSmallDataCountChanges_whenSnapshotTimerFires_thenSkipsSnapshotsBelowMinimumDelta() async throws {
-        var connectionModule = MockConnectionModule()
-        connectionModule.options.reportedDataCounts = [
-            (50, DataCount(40, 0)),
-            (110, DataCount(80, 0)),
-            (170, DataCount(140, 0))
-        ]
-        let profile = try Profile.Builder(
-            modules: [connectionModule],
-            activeModulesIds: [connectionModule.id]
-        ).build()
-        #expect(profile.activeConnectionModule != nil)
-
-        let recorder = SnapshotRecorder()
-        let expDataCount = Expectation()
-        let sut = try await newDaemon(
-            with: profile,
-            reconnectionDelay: 5000,
-            snapshotInterval: 30,
-            minDataCountDelta: 100,
-            onSnapshot: { snapshot in
-                Task {
-                    await recorder.append(snapshot)
-                    guard snapshot.environment?.dataCount == DataCount(140, 0) else { return }
-                    await expDataCount.fulfill()
-                }
-            }
-        )
-        let stream = sut.statusStream
-
-        try await sut.start()
-        #expect(await stream.nextElement() == .disconnected)
-        #expect(await stream.nextElement() == .connecting)
-        #expect(await stream.nextElement() == .connected)
-        try await expDataCount.fulfillment(timeout: 1000)
-
-        let dataCounts = await recorder.dataCounts.filter { $0 != DataCount() }
-        #expect(!dataCounts.contains(DataCount(40, 0)))
-        #expect(!dataCounts.contains(DataCount(80, 0)))
-        #expect(dataCounts.contains(DataCount(140, 0)))
-    }
-
-    @Test
     func givenStartedDaemon_whenStop_thenDisconnects() async throws {
         let connectionModule = MockConnectionModule()
         let profile = try Profile.Builder(
@@ -303,8 +260,6 @@ private extension SimpleConnectionDaemonTests {
         onCancel: @escaping (Error?) -> Void = { _ in },
         stopDelay: Int = 1000,
         reconnectionDelay: Int = 1000,
-        snapshotInterval: Int = 1000,
-        minDataCountDelta: UInt64 = 0,
         onSnapshot: OnTunnelSnapshotCallback? = nil
     ) async throws -> SimpleConnectionDaemon {
         let controller = MockTunnelController()
@@ -325,22 +280,8 @@ private extension SimpleConnectionDaemonTests {
             startsImmediately: false,
             stopDelay: stopDelay,
             reconnectionDelay: reconnectionDelay,
-            snapshotInterval: snapshotInterval,
-            minDataCountDelta: minDataCountDelta,
             onSnapshot: onSnapshot
         ))
-    }
-}
-
-private actor SnapshotRecorder {
-    private var snapshots: [TunnelSnapshot] = []
-
-    func append(_ snapshot: TunnelSnapshot) {
-        snapshots.append(snapshot)
-    }
-
-    var dataCounts: [DataCount] {
-        snapshots.compactMap { $0.environment?.dataCount }
     }
 }
 
@@ -392,8 +333,6 @@ private final class MockConnection: Connection {
 
         var reportedError: (interval: Int, error: Error)?
 
-        var reportedDataCounts: [(interval: Int, dataCount: DataCount)] = []
-
         var shouldTimeout = false
     }
 
@@ -438,12 +377,6 @@ private final class MockConnection: Connection {
                 try? await Task.sleep(milliseconds: reportedError.interval)
                 reporter.reportLastError(reportedError.error)
                 statusSubject.send(.disconnected)
-            }
-        }
-        for reportedDataCount in options.reportedDataCounts {
-            Task {
-                try? await Task.sleep(milliseconds: reportedDataCount.interval)
-                reporter.reportDataCount(reportedDataCount.dataCount)
             }
         }
         return true

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -258,16 +258,14 @@ private extension SimpleConnectionDaemonTests {
         controller.onCancelTunnelConnection = onCancel
         let options = ConnectionParameters.Options()
         let environment = environment ?? SharedTunnelEnvironment(profileId: profile.id)
-        let reporter = ConnectionReporter(environment: environment)
         return try SimpleConnectionDaemon(params: .init(
             connectionFactory: MockConnectionFactory(),
-            environment: environment,
             connectionParameters: .init(
                 profile: profile,
                 controller: controller,
                 factory: MockNetworkInterfaceFactory(),
                 reachability: reachability,
-                reporter: reporter,
+                environment: environment,
                 options: options
             ),
             messageHandler: DefaultMessageHandler(.global, environment: environment),

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -136,8 +136,15 @@ struct SimpleConnectionDaemonTests {
         #expect(profile.activeConnectionModule != nil)
 
         let expLastError = Expectation()
+        let expCancel = Expectation()
         let sut = try await newDaemon(
             with: profile,
+            onCancel: { error in
+                guard error?.partoutErrorCode == .authentication else { return }
+                Task {
+                    await expCancel.fulfill()
+                }
+            },
             reconnectionDelay: 5000,
             onSnapshot: { snapshot in
                 guard snapshot.environment?.lastErrorCode == .authentication else { return }
@@ -153,6 +160,7 @@ struct SimpleConnectionDaemonTests {
         #expect(await stream.nextElement() == .connecting)
         #expect(await stream.nextElement() == .connected)
         try await expLastError.fulfillment(timeout: 500)
+        try await expCancel.fulfillment(timeout: 500)
     }
 
     @Test

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -186,6 +186,49 @@ struct SimpleConnectionDaemonTests {
     }
 
     @Test
+    func givenStartedConnectionReportingSmallDataCountChanges_whenSnapshotTimerFires_thenSkipsSnapshotsBelowMinimumDelta() async throws {
+        var connectionModule = MockConnectionModule()
+        connectionModule.options.reportedDataCounts = [
+            (50, DataCount(40, 0)),
+            (110, DataCount(80, 0)),
+            (170, DataCount(140, 0))
+        ]
+        let profile = try Profile.Builder(
+            modules: [connectionModule],
+            activeModulesIds: [connectionModule.id]
+        ).build()
+        #expect(profile.activeConnectionModule != nil)
+
+        let recorder = SnapshotRecorder()
+        let expDataCount = Expectation()
+        let sut = try await newDaemon(
+            with: profile,
+            reconnectionDelay: 5000,
+            snapshotInterval: 30,
+            minDataCountDelta: 100,
+            onSnapshot: { snapshot in
+                Task {
+                    await recorder.append(snapshot)
+                    guard snapshot.environment?.dataCount == DataCount(140, 0) else { return }
+                    await expDataCount.fulfill()
+                }
+            }
+        )
+        let stream = sut.statusStream
+
+        try await sut.start()
+        #expect(await stream.nextElement() == .disconnected)
+        #expect(await stream.nextElement() == .connecting)
+        #expect(await stream.nextElement() == .connected)
+        try await expDataCount.fulfillment(timeout: 1000)
+
+        let dataCounts = await recorder.dataCounts.filter { $0 != DataCount() }
+        #expect(!dataCounts.contains(DataCount(40, 0)))
+        #expect(!dataCounts.contains(DataCount(80, 0)))
+        #expect(dataCounts.contains(DataCount(140, 0)))
+    }
+
+    @Test
     func givenStartedDaemon_whenStop_thenDisconnects() async throws {
         let connectionModule = MockConnectionModule()
         let profile = try Profile.Builder(
@@ -252,6 +295,8 @@ private extension SimpleConnectionDaemonTests {
         onCancel: @escaping (Error?) -> Void = { _ in },
         stopDelay: Int = 1000,
         reconnectionDelay: Int = 1000,
+        snapshotInterval: Int = 1000,
+        minDataCountDelta: UInt64 = 0,
         onSnapshot: OnTunnelSnapshotCallback? = nil
     ) async throws -> SimpleConnectionDaemon {
         let controller = MockTunnelController()
@@ -272,8 +317,22 @@ private extension SimpleConnectionDaemonTests {
             startsImmediately: false,
             stopDelay: stopDelay,
             reconnectionDelay: reconnectionDelay,
+            snapshotInterval: snapshotInterval,
+            minDataCountDelta: minDataCountDelta,
             onSnapshot: onSnapshot
         ))
+    }
+}
+
+private actor SnapshotRecorder {
+    private var snapshots: [TunnelSnapshot] = []
+
+    func append(_ snapshot: TunnelSnapshot) {
+        snapshots.append(snapshot)
+    }
+
+    var dataCounts: [DataCount] {
+        snapshots.compactMap { $0.environment?.dataCount }
     }
 }
 
@@ -325,6 +384,8 @@ private final class MockConnection: Connection {
 
         var reportedError: (interval: Int, error: Error)?
 
+        var reportedDataCounts: [(interval: Int, dataCount: DataCount)] = []
+
         var shouldTimeout = false
     }
 
@@ -369,6 +430,12 @@ private final class MockConnection: Connection {
                 try? await Task.sleep(milliseconds: reportedError.interval)
                 reporter.reportLastError(reportedError.error)
                 statusSubject.send(.disconnected)
+            }
+        }
+        for reportedDataCount in options.reportedDataCounts {
+            Task {
+                try? await Task.sleep(milliseconds: reportedDataCount.interval)
+                reporter.reportDataCount(reportedDataCount.dataCount)
             }
         }
         return true

--- a/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
+++ b/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
@@ -338,13 +338,12 @@ private struct Constants {
             }
         )
         let options = ConnectionParameters.Options()
-        let reporter = ConnectionReporter(environment: environment)
         let conn = try module.newConnection(with: impl, parameters: .init(
             profile: profile,
             controller: controller,
             factory: factory,
             reachability: MockReachabilityObserver(),
-            reporter: reporter,
+            environment: environment,
             options: options
         ))
         return try #require(conn as? OpenVPNConnectionType)

--- a/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
+++ b/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
@@ -338,12 +338,13 @@ private struct Constants {
             }
         )
         let options = ConnectionParameters.Options()
+        let reporter = ConnectionReporter(environment: environment)
         let conn = try module.newConnection(with: impl, parameters: .init(
             profile: profile,
             controller: controller,
             factory: factory,
             reachability: MockReachabilityObserver(),
-            environment: environment,
+            reporter: reporter,
             options: options
         ))
         return try #require(conn as? OpenVPNConnectionType)

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
 import android.util.Log
-import com.algoritmico.passepartout.Globals
 import io.partout.models.TaggedModuleDNS
 import io.partout.models.TaggedModuleHTTPProxy
 import io.partout.models.TaggedModuleIP
@@ -89,7 +88,7 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to start VPN daemon (code=${result.code}): ${result.payload}")
             stopService()
             isRunning = false
-            sendSnapshots(emptyMap())
+            sendSnapshots(null)
             return@launchCommand
         }
         Log.i(logTag, "Started VPN daemon")
@@ -111,7 +110,7 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to stop VPN daemon (code=${result.code}): ${result.payload}")
         }
         isRunning = false
-        sendSnapshots(emptyMap())
+        sendSnapshots(null)
     }
 
     private fun launchCommand(action: suspend () -> Unit) {
@@ -236,9 +235,9 @@ class PartoutVpnServiceRuntime(
 
     // Broadcasts emitters
 
-    private fun sendSnapshots(snapshots: Map<String, TunnelSnapshot>) {
+    private fun sendSnapshots(snapshots: Map<String, TunnelSnapshot>?) {
         val newSnapshots: Map<String, TunnelSnapshot>
-        if (!snapshots.isEmpty()) {
+        if (snapshots != null) {
             newSnapshots = snapshots
         } else {
             newSnapshots = latestSnapshots.mapValues {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -39,6 +39,7 @@ class PartoutVpnServiceRuntime(
     private val commandMutex = Mutex()
     private var descriptor: ParcelFileDescriptor? = null
     private var isRunning = false
+    private var latestSnapshots: Map<String, TunnelSnapshot> = emptyMap()
 
     // Service lifecycle
 
@@ -236,9 +237,16 @@ class PartoutVpnServiceRuntime(
     // Broadcasts emitters
 
     private fun sendSnapshots(snapshots: Map<String, TunnelSnapshot>) {
+        if (!snapshots.isEmpty()) {
+            latestSnapshots = snapshots
+        } else {
+            latestSnapshots = latestSnapshots.mapValues {
+                it.value.disabled()
+            }
+        }
         val intent = Intent(ACTION_SNAPSHOTS).apply {
             setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOTS_JSON, json.encodeToString(snapshots))
+            putExtra(EXTRA_SNAPSHOTS_JSON, json.encodeToString(latestSnapshots))
         }
         service.sendBroadcast(intent)
     }
@@ -254,6 +262,14 @@ class PartoutVpnServiceRuntime(
         suspend fun start(runtime: PartoutVpnServiceRuntime, profileJSON: String): Result
         suspend fun stop(): Result
     }
+
+    private fun TunnelSnapshot.disabled() = TunnelSnapshot(
+        id,
+        false,
+        false,
+        status,
+        environment
+    )
 
     companion object {
         const val ACTION_STOP_VPN = "io.partout.action.STOP_VPN"

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -223,6 +223,16 @@ class PartoutVpnServiceRuntime(
         sendSnapshots(snapshots.associateBy { it.id })
     }
 
+    // JNI
+    fun cancelTunnel(errorMessage: String?) {
+        if (errorMessage != null) {
+            Log.e(logTag, "VPN daemon cancelled: $errorMessage")
+        } else {
+            Log.i(logTag, "VPN daemon cancelled")
+        }
+        disconnect()
+    }
+
     // Broadcasts emitters
 
     private fun sendSnapshots(snapshots: Map<String, TunnelSnapshot>) {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
 import android.util.Log
+import com.algoritmico.passepartout.Globals
 import io.partout.models.TaggedModuleDNS
 import io.partout.models.TaggedModuleHTTPProxy
 import io.partout.models.TaggedModuleIP
@@ -220,7 +221,6 @@ class PartoutVpnServiceRuntime(
     // JNI
     fun onSnapshots(snapshotsJSON: String) {
         val snapshots = json.decodeFromString<List<TunnelSnapshot>>(snapshotsJSON)
-        Log.d(logTag, "Report daemon snapshots: $snapshots")
         sendSnapshots(snapshots.associateBy { it.id })
     }
 
@@ -237,18 +237,24 @@ class PartoutVpnServiceRuntime(
     // Broadcasts emitters
 
     private fun sendSnapshots(snapshots: Map<String, TunnelSnapshot>) {
+        val newSnapshots: Map<String, TunnelSnapshot>
         if (!snapshots.isEmpty()) {
-            latestSnapshots = snapshots
+            newSnapshots = snapshots
         } else {
-            latestSnapshots = latestSnapshots.mapValues {
+            newSnapshots = latestSnapshots.mapValues {
                 it.value.disabled()
             }
         }
+        if (newSnapshots == latestSnapshots) {
+            return
+        }
+        Log.d(logTag, "Report daemon snapshots: $newSnapshots")
         val intent = Intent(ACTION_SNAPSHOTS).apply {
             setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOTS_JSON, json.encodeToString(latestSnapshots))
+            putExtra(EXTRA_SNAPSHOTS_JSON, json.encodeToString(newSnapshots))
         }
         service.sendBroadcast(intent)
+        latestSnapshots = newSnapshots
     }
 
     // Nested classes


### PR DESCRIPTION
Rather than giving the connection direct access to the TunnelEnvironment, report connection updates through a ConnectionReporter wrapper. This way:

- It's easier to centralize status/error reporting
- A new snapshot may be emitted immediately

Other fixes:

- OpenVPN: Fix bad error codes, `.recoverable` in particular was not properly mapped through the inner error.
- OpenVPN: Report recoverable error codes, too.
- WireGuard: Report errors because it wasn't being done.

Lastly, on Android, fix the service not being stopped on unrecoverable connection failure, leaving the daemon in a hanging state because of the finished connection status stream. Implement `cancelTunnelConnection()` via JNI to call `PartoutVpnServiceRuntime.disconnect()` when that happens, and stop the service.