### PR TITLE
Android: Restore tunnel state on client initialization

### DIFF
--- a/cross/android/io/partout/PartoutTunnel.kt
+++ b/cross/android/io/partout/PartoutTunnel.kt
@@ -11,7 +11,11 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.net.VpnService
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
 import android.util.Log
 import androidx.core.content.ContextCompat
 import io.partout.models.TaggedProfile
@@ -36,41 +40,54 @@ class PartoutTunnel(
     val state = _state.asStateFlow()
 
     // Service updates through binding and broadcasts
+    private val clientMessenger: Messenger
     private val deathRecipient: IBinder.DeathRecipient
     private val connection: ServiceConnection
     private val snapshotsReceiver: BroadcastReceiver
     private var isBound: Boolean
-    private var binder: IBinder? = null
+    private var serviceMessenger: Messenger? = null
 
     // Initialization
 
     init {
+        clientMessenger = Messenger(object : Handler(Looper.getMainLooper()) {
+            override fun handleMessage(msg: Message) {
+                when (msg.what) {
+                    PartoutVpnServiceRuntime.MSG_GET_STATUS  -> {
+                        val status = msg.data.getString(PartoutVpnServiceRuntime.MSG_KEY_STATUS)
+                        if (status != null) {
+                            Log.e(logTag, ">>> Message received: ${status}")
+                        }
+                    }
+                    else -> super.handleMessage(msg)
+                }
+            }
+        })
         deathRecipient = IBinder.DeathRecipient {
-            binder = null
+            serviceMessenger = null
             onServiceDead()
         }
         connection = object : ServiceConnection {
             override fun onServiceConnected(name: ComponentName, service: IBinder) {
-                binder = service
+                serviceMessenger = Messenger(service)
                 service.linkToDeath(deathRecipient, 0)
 
                 // Important: immediately ask the service for its current snapshot.
-                // Do not wait for the next broadcast.
-//                requestCurrentVpnStatus(service)
+                requestStatus()
             }
 
             override fun onServiceDisconnected(name: ComponentName) {
-                binder = null
+                serviceMessenger = null
                 onServiceDead()
             }
 
             override fun onBindingDied(name: ComponentName) {
-                binder = null
+                serviceMessenger = null
                 onServiceDead()
             }
 
             override fun onNullBinding(name: ComponentName) {
-                binder = null
+                serviceMessenger = null
                 onServiceDead()
             }
         }
@@ -106,8 +123,8 @@ class PartoutTunnel(
 
     override fun close() {
         appContext.unregisterReceiver(snapshotsReceiver)
-        binder?.unlinkToDeath(deathRecipient, 0)
-        binder = null
+        serviceMessenger?.binder?.unlinkToDeath(deathRecipient, 0)
+        serviceMessenger = null
         if (isBound) {
             appContext.unbindService(connection)
             isBound = false
@@ -144,6 +161,15 @@ class PartoutTunnel(
         pendingPermission = null
         stopVpnService(profileId)
         completion(ERROR_NONE)
+    }
+
+    // Messaging
+
+    fun requestStatus() {
+        val msg = Message.obtain(null, PartoutVpnServiceRuntime.MSG_GET_STATUS).apply {
+            replyTo = clientMessenger
+        }
+        serviceMessenger?.send(msg)
     }
 
     // Internals

--- a/cross/android/io/partout/PartoutTunnel.kt
+++ b/cross/android/io/partout/PartoutTunnel.kt
@@ -54,14 +54,8 @@ class PartoutTunnel(
             override fun handleMessage(msg: Message) {
                 when (msg.what) {
                     PartoutVpnServiceRuntime.MSG_GET_STATUS  -> {
-                        val snapshotJSON = msg.data.getString(PartoutVpnServiceRuntime.MSG_KEY_SNAPSHOT)
-                        if (snapshotJSON == null) { return }
-                        runCatching {
-                            return@runCatching json.decodeFromString<TunnelSnapshot>(snapshotJSON)
-                        }.onSuccess {
-                            Log.e(logTag, ">>> Snapshot received: ${it}")
-                        }.onFailure {
-                            Log.e(logTag, ">>> Unable to decode snapshot: ${0}")
+                        msg.data.getString(PartoutVpnServiceRuntime.MSG_KEY_SNAPSHOT)?.let {
+                            onSnapshotJSON(it)
                         }
                     }
                     else -> super.handleMessage(msg)
@@ -101,14 +95,8 @@ class PartoutTunnel(
                 if (intent?.action != PartoutVpnServiceRuntime.ACTION_SNAPSHOT) {
                     return
                 }
-                val extra = intent.getStringExtra(PartoutVpnServiceRuntime.EXTRA_SNAPSHOT_JSON)
-                if (extra == null) {
-                    Log.e(logTag, "Missing snapshot from broadcast intent")
-                    return
-                }
-                val snapshot = json.decodeFromString<TunnelSnapshot>(extra)
-                _state.update {
-                    it.copy(mapOf(snapshot.id to snapshot))
+                intent.getStringExtra(PartoutVpnServiceRuntime.EXTRA_SNAPSHOT_JSON)?.let {
+                    onSnapshotJSON(it)
                 }
             }
         }
@@ -177,6 +165,12 @@ class PartoutTunnel(
         serviceMessenger?.send(msg)
     }
 
+    private fun onServiceDead() {
+        _state.update {
+            it.copy(emptyMap())
+        }
+    }
+
     // Internals
 
     private fun startVpnService(profile: TaggedProfile) {
@@ -196,9 +190,16 @@ class PartoutTunnel(
         ContextCompat.startForegroundService(appContext, stopIntent)
     }
 
-    private fun onServiceDead() {
-        _state.update {
-            it.copy(emptyMap())
+    private fun onSnapshotJSON(snapshotJSON: String) {
+        runCatching {
+            json.decodeFromString<TunnelSnapshot>(snapshotJSON)
+        }.onSuccess { snapshot ->
+            Log.e(logTag, ">>> Snapshot received: ${snapshot}")
+            _state.update {
+                it.copy(mapOf(snapshot.id to snapshot))
+            }
+        }.onFailure {
+            Log.e(logTag, ">>> Unable to decode snapshot: ${0}")
         }
     }
 

--- a/cross/android/io/partout/PartoutTunnel.kt
+++ b/cross/android/io/partout/PartoutTunnel.kt
@@ -5,10 +5,14 @@
 package io.partout
 
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.ServiceConnection
 import android.net.VpnService
+import android.os.IBinder
+import android.util.Log
 import androidx.core.content.ContextCompat
 import io.partout.models.TaggedProfile
 import io.partout.models.TunnelSnapshot
@@ -19,35 +23,79 @@ import kotlinx.serialization.json.Json
 import java.io.Closeable
 
 class PartoutTunnel(
+    private val logTag: String,
     context: Context,
     private val vpnServiceClass: Class<out VpnService>,
     private val requestVpnPermission: (Intent) -> Unit,
 ) : Closeable {
     private val appContext = context.applicationContext
     private var pendingPermission: PendingPermission? = null
+
+    // Emitted updates
     private val _state = MutableStateFlow(State())
     val state = _state.asStateFlow()
+
+    // Service updates through binding and broadcasts
+    private val deathRecipient: IBinder.DeathRecipient
+    private val connection: ServiceConnection
     private val snapshotsReceiver: BroadcastReceiver
+    private var isBound: Boolean
+    private var binder: IBinder? = null
+
+    // Initialization
 
     init {
+        deathRecipient = IBinder.DeathRecipient {
+            binder = null
+            onServiceDead()
+        }
+        connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName, service: IBinder) {
+                binder = service
+                service.linkToDeath(deathRecipient, 0)
+
+                // Important: immediately ask the service for its current snapshot.
+                // Do not wait for the next broadcast.
+//                requestCurrentVpnStatus(service)
+            }
+
+            override fun onServiceDisconnected(name: ComponentName) {
+                binder = null
+                onServiceDead()
+            }
+
+            override fun onBindingDied(name: ComponentName) {
+                binder = null
+                onServiceDead()
+            }
+
+            override fun onNullBinding(name: ComponentName) {
+                binder = null
+                onServiceDead()
+            }
+        }
         snapshotsReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context?, intent: Intent?) {
                 if (intent?.action != PartoutVpnServiceRuntime.ACTION_SNAPSHOT) {
                     return
                 }
                 val extra = intent.getStringExtra(PartoutVpnServiceRuntime.EXTRA_SNAPSHOT_JSON)
-                if (extra != null) {
-                    val snapshot = json.decodeFromString<TunnelSnapshot>(extra)
-                    _state.update {
-                        it.copy(mapOf(snapshot.id to snapshot))
-                    }
-                } else {
-                    _state.update {
-                        it.copy(emptyMap())
-                    }
+                if (extra == null) {
+                    Log.e(logTag, "Missing snapshot from broadcast intent")
+                    return
+                }
+                val snapshot = json.decodeFromString<TunnelSnapshot>(extra)
+                _state.update {
+                    it.copy(mapOf(snapshot.id to snapshot))
                 }
             }
         }
+
+        // Bind service immediately
+        val intent = Intent(context, vpnServiceClass)
+        isBound = context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
+
+        // Register for snapshots
         ContextCompat.registerReceiver(
             appContext,
             snapshotsReceiver,
@@ -55,6 +103,18 @@ class PartoutTunnel(
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
     }
+
+    override fun close() {
+        appContext.unregisterReceiver(snapshotsReceiver)
+        binder?.unlinkToDeath(deathRecipient, 0)
+        binder = null
+        if (isBound) {
+            appContext.unbindService(connection)
+            isBound = false
+        }
+    }
+
+    // Actions
 
     fun onVpnPermissionResult(granted: Boolean) {
         val permission = pendingPermission ?: return
@@ -86,6 +146,8 @@ class PartoutTunnel(
         completion(ERROR_NONE)
     }
 
+    // Internals
+
     private fun startVpnService(profile: TaggedProfile) {
         val startIntent = Intent(appContext, vpnServiceClass).apply {
             putExtra(PartoutVpnServiceRuntime.EXTRA_PROFILE_JSON, json.encodeToString(profile))
@@ -103,8 +165,10 @@ class PartoutTunnel(
         ContextCompat.startForegroundService(appContext, stopIntent)
     }
 
-    override fun close() {
-        appContext.unregisterReceiver(snapshotsReceiver)
+    private fun onServiceDead() {
+        _state.update {
+            it.copy(emptyMap())
+        }
     }
 
     companion object {

--- a/cross/android/io/partout/PartoutTunnel.kt
+++ b/cross/android/io/partout/PartoutTunnel.kt
@@ -54,9 +54,14 @@ class PartoutTunnel(
             override fun handleMessage(msg: Message) {
                 when (msg.what) {
                     PartoutVpnServiceRuntime.MSG_GET_STATUS  -> {
-                        val status = msg.data.getString(PartoutVpnServiceRuntime.MSG_KEY_STATUS)
-                        if (status != null) {
-                            Log.e(logTag, ">>> Message received: ${status}")
+                        val snapshotJSON = msg.data.getString(PartoutVpnServiceRuntime.MSG_KEY_SNAPSHOT)
+                        if (snapshotJSON == null) { return }
+                        runCatching {
+                            return@runCatching json.decodeFromString<TunnelSnapshot>(snapshotJSON)
+                        }.onSuccess {
+                            Log.e(logTag, ">>> Snapshot received: ${it}")
+                        }.onFailure {
+                            Log.e(logTag, ">>> Unable to decode snapshot: ${0}")
                         }
                     }
                     else -> super.handleMessage(msg)
@@ -72,8 +77,8 @@ class PartoutTunnel(
                 serviceMessenger = Messenger(service)
                 service.linkToDeath(deathRecipient, 0)
 
-                // Important: immediately ask the service for its current snapshot.
-                requestStatus()
+                // Ask the service for its current snapshot
+                requestSnapshot()
             }
 
             override fun onServiceDisconnected(name: ComponentName) {
@@ -165,7 +170,7 @@ class PartoutTunnel(
 
     // Messaging
 
-    fun requestStatus() {
+    fun requestSnapshot() {
         val msg = Message.obtain(null, PartoutVpnServiceRuntime.MSG_GET_STATUS).apply {
             replyTo = clientMessenger
         }

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -7,6 +7,8 @@ package io.partout
 import android.app.Service
 import android.content.Intent
 import android.net.VpnService
+import android.os.Binder
+import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import android.util.Log
 import io.partout.models.TaggedModuleDNS
@@ -37,6 +39,7 @@ class PartoutVpnServiceRuntime(
 ) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandMutex = Mutex()
+    private val binder = Binder()
     private var descriptor: ParcelFileDescriptor? = null
     private var isRunning = false
     private var latestSnapshot: TunnelSnapshot? = null
@@ -77,6 +80,10 @@ class PartoutVpnServiceRuntime(
         disconnect()
     }
 
+    @Suppress("UNUSED_PARAMETER")
+    fun onBind(intent: Intent?): IBinder? {
+        return binder
+    }
     // Actions
 
     private fun connect(profileJSON: String) = launchCommand {
@@ -90,7 +97,6 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to start VPN daemon (code=${result.code}): ${result.payload}")
             stopService()
             isRunning = false
-            sendSnapshot(null)
             return@launchCommand
         }
         Log.i(logTag, "Started VPN daemon")
@@ -112,7 +118,7 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to stop VPN daemon (code=${result.code}): ${result.payload}")
         }
         isRunning = false
-        sendSnapshot(null)
+        sendFinalSnapshot()
     }
 
     private fun launchCommand(action: suspend () -> Unit) {
@@ -240,25 +246,20 @@ class PartoutVpnServiceRuntime(
 
     // Broadcasts emitters
 
-    private fun sendSnapshot(snapshot: TunnelSnapshot?) {
-        val newSnapshot: TunnelSnapshot?
-        if (snapshot != null) {
-            newSnapshot = snapshot
-        } else {
-            newSnapshot = latestSnapshot?.disabled()
-        }
-        if (newSnapshot == latestSnapshot) {
-            return
-        }
-        Log.d(logTag, "Report daemon snapshot: $newSnapshot")
+    private fun sendSnapshot(snapshot: TunnelSnapshot) {
+        Log.d(logTag, "Report daemon snapshot: $snapshot")
         val intent = Intent(ACTION_SNAPSHOT).apply {
             setPackage(service.packageName)
-            newSnapshot?.let {
-                putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(it))
-            }
+            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
         }
         service.sendBroadcast(intent)
-        latestSnapshot = newSnapshot
+        latestSnapshot = snapshot
+    }
+
+    private fun sendFinalSnapshot() {
+        latestSnapshot?.let {
+            sendSnapshot(it.disabled())
+        }
     }
 
     // Nested classes

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -7,7 +7,6 @@ package io.partout
 import android.app.Service
 import android.content.Intent
 import android.net.VpnService
-import android.os.Binder
 import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
@@ -22,7 +21,6 @@ import io.partout.models.TaggedModuleIP
 import io.partout.models.TaggedModuleOnDemand
 import io.partout.models.TunnelRemoteInfoWrapper
 import io.partout.models.TunnelSnapshot
-import io.partout.models.TunnelStatus
 import io.partout.vpn.DNSModuleApplying
 import io.partout.vpn.HTTPProxyModuleApplying
 import io.partout.vpn.IPModuleApplying

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -146,7 +146,7 @@ class PartoutVpnServiceRuntime(
             override fun handleMessage(msg: Message) {
                 when (msg.what) {
                     MSG_GET_STATUS -> {
-                        msg.replyTo?.let { replyStatus(it) }
+                        msg.replyTo?.let { replySnapshot(it) }
                     }
                     else -> super.handleMessage(msg)
                 }
@@ -154,10 +154,14 @@ class PartoutVpnServiceRuntime(
         }
     )
 
-    private fun replyStatus(client: Messenger) {
-        val status = latestSnapshot?.status ?: TunnelStatus.inactive
+    private fun replySnapshot(client: Messenger) {
+        val snapshotJSON = latestSnapshot?.let {
+            json.encodeToString(it)
+        }
         val bundle = Bundle().apply {
-            putString(MSG_KEY_STATUS, status.value)
+            snapshotJSON?.let {
+                putString(MSG_KEY_SNAPSHOT, it)
+            }
         }
         val msg = Message.obtain(null, MSG_GET_STATUS).apply {
             data = bundle
@@ -322,7 +326,7 @@ class PartoutVpnServiceRuntime(
         const val EXTRA_SNAPSHOT_JSON = "io.partout.extra.SNAPSHOT_JSON"
 
         const val MSG_GET_STATUS = 1
-        const val MSG_KEY_STATUS = "status"
+        const val MSG_KEY_SNAPSHOT = "snapshot"
 
         private val json = Json {
             ignoreUnknownKeys = true

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -8,7 +8,12 @@ import android.app.Service
 import android.content.Intent
 import android.net.VpnService
 import android.os.Binder
+import android.os.Bundle
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
 import android.os.ParcelFileDescriptor
 import android.util.Log
 import io.partout.models.TaggedModuleDNS
@@ -17,6 +22,7 @@ import io.partout.models.TaggedModuleIP
 import io.partout.models.TaggedModuleOnDemand
 import io.partout.models.TunnelRemoteInfoWrapper
 import io.partout.models.TunnelSnapshot
+import io.partout.models.TunnelStatus
 import io.partout.vpn.DNSModuleApplying
 import io.partout.vpn.HTTPProxyModuleApplying
 import io.partout.vpn.IPModuleApplying
@@ -39,7 +45,6 @@ class PartoutVpnServiceRuntime(
 ) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandMutex = Mutex()
-    private val binder = Binder()
     private var descriptor: ParcelFileDescriptor? = null
     private var isRunning = false
     private var latestSnapshot: TunnelSnapshot? = null
@@ -80,10 +85,6 @@ class PartoutVpnServiceRuntime(
         disconnect()
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    fun onBind(intent: Intent?): IBinder? {
-        return binder
-    }
     // Actions
 
     private fun connect(profileJSON: String) = launchCommand {
@@ -131,6 +132,37 @@ class PartoutVpnServiceRuntime(
 
     private fun close() {
         serviceScope.cancel()
+    }
+
+    // Messaging
+
+    @Suppress("UNUSED_PARAMETER")
+    fun onBind(intent: Intent?): IBinder? {
+        return messenger.binder
+    }
+
+    private val messenger = Messenger(
+        object : Handler(Looper.getMainLooper()) {
+            override fun handleMessage(msg: Message) {
+                when (msg.what) {
+                    MSG_GET_STATUS -> {
+                        msg.replyTo?.let { replyStatus(it) }
+                    }
+                    else -> super.handleMessage(msg)
+                }
+            }
+        }
+    )
+
+    private fun replyStatus(client: Messenger) {
+        val status = latestSnapshot?.status ?: TunnelStatus.inactive
+        val bundle = Bundle().apply {
+            putString(MSG_KEY_STATUS, status.value)
+        }
+        val msg = Message.obtain(null, MSG_GET_STATUS).apply {
+            data = bundle
+        }
+        client.send(msg)
     }
 
     // WARNING: These methods are called from a JNI background thread
@@ -288,6 +320,9 @@ class PartoutVpnServiceRuntime(
         const val EXTRA_PROFILE_ID = "io.partout.extra.PROFILE_ID"
         const val EXTRA_PROFILE_JSON = "io.partout.extra.PROFILE_JSON"
         const val EXTRA_SNAPSHOT_JSON = "io.partout.extra.SNAPSHOT_JSON"
+
+        const val MSG_GET_STATUS = 1
+        const val MSG_KEY_STATUS = "status"
 
         private val json = Json {
             ignoreUnknownKeys = true


### PR DESCRIPTION
Bind to the service with a `Messenger` so that `PartoutTunnel` can:

- Request the latest tunnel snapshot on app launch
- Be notified of unexpected service death

The same setup will be useful later for more advanced messaging, e.g., to fetch the tunnel logs or other connection metadata.