### PR TITLE
Core: Skip snapshots below data count delta

### DIFF
--- a/Sources/PartoutCore/Connection/DataCount.swift
+++ b/Sources/PartoutCore/Connection/DataCount.swift
@@ -4,6 +4,7 @@
 
 /// A pair of received/sent bytes count.
 public struct DataCount: Hashable, Codable, Sendable {
+    public static let zero = DataCount()
 
     /// Received bytes count.
     public let received: UInt64

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -32,6 +32,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let snapshotInterval: Int
 
+    private let minDataCountDelta: UInt64
+
     private var onSnapshot: OnTunnelSnapshotCallback?
 
     private var connection: Connection?
@@ -60,6 +62,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private var snapshotSubscription: Task<Void, Never>?
 
+    private var lastPublishedSnapshot: TunnelSnapshot?
+
     // MARK: Testing
 
     private var testEvaluateConnection: (() -> Void)?
@@ -79,6 +83,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         stopDelay = params.stopDelay
         reconnectionDelay = params.reconnectionDelay
         snapshotInterval = params.snapshotInterval
+        minDataCountDelta = params.minDataCountDelta
         onSnapshot = params.onSnapshot
 
         state = .initial
@@ -436,15 +441,15 @@ extension SimpleConnectionDaemon {
 
     func reportLastError(_ error: Error) {
         reporter.reportLastError(error)
-        publishSnapshot()
+        publishSnapshot(force: true)
     }
 
     func reportStatus(_ status: ConnectionStatus) {
         statusSubject.send(status)
-        publishSnapshot(with: status)
+        publishSnapshot(with: status, force: true)
     }
 
-    func publishSnapshot(with latestConnectionStatus: ConnectionStatus? = nil) {
+    func publishSnapshot(with latestConnectionStatus: ConnectionStatus? = nil, force: Bool = false) {
         let connectionStatus = latestConnectionStatus ?? statusSubject.value
         let status = connectionStatus.toTunnelStatus
         let env = environment.snapshot.with(connectionStatus: connectionStatus)
@@ -455,8 +460,24 @@ extension SimpleConnectionDaemon {
             onDemand: false,
             environment: env
         )
+        guard shouldPublishSnapshot(snapshot, force: force) else {
+            return
+        }
+        lastPublishedSnapshot = snapshot
         controller.reportSnapshots([snapshot])
         onSnapshot?(snapshot)
+    }
+
+    func shouldPublishSnapshot(_ snapshot: TunnelSnapshot, force: Bool) -> Bool {
+        guard !force, minDataCountDelta > 0, let lastPublishedSnapshot else {
+            return true
+        }
+        guard snapshot.isEquivalentExceptDataCount(to: lastPublishedSnapshot) else {
+            return true
+        }
+        let dataCount = snapshot.environment?.dataCount ?? DataCount()
+        let lastDataCount = lastPublishedSnapshot.environment?.dataCount ?? DataCount()
+        return dataCount.delta(from: lastDataCount) >= minDataCountDelta
     }
 }
 
@@ -468,6 +489,32 @@ private extension ConnectionStatus {
         case .disconnecting: .deactivating
         case .disconnected: .inactive
         }
+    }
+}
+
+private extension TunnelSnapshot {
+    func isEquivalentExceptDataCount(to other: Self) -> Bool {
+        id == other.id &&
+        isEnabled == other.isEnabled &&
+        status == other.status &&
+        onDemand == other.onDemand &&
+        environment?.connectionStatus == other.environment?.connectionStatus &&
+        environment?.lastErrorCode == other.environment?.lastErrorCode
+    }
+}
+
+private extension DataCount {
+    func delta(from other: Self) -> UInt64 {
+        let receivedDelta = received.delta(from: other.received)
+        let sentDelta = sent.delta(from: other.sent)
+        let (sum, overflow) = receivedDelta.addingReportingOverflow(sentDelta)
+        return overflow ? UInt64.max : sum
+    }
+}
+
+private extension UInt64 {
+    func delta(from other: Self) -> Self {
+        self >= other ? self - other : other - self
     }
 }
 
