### PR TITLE
Android: Externalize more runtime to Engine

### DIFF
--- a/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
+++ b/Tests/PartoutCoreTests/SimpleConnectionDaemonTests.swift
@@ -16,11 +16,7 @@ struct SimpleConnectionDaemonTests {
             .build()
 
         let sut = try newDaemon(with: profile)
-        do {
-            try await sut.start()
-        } catch {
-            #expect(Bool(false), error.localizedComment)
-        }
+        try await withStartedDaemon(sut)
     }
 
     @Test
@@ -36,10 +32,11 @@ struct SimpleConnectionDaemonTests {
         let sut = try newDaemon(with: profile, reachability: reachability)
         let stream = sut.statusStream
 
-        try await sut.start()
-        #expect(await stream.nextElement() == .disconnected)
-        #expect(await stream.nextElement() == .connecting)
-        #expect(await stream.nextElement() == .connected)
+        try await withStartedDaemon(sut) {
+            #expect(await stream.nextElement() == .disconnected)
+            #expect(await stream.nextElement() == .connecting)
+            #expect(await stream.nextElement() == .connected)
+        }
     }
 
     @Test
@@ -82,11 +79,8 @@ struct SimpleConnectionDaemonTests {
                 }
             }
         )
-        do {
-            try await sut.start()
+        try await withStartedDaemon(sut) {
             try await expLastError.fulfillment(timeout: 500)
-        } catch {
-            #expect(Bool(false), error.localizedComment)
         }
     }
 
@@ -115,14 +109,15 @@ struct SimpleConnectionDaemonTests {
             }
         }
 
-        try await sut.start()
-        Task {
-            reachability.isReachable = true
+        try await withStartedDaemon(sut) {
+            Task {
+                reachability.isReachable = true
+            }
+            try await expAvailable.fulfillment(timeout: 500)
+            #expect(await stream.nextElement() == .disconnected)
+            #expect(await stream.nextElement() == .connecting)
+            #expect(await stream.nextElement() == .connected)
         }
-        try await expAvailable.fulfillment(timeout: 500)
-        #expect(await stream.nextElement() == .disconnected)
-        #expect(await stream.nextElement() == .connecting)
-        #expect(await stream.nextElement() == .connected)
     }
 
     @Test
@@ -155,12 +150,13 @@ struct SimpleConnectionDaemonTests {
         )
         let stream = sut.statusStream
 
-        try await sut.start()
-        #expect(await stream.nextElement() == .disconnected)
-        #expect(await stream.nextElement() == .connecting)
-        #expect(await stream.nextElement() == .connected)
-        try await expLastError.fulfillment(timeout: 500)
-        try await expCancel.fulfillment(timeout: 500)
+        try await withStartedDaemon(sut) {
+            #expect(await stream.nextElement() == .disconnected)
+            #expect(await stream.nextElement() == .connecting)
+            #expect(await stream.nextElement() == .connected)
+            try await expLastError.fulfillment(timeout: 500)
+            try await expCancel.fulfillment(timeout: 500)
+        }
     }
 
     @Test
@@ -186,11 +182,12 @@ struct SimpleConnectionDaemonTests {
         )
         let stream = sut.statusStream
 
-        try await sut.start()
-        #expect(await stream.nextElement() == .disconnected)
-        #expect(await stream.nextElement() == .connecting)
-        #expect(await stream.nextElement() == .connected)
-        try await expLastError.fulfillment(timeout: 500)
+        try await withStartedDaemon(sut) {
+            #expect(await stream.nextElement() == .disconnected)
+            #expect(await stream.nextElement() == .connecting)
+            #expect(await stream.nextElement() == .connected)
+            try await expLastError.fulfillment(timeout: 500)
+        }
     }
 
     @Test
@@ -224,16 +221,17 @@ struct SimpleConnectionDaemonTests {
         )
         let stream = sut.statusStream
 
-        try await sut.start()
-        #expect(await stream.nextElement() == .disconnected)
-        #expect(await stream.nextElement() == .connecting)
-        #expect(await stream.nextElement() == .connected)
-        try await expDataCount.fulfillment(timeout: 1000)
+        try await withStartedDaemon(sut) {
+            #expect(await stream.nextElement() == .disconnected)
+            #expect(await stream.nextElement() == .connecting)
+            #expect(await stream.nextElement() == .connected)
+            try await expDataCount.fulfillment(timeout: 1000)
 
-        let dataCounts = await recorder.dataCounts.filter { $0 != DataCount() }
-        #expect(!dataCounts.contains(DataCount(40, 0)))
-        #expect(!dataCounts.contains(DataCount(80, 0)))
-        #expect(dataCounts.contains(DataCount(140, 0)))
+            let dataCounts = await recorder.dataCounts.filter { $0 != DataCount() }
+            #expect(!dataCounts.contains(DataCount(40, 0)))
+            #expect(!dataCounts.contains(DataCount(80, 0)))
+            #expect(dataCounts.contains(DataCount(140, 0)))
+        }
     }
 
     @Test
