### PR TITLE
Core: Regressions in error reporting

### DIFF
--- a/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
+++ b/Sources/PartoutCore/Connection/SimpleConnectionDaemon.swift
@@ -26,6 +26,8 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
 
     private let startsImmediately: Bool
 
+    private let cancelsUnrecoverable: Bool
+
     private let stopDelay: Int
 
     private let reconnectionDelay: Int
@@ -80,6 +82,7 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
         reachability = params.connectionParameters.reachability
         messageHandler = params.messageHandler
         startsImmediately = params.startsImmediately
+        cancelsUnrecoverable = params.cancelsUnrecoverable
         stopDelay = params.stopDelay
         reconnectionDelay = params.reconnectionDelay
         snapshotInterval = params.snapshotInterval
@@ -162,7 +165,9 @@ public actor SimpleConnectionDaemon: ConnectionDaemon {
             pp_log_id(profile.id, .core, .fault, "Unable to start daemon: \(error)")
             reportLastError(error)
             controller.setReasserting(false)
-            controller.cancelTunnelConnection(with: error)
+            if cancelsUnrecoverable {
+                controller.cancelTunnelConnection(with: error)
+            }
         }
         if !startsImmediately {
             networkObserver?.setEnabled(true)
@@ -436,7 +441,9 @@ extension SimpleConnectionDaemon {
     func onConnectionError(_ error: Error) {
         reportLastError(error)
         controller.setReasserting(false)
-        controller.cancelTunnelConnection(with: error)
+        if cancelsUnrecoverable {
+            controller.cancelTunnelConnection(with: error)
+        }
     }
 
     func reportLastError(_ error: Error) {
@@ -519,6 +526,8 @@ extension SimpleConnectionDaemon {
 
         let startsImmediately: Bool
 
+        let cancelsUnrecoverable: Bool
+
         let stopDelay: Int
 
         let reconnectionDelay: Int
@@ -534,6 +543,7 @@ extension SimpleConnectionDaemon {
             connectionParameters: ConnectionParameters,
             messageHandler: MessageHandler,
             startsImmediately: Bool,
+            cancelsUnrecoverable: Bool,
             stopDelay: Int? = nil,
             reconnectionDelay: Int? = nil,
             snapshotInterval: Int? = nil,
@@ -544,6 +554,7 @@ extension SimpleConnectionDaemon {
             self.connectionParameters = connectionParameters
             self.messageHandler = messageHandler
             self.startsImmediately = startsImmediately
+            self.cancelsUnrecoverable = cancelsUnrecoverable
             self.stopDelay = stopDelay ?? 2000
             self.reconnectionDelay = reconnectionDelay ?? 2000
             self.snapshotInterval = snapshotInterval ?? 1000

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -26,6 +26,7 @@ public actor NEPTPForwarder {
         environment: TunnelEnvironment,
         factoryOptions: NEInterfaceFactory.Options = .init(),
         connectionOptions: ConnectionParameters.Options = .init(),
+        cancelsUnrecoverable: Bool,
         stopDelay: Int? = nil,
         reconnectionDelay: Int? = nil,
         minDataCountDelta: UInt64? = nil
@@ -51,6 +52,7 @@ public actor NEPTPForwarder {
             connectionParameters: connectionParameters,
             messageHandler: messageHandler,
             startsImmediately: true,
+            cancelsUnrecoverable: cancelsUnrecoverable,
             stopDelay: stopDelay,
             reconnectionDelay: reconnectionDelay,
             minDataCountDelta: minDataCountDelta

--- a/Sources/PartoutOpenVPN/Partout+OpenVPN.swift
+++ b/Sources/PartoutOpenVPN/Partout+OpenVPN.swift
@@ -33,6 +33,8 @@ extension PartoutError.Code {
 
         public static let passphraseRequired = PartoutError.Code("OpenVPN.passphraseRequired")
 
+        public static let recoverableAuthentication = PartoutError.Code("OpenVPN.recoverableAuthentication")
+
         public static let serverShutdown = PartoutError.Code("OpenVPN.serverShutdown")
 
         public static let tlsFailure = PartoutError.Code("OpenVPN.tlsFailure")

--- a/Sources/PartoutOpenVPNConnection/Internal/Error+Recoverable.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Error+Recoverable.swift
@@ -20,5 +20,6 @@ private let ppRecoverableCodes: [PartoutError.Code] = [
     .linkFailure,
     .networkChanged,
     .OpenVPN.connectionFailure,
+    .OpenVPN.recoverableAuthentication,
     .OpenVPN.serverShutdown
 ]

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionError+Mapping.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionError+Mapping.swift
@@ -15,7 +15,7 @@ extension OpenVPNSessionError: PartoutErrorMappable {
         case .negotiationTimeout, .pingTimeout, .writeTimeout:
             return .timeout
 
-        case .badCredentials, .badCredentialsWithLocalOptions:
+        case .badCredentials:
             return .authentication
 
         case .serverCompression:

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionError+Mapping.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionError+Mapping.swift
@@ -18,6 +18,9 @@ extension OpenVPNSessionError: PartoutErrorMappable {
         case .badCredentials:
             return .authentication
 
+        case .badCredentialsWithLocalOptions:
+            return .OpenVPN.recoverableAuthentication
+
         case .serverCompression:
             return .OpenVPN.compressionMismatch
 

--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -15,7 +15,7 @@ struct SimpleConnectionDaemonTests {
         let profile = try Profile.Builder()
             .build()
 
-        let sut = try await newDaemon(with: profile)
+        let sut = try newDaemon(with: profile)
         do {
             try await sut.start()
         } catch {
@@ -33,7 +33,7 @@ struct SimpleConnectionDaemonTests {
         #expect(profile.activeConnectionModule != nil)
 
         let reachability = MockReachabilityObserver()
-        let sut = try await newDaemon(with: profile, reachability: reachability)
+        let sut = try newDaemon(with: profile, reachability: reachability)
         let stream = sut.statusStream
 
         try await sut.start()
@@ -54,7 +54,7 @@ struct SimpleConnectionDaemonTests {
 
         let environment = SharedTunnelEnvironment(profileId: profile.id)
         do {
-            _ = try await newDaemon(with: profile, environment: environment)
+            _ = try newDaemon(with: profile, environment: environment)
         } catch let error as PartoutError {
             #expect(error.code == .authentication)
         } catch {
@@ -73,7 +73,7 @@ struct SimpleConnectionDaemonTests {
         #expect(profile.activeConnectionModule != nil)
 
         let expLastError = Expectation()
-        let sut = try await newDaemon(
+        let sut = try newDaemon(
             with: profile,
             onSnapshot: { snapshot in
                 guard snapshot.environment?.lastErrorCode == .dnsFailure else { return }
@@ -101,7 +101,7 @@ struct SimpleConnectionDaemonTests {
 
         let reachability = MockReachabilityObserver()
         reachability.isReachable = false
-        let sut = try await newDaemon(
+        let sut = try newDaemon(
             with: profile,
             reachability: reachability,
             reconnectionDelay: 100
@@ -137,7 +137,7 @@ struct SimpleConnectionDaemonTests {
 
         let expLastError = Expectation()
         let expCancel = Expectation()
-        let sut = try await newDaemon(
+        let sut = try newDaemon(
             with: profile,
             onCancel: { error in
                 guard error?.partoutErrorCode == .authentication else { return }
@@ -174,7 +174,7 @@ struct SimpleConnectionDaemonTests {
         #expect(profile.activeConnectionModule != nil)
 
         let expLastError = Expectation()
-        let sut = try await newDaemon(
+        let sut = try newDaemon(
             with: profile,
             reconnectionDelay: 5000,
             onSnapshot: { snapshot in
@@ -209,7 +209,7 @@ struct SimpleConnectionDaemonTests {
 
         let recorder = SnapshotRecorder()
         let expDataCount = Expectation()
-        let sut = try await newDaemon(
+        let sut = try newDaemon(
             with: profile,
             reconnectionDelay: 5000,
             snapshotInterval: 30,
@@ -246,7 +246,7 @@ struct SimpleConnectionDaemonTests {
         #expect(profile.activeConnectionModule != nil)
 
         let reachability = MockReachabilityObserver()
-        let sut = try await newDaemon(
+        let sut = try newDaemon(
             with: profile,
             reachability: reachability,
             stopDelay: 100,
@@ -275,7 +275,7 @@ struct SimpleConnectionDaemonTests {
         #expect(profile.activeConnectionModule != nil)
 
         let reachability = MockReachabilityObserver()
-        let sut = try await newDaemon(
+        let sut = try newDaemon(
             with: profile,
             reachability: reachability,
             stopDelay: 200
@@ -306,7 +306,7 @@ private extension SimpleConnectionDaemonTests {
         snapshotInterval: Int = 1000,
         minDataCountDelta: UInt64 = 0,
         onSnapshot: OnTunnelSnapshotCallback? = nil
-    ) async throws -> SimpleConnectionDaemon {
+    ) throws -> SimpleConnectionDaemon {
         let controller = MockTunnelController()
         controller.onCancelTunnelConnection = onCancel
         let options = ConnectionParameters.Options()
@@ -323,6 +323,7 @@ private extension SimpleConnectionDaemonTests {
             ),
             messageHandler: DefaultMessageHandler(.global, environment: environment),
             startsImmediately: false,
+            cancelsUnrecoverable: true,
             stopDelay: stopDelay,
             reconnectionDelay: reconnectionDelay,
             snapshotInterval: snapshotInterval,


### PR DESCRIPTION
- Temporary OpenVPN `badCredentialsWithLocalOptions` auth failure was mapped to an unrecoverable error (would not retry)
- Make cancel on failure an option in SimpleConnectionDaemon, because on Apple systems, on-demand may cause an infinite reconnection cycle

Regressions in #405 