@@ -489,6 +536,8 @@ extension SimpleConnectionDaemon {
 
         let snapshotInterval: Int
 
+        let minDataCountDelta: UInt64
+
         let onSnapshot: OnTunnelSnapshotCallback?
 
         public init(
@@ -499,6 +548,7 @@ extension SimpleConnectionDaemon {
             stopDelay: Int? = nil,
             reconnectionDelay: Int? = nil,
             snapshotInterval: Int? = nil,
+            minDataCountDelta: UInt64? = nil,
             onSnapshot: OnTunnelSnapshotCallback? = nil
         ) {
             self.connectionFactory = connectionFactory
@@ -508,6 +558,7 @@ extension SimpleConnectionDaemon {
             self.stopDelay = stopDelay ?? 2000
             self.reconnectionDelay = reconnectionDelay ?? 2000
             self.snapshotInterval = snapshotInterval ?? 1000
+            self.minDataCountDelta = minDataCountDelta ?? 0
             self.onSnapshot = onSnapshot
         }
     }

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -492,17 +492,6 @@ private extension ConnectionStatus {
     }
 }
 
-private extension TunnelSnapshot {
-    func isEquivalentExceptDataCount(to other: Self) -> Bool {
-        id == other.id &&
-        isEnabled == other.isEnabled &&
-        status == other.status &&
-        onDemand == other.onDemand &&
-        environment?.connectionStatus == other.environment?.connectionStatus &&
-        environment?.lastErrorCode == other.environment?.lastErrorCode
-    }
-}
-
 private extension DataCount {
     func delta(from other: Self) -> UInt64 {
         let receivedDelta = received.delta(from: other.received)

--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -497,7 +497,7 @@ private extension DataCount {
         let receivedDelta = received.delta(from: other.received)
         let sentDelta = sent.delta(from: other.sent)
         let (sum, overflow) = receivedDelta.addingReportingOverflow(sentDelta)
-        return overflow ? UInt64.max : sum
+        return overflow ? .max : sum
     }
 }
 

--- a/Sources/PartoutCore/Tunnel/TunnelSnapshot.swift
+++ b/Sources/PartoutCore/Tunnel/TunnelSnapshot.swift
@@ -65,8 +65,8 @@ public struct TunnelSnapshot: Hashable, Codable, Sendable, CustomStringConvertib
     }
 
     public func isEquivalentExceptDataCount(to other: Self) -> Bool {
-        var e1 = environment?.with(dataCount: .zero)
-        var e2 = other.environment?.with(dataCount:.zero)
+        let e1 = environment?.with(dataCount: .zero)
+        let e2 = other.environment?.with(dataCount:.zero)
         return with(environment: e1) == other.with(environment: e2)
     }
 

--- a/Sources/PartoutCore/Tunnel/TunnelSnapshot.swift
+++ b/Sources/PartoutCore/Tunnel/TunnelSnapshot.swift
@@ -58,14 +58,20 @@ public struct TunnelSnapshot: Hashable, Codable, Sendable, CustomStringConvertib
         self.environment = environment
     }
 