@@ -296,6 +294,20 @@ struct SimpleConnectionDaemonTests {
 // MARK: - Helpers
 
 private extension SimpleConnectionDaemonTests {
+    func withStartedDaemon(
+        _ daemon: SimpleConnectionDaemon,
+        operation: () async throws -> Void = {}
+    ) async throws {
+        try await daemon.start()
+        do {
+            try await operation()
+        } catch {
+            await daemon.stop()
+            throw error
+        }
+        await daemon.stop()
+    }
+
     func newDaemon(
         with profile: Profile,
         reachability: ReachabilityObserver = MockReachabilityObserver(),

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -33,10 +33,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import java.io.File
 
 class PartoutVpnServiceRuntime(
     private val logTag: String,
@@ -48,8 +46,6 @@ class PartoutVpnServiceRuntime(
     private var descriptor: ParcelFileDescriptor? = null
     private var isRunning = false
     private var latestSnapshot: TunnelSnapshot? = null
-
-    private val lastProfilePath = File(service.noBackupFilesDir, "tunnel_profile.json")
 
     // Service lifecycle
 
@@ -87,14 +83,10 @@ class PartoutVpnServiceRuntime(
         val json = intent?.getStringExtra(EXTRA_PROFILE_JSON)
         if (json.isNullOrBlank()) {
             Log.i(logTag, "No profile from VPN start intent, loading last persisted")
-            return withContext(Dispatchers.IO) {
-                lastProfilePath.readText()
-            }
+            return engine.readLastProfile()
         }
         Log.i(logTag, "Profile from VPN start intent, persisting it")
-        withContext(Dispatchers.IO) {
-            lastProfilePath.writeText(json)
-        }
+        engine.writeLastProfile(json)
         return json
     }
 
@@ -335,6 +327,8 @@ class PartoutVpnServiceRuntime(
     interface Engine {
         suspend fun start(runtime: PartoutVpnServiceRuntime, profileJSON: String): Result
         suspend fun stop(): Result
+        suspend fun readLastProfile(): String
+        suspend fun writeLastProfile(json: String)
     }
 
     private fun stopService() {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -41,8 +41,7 @@ import java.io.File
 class PartoutVpnServiceRuntime(
     private val logTag: String,
     private val service: VpnService,
-    private val engine: Engine,
-    private val stopService: () -> Unit,
+    private val engine: Engine
 ) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandMutex = Mutex()
@@ -326,7 +325,7 @@ class PartoutVpnServiceRuntime(
         }
     }
 
-    // Nested classes
+    // Helpers
 
     data class Result(
         val code: Int,
@@ -336,6 +335,10 @@ class PartoutVpnServiceRuntime(
     interface Engine {
         suspend fun start(runtime: PartoutVpnServiceRuntime, profileJSON: String): Result
         suspend fun stop(): Result
+    }
+
+    private fun stopService() {
+        service.stopSelf()
     }
 
     private fun TunnelSnapshot.disabled() = TunnelSnapshot(

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -86,7 +86,12 @@ class PartoutVpnServiceRuntime(
             return engine.readLastProfile()
         }
         Log.i(logTag, "Profile from VPN start intent, persisting it")
-        engine.writeLastProfile(json)
+        try {
+            engine.writeLastProfile(json)
+        } catch (e: Exception) {
+            e.throwIfCancellation()
+            Log.w(logTag, "Unable to persist profile JSON, continuing with intent profile", e)
+        }
         return json
     }
 
@@ -95,7 +100,7 @@ class PartoutVpnServiceRuntime(
             loadOrPersistProfile(intent)
         } catch (e: Exception) {
             e.throwIfCancellation()
-            Log.e(logTag, "Unable to load or persist profile JSON", e)
+            Log.e(logTag, "Unable to load profile JSON", e)
             stopService()
             return@launchCommand
         }


### PR DESCRIPTION
- Having `service`, invoke .stopSelf() directly
- Externalize last profile persistence
- Start anyway if unable to persist last profile