### PR TITLE
Android: Retain JNI ref to runtime in NativeTunnelController

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -19,14 +19,26 @@ public final class NativeTunnelController: TunnelController {
         maxReadLength: Int = 128 * 1024
     ) throws {
         self.ctx = ctx
+#if os(Android)
+        pp_log(ctx, .core, .debug, "NativeTunnelController: Retain JNI ref to PartoutVpnServiceRuntime")
+        guard let retainedRef = pp_jni_new_global_ref(ref) else {
+            throw PartoutError(.releasedObject)
+        }
+        self.ref = retainedRef
+#else
         self.ref = ref
+#endif
         self.maxReadLength = maxReadLength
 
-        pp_tun_ctrl_test_working(ref)
+        pp_tun_ctrl_test_working(self.ref)
     }
 
     deinit {
         pp_log(ctx, .core, .debug, "Deinit NativeTunnelController")
+#if os(Android)
+        pp_log(ctx, .core, .debug, "NativeTunnelController: Release JNI ref to PartoutVpnServiceRuntime")
+        pp_jni_delete_global_ref(ref)
+#endif
     }
 
     public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface {

--- a/Sources/PartoutCore_C/common.c
+++ b/Sources/PartoutCore_C/common.c
@@ -50,7 +50,7 @@ JNIEnv *pp_jni_attach_thread(bool *did_attach) {
 void *pp_jni_new_global_ref(void *ref) {
     if (!ref) return NULL;
 
-    JNI_ATTACH_OR_RETURN(env, NULL);
+    PP_JNI_ATTACH_OR_RETURN(env, NULL);
 
     jobject global_ref = (*env)->NewGlobalRef(env, (jobject)ref);
     if ((*env)->ExceptionCheck(env)) {
@@ -59,18 +59,18 @@ void *pp_jni_new_global_ref(void *ref) {
         global_ref = NULL;
     }
 
-    JNI_DETACH(env);
+    PP_JNI_DETACH(env);
     return global_ref;
 }
 
 void pp_jni_delete_global_ref(void *ref) {
     if (!ref) return;
 
-    JNI_ATTACH_OR_RETURN_VOID(env);
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
 
     (*env)->DeleteGlobalRef(env, (jobject)ref);
 
-    JNI_DETACH(env);
+    PP_JNI_DETACH(env);
 }
 
 void pp_log_simple_append(const char *tag, pp_log_level level, const char *_Nonnull message) {

--- a/Sources/PartoutCore_C/common.c
+++ b/Sources/PartoutCore_C/common.c
@@ -50,9 +50,7 @@ JNIEnv *pp_jni_attach_thread(bool *did_attach) {
 void *pp_jni_new_global_ref(void *ref) {
     if (!ref) return NULL;
 
-    bool did_attach = false;
-    JNIEnv *env = pp_jni_attach_thread(&did_attach);
-    if (!env) return NULL;
+    JNI_ATTACH_OR_RETURN(env, NULL);
 
     jobject global_ref = (*env)->NewGlobalRef(env, (jobject)ref);
     if ((*env)->ExceptionCheck(env)) {
@@ -61,24 +59,18 @@ void *pp_jni_new_global_ref(void *ref) {
         global_ref = NULL;
     }
 
-    if (did_attach) {
-        (*jvm)->DetachCurrentThread(jvm);
-    }
+    JNI_DETACH(env);
     return global_ref;
 }
 
 void pp_jni_delete_global_ref(void *ref) {
     if (!ref) return;
 
-    bool did_attach = false;
-    JNIEnv *env = pp_jni_attach_thread(&did_attach);
-    if (!env) return;
+    JNI_ATTACH_OR_RETURN_VOID(env);
 
     (*env)->DeleteGlobalRef(env, (jobject)ref);
 
-    if (did_attach) {
-        (*jvm)->DetachCurrentThread(jvm);
-    }
+    JNI_DETACH(env);
 }
 
 void pp_log_simple_append(const char *tag, pp_log_level level, const char *_Nonnull message) {

--- a/Sources/PartoutCore_C/common.c
+++ b/Sources/PartoutCore_C/common.c
@@ -47,6 +47,40 @@ JNIEnv *pp_jni_attach_thread(bool *did_attach) {
     }
 }
 
+void *pp_jni_new_global_ref(void *ref) {
+    if (!ref) return NULL;
+
+    bool did_attach = false;
+    JNIEnv *env = pp_jni_attach_thread(&did_attach);
+    if (!env) return NULL;
+
+    jobject global_ref = (*env)->NewGlobalRef(env, (jobject)ref);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        global_ref = NULL;
+    }
+
+    if (did_attach) {
+        (*jvm)->DetachCurrentThread(jvm);
+    }
+    return global_ref;
+}
+
+void pp_jni_delete_global_ref(void *ref) {
+    if (!ref) return;
+
+    bool did_attach = false;
+    JNIEnv *env = pp_jni_attach_thread(&did_attach);
+    if (!env) return;
+
+    (*env)->DeleteGlobalRef(env, (jobject)ref);
+
+    if (did_attach) {
+        (*jvm)->DetachCurrentThread(jvm);
+    }
+}
+
 void pp_log_simple_append(const char *tag, pp_log_level level, const char *_Nonnull message) {
     const char *log_tag = tag ? tag : "Partout";
     int android_level = 0;

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -105,6 +105,29 @@ FILE *_Nullable pp_fopen(const char *_Nonnull filename, const char *_Nonnull mod
 #include <stdbool.h>
 extern _Nullable JavaVM *_Nullable jvm;
 _Nullable JNIEnv *_Nullable pp_jni_attach_thread(bool *_Nonnull did_attach);
+
+#define JNI_ATTACH_OR_RETURN(env_name, return_value) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) return return_value
+
+#define JNI_ATTACH_OR_RETURN_VOID(env_name) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) return
+
+#define JNI_ATTACH_OR_COMPLETE(env_name, completion, ctx) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) { \
+        if (completion) completion(ctx, -1); \
+        return; \
+    }
+
+#define JNI_DETACH(env_name) \
+    do { \
+        if (env_name##_did_attach) (*jvm)->DetachCurrentThread(jvm); \
+    } while (0)
 #endif
 
 typedef void (*pp_completion)(void *_Nullable ctx, const int error_code);

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -108,17 +108,17 @@ _Nullable JNIEnv *_Nullable pp_jni_attach_thread(bool *_Nonnull did_attach);
 void *_Nullable pp_jni_new_global_ref(void *_Nullable ref);
 void pp_jni_delete_global_ref(void *_Nullable ref);
 
-#define JNI_ATTACH_OR_RETURN(env_name, return_value) \
+#define PP_JNI_ATTACH_OR_RETURN(env_name, return_value) \
     bool env_name##_did_attach; \
     JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
     if (!(env_name)) return return_value
 
-#define JNI_ATTACH_OR_RETURN_VOID(env_name) \
+#define PP_JNI_ATTACH_OR_RETURN_VOID(env_name) \
     bool env_name##_did_attach; \
     JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
     if (!(env_name)) return
 
-#define JNI_ATTACH_OR_COMPLETE(env_name, completion, ctx) \
+#define PP_JNI_ATTACH_OR_COMPLETE(env_name, completion, ctx) \
     bool env_name##_did_attach; \
     JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
     if (!(env_name)) { \
@@ -126,7 +126,7 @@ void pp_jni_delete_global_ref(void *_Nullable ref);
         return; \
     }
 
-#define JNI_DETACH(env_name) \
+#define PP_JNI_DETACH(env_name) \
     do { \
         if (env_name##_did_attach) (*jvm)->DetachCurrentThread(jvm); \
     } while (0)

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -105,6 +105,8 @@ FILE *_Nullable pp_fopen(const char *_Nonnull filename, const char *_Nonnull mod
 #include <stdbool.h>
 extern _Nullable JavaVM *_Nullable jvm;
 _Nullable JNIEnv *_Nullable pp_jni_attach_thread(bool *_Nonnull did_attach);
+void *_Nullable pp_jni_new_global_ref(void *_Nullable ref);
+void pp_jni_delete_global_ref(void *_Nullable ref);
 
 #define JNI_ATTACH_OR_RETURN(env_name, return_value) \
     bool env_name##_did_attach; \

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -81,7 +81,7 @@ void pp_tun_ctrl_test_working(void *jni_ref) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_test_working(%p)", jni_ref);
 
-    JNI_ATTACH_OR_RETURN_VOID(env);
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -99,7 +99,7 @@ void pp_tun_ctrl_test_working(void *jni_ref) {
 
 cleanup:
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    JNI_DETACH(env);
+    PP_JNI_DETACH(env);
 }
 
 pp_tun pp_tun_ctrl_set_tunnel(void *jni_ref, const char *uuid, const char *info_json) {
@@ -107,7 +107,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *jni_ref, const char *uuid, const char *info_
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_set_tunnel(%p)", jni_ref);
 
-    JNI_ATTACH_OR_RETURN(env, NULL);
+    PP_JNI_ATTACH_OR_RETURN(env, NULL);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -151,7 +151,7 @@ cleanup:
     }
     if (j_info_json != NULL) (*env)->DeleteLocalRef(env, j_info_json);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    JNI_DETACH(env);
+    PP_JNI_DETACH(env);
     return tun_impl;
 }
 
@@ -160,7 +160,7 @@ void pp_tun_ctrl_configure_sockets(void *jni_ref, const int *fds, const size_t f
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_configure_sockets(%p)", jni_ref);
     if (!fds || fds_len == 0) return;
 
-    JNI_ATTACH_OR_RETURN_VOID(env);
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -187,7 +187,7 @@ void pp_tun_ctrl_configure_sockets(void *jni_ref, const int *fds, const size_t f
 cleanup:
     if (j_fds != NULL) (*env)->DeleteLocalRef(env, j_fds);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    JNI_DETACH(env);
+    PP_JNI_DETACH(env);
 }
 
 void pp_tun_ctrl_report_snapshots(void *_Nullable ref,
@@ -195,7 +195,7 @@ void pp_tun_ctrl_report_snapshots(void *_Nullable ref,
     assert(ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_report_snapshots(%p)", ref);
 
-    JNI_ATTACH_OR_RETURN_VOID(env);
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -227,14 +227,14 @@ void pp_tun_ctrl_report_snapshots(void *_Nullable ref,
 cleanup:
     if (j_snapshots_json != NULL) (*env)->DeleteLocalRef(env, j_snapshots_json);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    JNI_DETACH(env);
+    PP_JNI_DETACH(env);
 }
 
 void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_cancel_tunnel(%p)", jni_ref);
 
-    JNI_ATTACH_OR_RETURN_VOID(env);
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
 
     jclass cls = NULL;
     jmethodID method = NULL;
@@ -262,7 +262,7 @@ void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
 cleanup:
     if (j_error_message != NULL) (*env)->DeleteLocalRef(env, j_error_message);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
-    JNI_DETACH(env);
+    PP_JNI_DETACH(env);
 }
 
 void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -54,29 +54,6 @@ typedef struct {
     const char *signature;
 } kotlin_sig;
 
-#define JNI_ATTACH_OR_RETURN(env_name, return_value) \
-    bool env_name##_did_attach; \
-    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
-    if (!(env_name)) return return_value
-
-#define JNI_ATTACH_OR_RETURN_VOID(env_name) \
-    bool env_name##_did_attach; \
-    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
-    if (!(env_name)) return
-
-#define JNI_ATTACH_OR_COMPLETE(env_name, completion, ctx) \
-    bool env_name##_did_attach; \
-    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
-    if (!(env_name)) { \
-        if (completion) completion(ctx, -1); \
-        return; \
-    }
-
-#define JNI_DETACH(env_name) \
-    do { \
-        if (env_name##_did_attach) (*jvm)->DetachCurrentThread(jvm); \
-    } while (0)
-
 /* Tunnel controller (PartoutVpnServiceRuntime) */
 
 static const kotlin_sig sig_ctrl_testWorking = {


### PR DESCRIPTION
NativeTunnelController may outlive the runtime in some cases. Act defensively and retain the JNI reference locally.