-    public func with(environment: Environment) -> Self {
+    public func with(environment: Environment?) -> Self {
         var copy = self
         copy.environment = environment
         return copy
     }
 
+    public func isEquivalentExceptDataCount(to other: Self) -> Bool {
+        var e1 = environment?.with(dataCount: .zero)
+        var e2 = other.environment?.with(dataCount:.zero)
+        return with(environment: e1) == other.with(environment: e2)
+    }
+
     public var description: String {
-        "{\(id.uuidString), isEnabled=\(isEnabled), status=\(status), onDemand=\(onDemand), environment=\(environment)}"
+        "{\(id.uuidString), isEnabled=\(isEnabled), status=\(status), onDemand=\(onDemand), environment=\(environment.debugDescription)}"
     }
 }
 

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -27,7 +27,8 @@ public actor NEPTPForwarder {
         factoryOptions: NEInterfaceFactory.Options = .init(),
         connectionOptions: ConnectionParameters.Options = .init(),
         stopDelay: Int? = nil,
-        reconnectionDelay: Int? = nil
+        reconnectionDelay: Int? = nil,
+        minDataCountDelta: UInt64? = nil
     ) throws {
         guard let provider = controller.provider else {
             pp_log(ctx, .os, .info, "NEPTPForwarder: NEPacketTunnelProvider released")
@@ -51,7 +52,8 @@ public actor NEPTPForwarder {
             messageHandler: messageHandler,
             startsImmediately: true,
             stopDelay: stopDelay,
-            reconnectionDelay: reconnectionDelay
+            reconnectionDelay: reconnectionDelay,
+            minDataCountDelta: minDataCountDelta
         )
 
         self.ctx = ctx

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -194,6 +194,49 @@ struct SimpleConnectionDaemonTests {
     }
 
     @Test
+    func givenStartedConnectionReportingSmallDataCountChanges_whenSnapshotTimerFires_thenSkipsSnapshotsBelowMinimumDelta() async throws {
+        var connectionModule = MockConnectionModule()
+        connectionModule.options.reportedDataCounts = [
+            (50, DataCount(40, 0)),
+            (110, DataCount(80, 0)),
+            (170, DataCount(140, 0))
+        ]
+        let profile = try Profile.Builder(
+            modules: [connectionModule],
+            activeModulesIds: [connectionModule.id]
+        ).build()
+        #expect(profile.activeConnectionModule != nil)
+
+        let recorder = SnapshotRecorder()
+        let expDataCount = Expectation()
+        let sut = try await newDaemon(
+            with: profile,
+            reconnectionDelay: 5000,
+            snapshotInterval: 30,
+            minDataCountDelta: 100,
+            onSnapshot: { snapshot in
+                Task {
+                    await recorder.append(snapshot)
+                    guard snapshot.environment?.dataCount == DataCount(140, 0) else { return }
+                    await expDataCount.fulfill()
+                }
+            }
+        )
+        let stream = sut.statusStream
+
+        try await sut.start()
+        #expect(await stream.nextElement() == .disconnected)
+        #expect(await stream.nextElement() == .connecting)
+        #expect(await stream.nextElement() == .connected)
+        try await expDataCount.fulfillment(timeout: 1000)
+
+        let dataCounts = await recorder.dataCounts.filter { $0 != DataCount() }
+        #expect(!dataCounts.contains(DataCount(40, 0)))
+        #expect(!dataCounts.contains(DataCount(80, 0)))
+        #expect(dataCounts.contains(DataCount(140, 0)))
+    }
+
+    @Test
     func givenStartedDaemon_whenStop_thenDisconnects() async throws {
         let connectionModule = MockConnectionModule()
         let profile = try Profile.Builder(
@@ -260,6 +303,8 @@ private extension SimpleConnectionDaemonTests {
         onCancel: @escaping (Error?) -> Void = { _ in },
         stopDelay: Int = 1000,
         reconnectionDelay: Int = 1000,
+        snapshotInterval: Int = 1000,
+        minDataCountDelta: UInt64 = 0,
         onSnapshot: OnTunnelSnapshotCallback? = nil
     ) async throws -> SimpleConnectionDaemon {
         let controller = MockTunnelController()
@@ -280,8 +325,22 @@ private extension SimpleConnectionDaemonTests {
             startsImmediately: false,
             stopDelay: stopDelay,
             reconnectionDelay: reconnectionDelay,
+            snapshotInterval: snapshotInterval,
+            minDataCountDelta: minDataCountDelta,
             onSnapshot: onSnapshot
         ))
+    }
+}
+
+private actor SnapshotRecorder {
+    private var snapshots: [TunnelSnapshot] = []
+
+    func append(_ snapshot: TunnelSnapshot) {
+        snapshots.append(snapshot)
+    }
+
+    var dataCounts: [DataCount] {
+        snapshots.compactMap { $0.environment?.dataCount }
     }
 }
 
@@ -333,6 +392,8 @@ private final class MockConnection: Connection {
 
         var reportedError: (interval: Int, error: Error)?
 
+        var reportedDataCounts: [(interval: Int, dataCount: DataCount)] = []
+
         var shouldTimeout = false
     }
 
@@ -377,6 +438,12 @@ private final class MockConnection: Connection {
                 try? await Task.sleep(milliseconds: reportedError.interval)
                 reporter.reportLastError(reportedError.error)
                 statusSubject.send(.disconnected)
+            }
+        }
+        for reportedDataCount in options.reportedDataCounts {
+            Task {
+                try? await Task.sleep(milliseconds: reportedDataCount.interval)
+                reporter.reportDataCount(reportedDataCount.dataCount)
             }
         }
         return true


### PR DESCRIPTION
Optionally ignore snapshots that don't differ except for the data count and when their delta lie below a given byte threshold.