### PR TITLE
Android: Review runtime/JNI thread-safety

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - "**/*.md"
       - "scripts/*.sh"
       - "scripts/*.ps1"
+      - "**/*.kt" # For now
 
 concurrency:
   group: ${{ github.ref }}

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -20,7 +20,7 @@ public final class NativeTunnelController: TunnelController {
     ) throws {
         self.ctx = ctx
 #if os(Android)
-        pp_log(ctx, .core, .debug, "NativeTunnelController: Retain JNI ref to PartoutVpnServiceRuntime")
+        pp_log(ctx, .core, .debug, "NativeTunnelController: Retain JNI ref")
         guard let retainedRef = pp_jni_new_global_ref(ref) else {
             throw PartoutError(.releasedObject)
         }
@@ -36,7 +36,7 @@ public final class NativeTunnelController: TunnelController {
     deinit {
         pp_log(ctx, .core, .debug, "Deinit NativeTunnelController")
 #if os(Android)
-        pp_log(ctx, .core, .debug, "NativeTunnelController: Release JNI ref to PartoutVpnServiceRuntime")
+        pp_log(ctx, .core, .debug, "NativeTunnelController: Release JNI ref")
         pp_jni_delete_global_ref(ref)
 #endif
     }

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -113,6 +113,7 @@ public final class NativeTunnelController: TunnelController {
             pp_tun_ctrl_cancel_tunnel(ref, nil)
             return
         }
+        // FIXME: ###, Use PartoutError.Code
         String(describing: error).withCString {
             pp_tun_ctrl_cancel_tunnel(ref, $0)
         }

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -183,6 +183,12 @@ void pp_tun_ctrl_configure_sockets(void *jni_ref, const int *fds, const size_t f
     }
     (*env)->SetIntArrayRegion(env, j_fds, 0, (jsize)fds_len, (const jint *)fds);
     (*env)->CallVoidMethod(env, jni_ref, method, j_fds);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_configure_sockets(), Kotlin exception");
+        goto cleanup;
+    }
 
 cleanup:
     if (j_fds != NULL) (*env)->DeleteLocalRef(env, j_fds);

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -13,18 +13,8 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.Message
 import android.os.Messenger
-import android.os.ParcelFileDescriptor
 import android.util.Log
-import io.partout.models.TaggedModuleDNS
-import io.partout.models.TaggedModuleHTTPProxy
-import io.partout.models.TaggedModuleIP
-import io.partout.models.TaggedModuleOnDemand
-import io.partout.models.TunnelRemoteInfoWrapper
 import io.partout.models.TunnelSnapshot
-import io.partout.vpn.DNSModuleApplying
-import io.partout.vpn.HTTPProxyModuleApplying
-import io.partout.vpn.IPModuleApplying
-import io.partout.vpn.OnDemandModuleApplying
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,26 +23,15 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-
-// Must match signatures in tun_android.c
-interface PartoutVpnServiceRuntimeJNI {
-    fun testWorking()
-    fun setTunnel(infoJSON: String): Int
-    fun configureSockets(fds: IntArray)
-    fun onSnapshot(snapshotJSON: String)
-    fun cancelTunnel(errorMessage: String?)
-}
 
 class PartoutVpnServiceRuntime(
     private val logTag: String,
     private val service: VpnService,
     private val engine: Engine
-): PartoutVpnServiceRuntimeJNI {
+) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandMutex = Mutex()
-    private var descriptor: ParcelFileDescriptor? = null
     private var latestSnapshot: TunnelSnapshot? = null
     private var isRunning = false
 
@@ -116,112 +95,6 @@ class PartoutVpnServiceRuntime(
     private fun deferDisconnect() = launchCommand {
         stopTunnel()
         stopService()
-    }
-    //endregion
-
-    //region Actions (C/JNI)
-    override fun testWorking() {
-        Log.d(logTag, "PartoutVpnServiceRuntime.testWorking()")
-    }
-
-    override fun setTunnel(infoJSON: String): Int {
-        Log.d(logTag, "PartoutVpnServiceRuntime.setTunnel()")
-        if (descriptor != null) {
-            Log.e(logTag, "Tunnel descriptor already established")
-            return -1
-        }
-
-        val builder = service.Builder()
-        val info: TunnelRemoteInfoWrapper = try {
-            json.decodeFromString(infoJSON)
-        } catch (e: SerializationException) {
-            Log.e(logTag, "Unable to decode tunnel info JSON", e)
-            return -1
-        }
-        val remoteFds = info.fileDescriptors
-        var appliedAddressSettings = false
-        var appliedDnsSettings = false
-
-        info.modules?.forEach {
-            when (it) {
-                is TaggedModuleDNS -> {
-                    Log.i(logTag, "DNS: ${it.value}")
-                    appliedDnsSettings = DNSModuleApplying(it.value).apply(logTag, builder)
-                            || appliedDnsSettings
-                }
-                is TaggedModuleIP -> {
-                    Log.i(logTag, "IP: ${it.value}")
-                    appliedAddressSettings = IPModuleApplying(it.value).apply(logTag, builder)
-                            || appliedAddressSettings
-                }
-                is TaggedModuleHTTPProxy -> {
-                    Log.i(logTag, "HTTP Proxy: ${it.value}")
-                    HTTPProxyModuleApplying(it.value).apply(logTag, builder)
-                }
-                is TaggedModuleOnDemand -> {
-                    Log.i(logTag, "OnDemand: ${it.value}")
-                    OnDemandModuleApplying(it.value).apply(logTag, builder)
-                }
-                else -> {}
-            }
-        }
-
-        if (!appliedAddressSettings) {
-            Log.e(logTag, "No valid interface address")
-            return -1
-        }
-
-        remoteFds.forEach {
-            require(it in 0..Int.MAX_VALUE.toLong()) {
-                "Invalid Android file descriptor: $it"
-            }
-            val protected = service.protect(it.toInt())
-            Log.d(logTag, "protect($it) = $protected")
-        }
-
-        // IMPORTANT: this is a requirement for VirtualTunnelInterface.
-        // By default, establish() returns a non-blocking descriptor.
-        builder.setBlocking(true)
-
-        descriptor = try {
-            builder.establish()
-        } catch (e: RuntimeException) {
-            Log.e(logTag, "Unable to establish tunnel", e)
-            null
-        }
-        if (descriptor == null) {
-            Log.e(logTag, "Unable to establish tunnel")
-            return -1
-        }
-
-        val fd = descriptor?.detachFd() ?: -1
-        descriptor = null
-        Log.i(logTag, "Established tunnel descriptor: $fd")
-        return fd
-    }
-
-    override fun configureSockets(fds: IntArray) {
-        Log.d(logTag, "PartoutVpnServiceRuntime.configureSockets(${fds.toList()})")
-        fds.forEach {
-            val protected = service.protect(it)
-            Log.d(logTag, "protect($it) = $protected")
-        }
-    }
-
-    override fun onSnapshot(snapshotJSON: String) {
-        Log.d(logTag, "PartoutVpnServiceRuntime.onSnapshot()")
-        val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
-        sendSnapshot(snapshot)
-    }
-
-    override fun cancelTunnel(errorMessage: String?) {
-        Log.d(logTag, "PartoutVpnServiceRuntime.cancelTunnel()")
-        if (errorMessage != null) {
-            Log.e(logTag, "VPN daemon cancelled: $errorMessage")
-        } else {
-            Log.i(logTag, "VPN daemon cancelled")
-        }
-        deferDisconnect()
     }
     //endregion
 

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -92,14 +92,16 @@ class PartoutVpnServiceRuntime(
         // Stop current tunnel if running
         stopTunnel()
 
+        // Observe snapshots during start attempt
         synchronized(snapshotLock) {
             acceptsSnapshots = true
         }
+
         isRunning = true
         Log.i(logTag, "Starting VPN daemon")
-
-        val result = try {
+        try {
             engine.start(this, profileJSON)
+            Log.i(logTag, "Started VPN daemon")
         } catch (e: Exception) {
             e.throwIfCancellation()
             Log.e(logTag, "Unable to start VPN daemon", e)
@@ -110,22 +112,11 @@ class PartoutVpnServiceRuntime(
             isRunning = false
             return@launchCommand
         }
-        if (result.code != 0) {
-            Log.e(logTag, "Unable to start VPN daemon (code=${result.code}): ${result.payload}")
-            stopService()
-            synchronized(snapshotLock) {
-                acceptsSnapshots = false
-            }
-            isRunning = false
-            return@launchCommand
-        }
-        Log.i(logTag, "Started VPN daemon")
     }
 
     fun sendSnapshot(snapshot: TunnelSnapshot) = synchronized(snapshotLock) {
-        if (acceptsSnapshots) {
-            emitSnapshot(snapshot)
-        }
+        if (!acceptsSnapshots) { return }
+        emitSnapshot(snapshot)
     }
 
     fun disconnect() = launchCommand {
@@ -163,11 +154,10 @@ class PartoutVpnServiceRuntime(
         if (!isRunning) { return }
 
         Log.i(logTag, "Stopping VPN daemon")
-        val result = engine.stop()
-        if (result.code == 0) {
-            Log.i(logTag, "Stopped VPN daemon")
-        } else {
-            Log.e(logTag, "Unable to stop VPN daemon (code=${result.code}): ${result.payload}")
+        try {
+            engine.stop()
+        } catch (e: Exception) {
+            Log.e(logTag, "Unable to stop VPN daemon", e)
         }
         isRunning = false
         sendFinalSnapshot()
@@ -182,6 +172,26 @@ class PartoutVpnServiceRuntime(
         commandQueue.close()
         serviceScope.cancel()
     }
+    //endregion
+
+    //region Snapshots
+    private fun emitSnapshot(snapshot: TunnelSnapshot) {
+        Log.d(logTag, "Emit daemon snapshot: $snapshot")
+        val intent = Intent(ACTION_SNAPSHOT).apply {
+            setPackage(service.packageName)
+            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+        }
+        latestSnapshot = snapshot
+        service.sendBroadcast(intent)
+    }
+
+    private fun TunnelSnapshot.disabled() = TunnelSnapshot(
+        id,
+        false,
+        false,
+        status,
+        environment
+    )
     //endregion
 
     //region Messaging
@@ -227,35 +237,10 @@ class PartoutVpnServiceRuntime(
     }
     //endregion
 
-    //region Snapshots
-    private fun emitSnapshot(snapshot: TunnelSnapshot) {
-        Log.d(logTag, "Emit daemon snapshot: $snapshot")
-        val intent = Intent(ACTION_SNAPSHOT).apply {
-            setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
-        }
-        latestSnapshot = snapshot
-        service.sendBroadcast(intent)
-    }
-
-    private fun TunnelSnapshot.disabled() = TunnelSnapshot(
-        id,
-        false,
-        false,
-        status,
-        environment
-    )
-    //endregion
-
     //region Engine
-    data class Result(
-        val code: Int,
-        val payload: String?
-    )
-
     interface Engine {
-        suspend fun start(runtime: PartoutVpnServiceRuntime, profileJSON: String): Result
-        suspend fun stop(): Result
+        suspend fun start(runtime: PartoutVpnServiceRuntime, profileJSON: String)
+        suspend fun stop()
         suspend fun readLastProfile(): String
         suspend fun writeLastProfile(json: String)
     }

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -36,11 +36,20 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
+// Must match signatures in tun_android.c
+interface PartoutVpnServiceRuntimeJNI {
+    fun testWorking()
+    fun setTunnel(infoJSON: String): Int
+    fun configureSockets(fds: IntArray)
+    fun onSnapshot(snapshotJSON: String)
+    fun cancelTunnel(errorMessage: String?)
+}
+
 class PartoutVpnServiceRuntime(
     private val logTag: String,
     private val service: VpnService,
     private val engine: Engine
-) {
+): PartoutVpnServiceRuntimeJNI {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandMutex = Mutex()
     private var descriptor: ParcelFileDescriptor? = null
@@ -204,12 +213,12 @@ class PartoutVpnServiceRuntime(
     }
     //endregion
 
-    //region C/JNI (keep signatures!)
-    fun testWorking() {
+    //region C/JNI
+    override fun testWorking() {
         Log.d(logTag, "PartoutVpnServiceRuntime.testWorking()")
     }
 
-    fun setTunnel(infoJSON: String): Int {
+    override fun setTunnel(infoJSON: String): Int {
         Log.d(logTag, "PartoutVpnServiceRuntime.setTunnel()")
         if (descriptor != null) {
             Log.e(logTag, "Tunnel descriptor already established")
@@ -285,7 +294,7 @@ class PartoutVpnServiceRuntime(
         return fd
     }
 
-    fun configureSockets(fds: IntArray) {
+    override fun configureSockets(fds: IntArray) {
         Log.d(logTag, "PartoutVpnServiceRuntime.configureSockets(${fds.toList()})")
         fds.forEach {
             val protected = service.protect(it)
@@ -293,13 +302,13 @@ class PartoutVpnServiceRuntime(
         }
     }
 
-    fun onSnapshot(snapshotJSON: String) {
+    override fun onSnapshot(snapshotJSON: String) {
         Log.d(logTag, "PartoutVpnServiceRuntime.onSnapshot()")
         val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
         sendSnapshot(snapshot)
     }
 
-    fun cancelTunnel(errorMessage: String?) {
+    override fun cancelTunnel(errorMessage: String?) {
         Log.d(logTag, "PartoutVpnServiceRuntime.cancelTunnel()")
         if (errorMessage != null) {
             Log.e(logTag, "VPN daemon cancelled: $errorMessage")

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 
 class PartoutVpnServiceRuntime(
@@ -31,9 +31,23 @@ class PartoutVpnServiceRuntime(
     private val engine: Engine
 ) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-    private val commandMutex = Mutex()
+    private val commandQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
     private var latestSnapshot: TunnelSnapshot? = null
     private var isRunning = false
+
+    init {
+        serviceScope.launch {
+            for (action in commandQueue) {
+                try {
+                    action()
+                } catch (e: Exception) {
+                    e.throwIfCancellation()
+                    Log.e(logTag, "Unhandled VPN command failure", e)
+                    stopService()
+                }
+            }
+        }
+    }
 
     //region Lifecycle
     @Suppress("UNUSED_PARAMETER")
@@ -49,10 +63,6 @@ class PartoutVpnServiceRuntime(
 
     fun onDestroy() {
         Log.i(logTag, "PartoutVpnServiceRuntime.onDestroy()")
-        if (!isRunning) {
-            close()
-            return
-        }
         launchCommand {
             stopTunnel()
             close()
@@ -93,13 +103,7 @@ class PartoutVpnServiceRuntime(
     }
 
     fun sendSnapshot(snapshot: TunnelSnapshot) = launchCommand {
-        Log.d(logTag, "Report daemon snapshot: $snapshot")
-        val intent = Intent(ACTION_SNAPSHOT).apply {
-            setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
-        }
-        latestSnapshot = snapshot
-        service.sendBroadcast(intent)
+        emitSnapshot(snapshot)
     }
 
     fun disconnect() = launchCommand {
@@ -126,9 +130,9 @@ class PartoutVpnServiceRuntime(
     }
 
     private fun sendFinalSnapshot() {
-        Log.d(logTag, "Report final daemon snapshot")
+        Log.d(logTag, "Emit final daemon snapshot")
         latestSnapshot?.let {
-            sendSnapshot(it.disabled())
+            emitSnapshot(it.disabled())
         }
     }
 
@@ -152,6 +156,7 @@ class PartoutVpnServiceRuntime(
 
     private fun close() {
         Log.d(logTag, "Cancelling VPN runtime")
+        commandQueue.close()
         serviceScope.cancel()
     }
     //endregion
@@ -167,7 +172,11 @@ class PartoutVpnServiceRuntime(
             override fun handleMessage(msg: Message) {
                 when (msg.what) {
                     MSG_GET_STATUS -> {
-                        msg.replyTo?.let { replySnapshot(it) }
+                        msg.replyTo?.let { client ->
+                            launchCommand {
+                                replySnapshot(client)
+                            }
+                        }
                     }
                     else -> super.handleMessage(msg)
                 }
@@ -187,7 +196,11 @@ class PartoutVpnServiceRuntime(
         val msg = Message.obtain(null, MSG_GET_STATUS).apply {
             data = bundle
         }
-        client.send(msg)
+        try {
+            client.send(msg)
+        } catch (e: Exception) {
+            Log.w(logTag, "Unable to reply with VPN snapshot", e)
+        }
     }
     //endregion
 
@@ -207,17 +220,19 @@ class PartoutVpnServiceRuntime(
 
     //region Generic helpers
     private fun launchCommand(action: suspend () -> Unit) {
-        serviceScope.launch {
-            commandMutex.withLock {
-                try {
-                    action()
-                } catch (e: Exception) {
-                    e.throwIfCancellation()
-                    Log.e(logTag, "Unhandled VPN command failure", e)
-                    stopService()
-                }
-            }
+        commandQueue.trySend(action).onFailure {
+            Log.w(logTag, "Unable to enqueue VPN command", it)
         }
+    }
+
+    private fun emitSnapshot(snapshot: TunnelSnapshot) {
+        Log.d(logTag, "Emit daemon snapshot: $snapshot")
+        val intent = Intent(ACTION_SNAPSHOT).apply {
+            setPackage(service.packageName)
+            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+        }
+        latestSnapshot = snapshot
+        service.sendBroadcast(intent)
     }
 
     private fun TunnelSnapshot.disabled() = TunnelSnapshot(

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -14,6 +14,7 @@ import android.os.Looper
 import android.os.Message
 import android.os.Messenger
 import android.util.Log
+import io.partout.models.TaggedProfile
 import io.partout.models.TunnelSnapshot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -36,6 +37,7 @@ class PartoutVpnServiceRuntime(
     @Volatile
     private var latestSnapshot: TunnelSnapshot? = null
     private var acceptsSnapshots = false
+    private var activeSnapshotProfileId: String? = null
     private var isRunning = false
 
     init {
@@ -88,6 +90,14 @@ class PartoutVpnServiceRuntime(
             stopService()
             return@launchCommand
         }
+        val profileId = try {
+            decodeProfileId(profileJSON)
+        } catch (e: Exception) {
+            e.throwIfCancellation()
+            Log.e(logTag, "Unable to decode profile JSON", e)
+            stopService()
+            return@launchCommand
+        }
 
         // Stop current tunnel if running
         stopTunnel()
@@ -95,6 +105,8 @@ class PartoutVpnServiceRuntime(
         // Observe snapshots during start attempt
         synchronized(snapshotLock) {
             acceptsSnapshots = true
+            activeSnapshotProfileId = profileId
+            latestSnapshot = null
         }
 
         isRunning = true
@@ -108,6 +120,7 @@ class PartoutVpnServiceRuntime(
             stopService()
             synchronized(snapshotLock) {
                 acceptsSnapshots = false
+                activeSnapshotProfileId = null
             }
             isRunning = false
             return@launchCommand
@@ -116,6 +129,10 @@ class PartoutVpnServiceRuntime(
 
     fun sendSnapshot(snapshot: TunnelSnapshot) = synchronized(snapshotLock) {
         if (!acceptsSnapshots) { return }
+        if (snapshot.id != activeSnapshotProfileId) {
+            Log.d(logTag, "Drop stale daemon snapshot: $snapshot")
+            return
+        }
         emitSnapshot(snapshot)
     }
 
@@ -142,12 +159,17 @@ class PartoutVpnServiceRuntime(
         return json
     }
 
+    private fun decodeProfileId(profileJSON: String): String {
+        return json.decodeFromString<TaggedProfile>(profileJSON).id
+    }
+
     private fun sendFinalSnapshot() = synchronized(snapshotLock) {
         Log.d(logTag, "Emit final daemon snapshot")
         latestSnapshot?.let {
             emitSnapshot(it.disabled())
         }
         acceptsSnapshots = false
+        activeSnapshotProfileId = null
     }
 
     private suspend fun stopTunnel() {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -37,10 +37,7 @@ class PartoutVpnServiceRuntime(
     private var isRunning = false
 
     // Deliver snapshots with mutex
-    private val snapshotLock = Any()
-    private var acceptsSnapshots = false
-    private var activeSnapshotProfileId: String? = null
-    @Volatile private var latestSnapshot: TunnelSnapshot? = null
+    private val snapshotEmitter = SnapshotEmitter(logTag, service)
 
     init {
         serviceScope.launch {
@@ -105,11 +102,7 @@ class PartoutVpnServiceRuntime(
         stopTunnel()
 
         // Observe snapshots during start attempt
-        synchronized(snapshotLock) {
-            acceptsSnapshots = true
-            activeSnapshotProfileId = profileId
-            latestSnapshot = null
-        }
+        snapshotEmitter.accept(profileId)
 
         isRunning = true
         Log.i(logTag, "Starting VPN daemon")
@@ -120,22 +113,14 @@ class PartoutVpnServiceRuntime(
             e.throwIfCancellation()
             Log.e(logTag, "Unable to start VPN daemon", e)
             stopService()
-            synchronized(snapshotLock) {
-                acceptsSnapshots = false
-                activeSnapshotProfileId = null
-            }
+            snapshotEmitter.shutdown()
             isRunning = false
             return@launchCommand
         }
     }
 
-    fun sendSnapshot(snapshot: TunnelSnapshot) = synchronized(snapshotLock) {
-        if (!acceptsSnapshots) { return }
-        if (snapshot.id != activeSnapshotProfileId) {
-            Log.d(logTag, "Drop stale daemon snapshot: $snapshot")
-            return
-        }
-        emitSnapshot(snapshot)
+    fun sendSnapshot(snapshot: TunnelSnapshot) {
+        snapshotEmitter.emit(snapshot)
     }
 
     fun disconnect() = launchCommand {
@@ -165,15 +150,6 @@ class PartoutVpnServiceRuntime(
         return json.decodeFromString<TaggedProfile>(profileJSON).id
     }
 
-    private fun sendFinalSnapshot() = synchronized(snapshotLock) {
-        Log.d(logTag, "Emit final daemon snapshot")
-        latestSnapshot?.let {
-            emitSnapshot(it.disabled())
-        }
-        acceptsSnapshots = false
-        activeSnapshotProfileId = null
-    }
-
     private suspend fun stopTunnel() {
         if (!isRunning) { return }
 
@@ -184,7 +160,7 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to stop VPN daemon", e)
         }
         isRunning = false
-        sendFinalSnapshot()
+        snapshotEmitter.emitFinal()
     }
 
     private fun stopService() {
@@ -199,23 +175,70 @@ class PartoutVpnServiceRuntime(
     //endregion
 
     //region Snapshots
-    private fun emitSnapshot(snapshot: TunnelSnapshot) {
-        Log.d(logTag, "Emit daemon snapshot: $snapshot")
-        val intent = Intent(ACTION_SNAPSHOT).apply {
-            setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
-        }
-        latestSnapshot = snapshot
-        service.sendBroadcast(intent)
-    }
+    private class SnapshotEmitter(
+        private val logTag: String,
+        private val service: Service
+    ) {
+        private val lock = Any()
+        private var isAccepting = false
+        private var activeProfileId: String? = null
+        @Volatile private var latestSnapshot: TunnelSnapshot? = null
 
-    private fun TunnelSnapshot.disabled() = TunnelSnapshot(
-        id,
-        false,
-        false,
-        status,
-        environment
-    )
+        fun accept(profileId: String) {
+            synchronized(lock) {
+                isAccepting = true
+                activeProfileId = profileId
+                latestSnapshot = null
+            }
+        }
+
+        fun shutdown() {
+            synchronized(lock) {
+                isAccepting = false
+                activeProfileId = null
+            }
+        }
+
+        fun emit(snapshot: TunnelSnapshot) = synchronized(lock) {
+            if (!isAccepting) { return }
+            if (snapshot.id != activeProfileId) {
+                Log.d(logTag, "Drop stale daemon snapshot: $snapshot")
+                return
+            }
+            broadcast(snapshot)
+        }
+
+        fun emitFinal() = synchronized(lock) {
+            Log.d(logTag, "Emit final daemon snapshot")
+            latestSnapshot?.let {
+                emit(it.disabled())
+            }
+            isAccepting = false
+            activeProfileId = null
+        }
+
+        fun latest(): TunnelSnapshot? = synchronized(lock) {
+            latestSnapshot
+        }
+
+        private fun broadcast(snapshot: TunnelSnapshot) {
+            Log.d(logTag, "Emit daemon snapshot: $snapshot")
+            val intent = Intent(ACTION_SNAPSHOT).apply {
+                setPackage(service.packageName)
+                putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+            }
+            latestSnapshot = snapshot
+            service.sendBroadcast(intent)
+        }
+
+        private fun TunnelSnapshot.disabled() = TunnelSnapshot(
+            id,
+            false,
+            false,
+            status,
+            environment
+        )
+    }
     //endregion
 
     //region Messaging
@@ -242,7 +265,7 @@ class PartoutVpnServiceRuntime(
     )
 
     private fun replySnapshot(client: Messenger) {
-        val snapshotJSON = latestSnapshot?.let {
+        val snapshotJSON = snapshotEmitter.latest()?.let {
             json.encodeToString(it)
         }
         val bundle = Bundle().apply {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -119,101 +119,7 @@ class PartoutVpnServiceRuntime(
     }
     //endregion
 
-    //region Actions (JNI)
-    //endregion
-
-    //region Action helpers
-    private suspend fun loadOrPersistProfile(intent: Intent?): String {
-        val json = intent?.getStringExtra(EXTRA_PROFILE_JSON)
-        if (json.isNullOrBlank()) {
-            Log.i(logTag, "No profile from VPN start intent, loading last persisted")
-            return engine.readLastProfile()
-        }
-        Log.i(logTag, "Profile from VPN start intent, persisting it")
-        try {
-            engine.writeLastProfile(json)
-        } catch (e: Exception) {
-            e.throwIfCancellation()
-            Log.w(logTag, "Unable to persist profile JSON, continuing with intent profile", e)
-        }
-        return json
-    }
-
-    private fun sendSnapshot(snapshot: TunnelSnapshot) {
-        Log.d(logTag, "Report daemon snapshot: $snapshot")
-        val intent = Intent(ACTION_SNAPSHOT).apply {
-            setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
-        }
-        service.sendBroadcast(intent)
-        latestSnapshot = snapshot
-    }
-
-    private fun sendFinalSnapshot() {
-        latestSnapshot?.let {
-            sendSnapshot(it.disabled())
-        }
-    }
-
-    private suspend fun stopTunnel() {
-        if (!isRunning) { return }
-
-        Log.i(logTag, "Stopping VPN daemon")
-        val result = engine.stop()
-        if (result.code == 0) {
-            Log.i(logTag, "Stopped VPN daemon")
-        } else {
-            Log.e(logTag, "Unable to stop VPN daemon (code=${result.code}): ${result.payload}")
-        }
-        isRunning = false
-        sendFinalSnapshot()
-    }
-
-    private fun stopService() {
-        service.stopSelf()
-    }
-
-    private fun close() {
-        serviceScope.cancel()
-    }
-    //endregion
-
-    //region Messaging
-    @Suppress("UNUSED_PARAMETER")
-    fun onBind(intent: Intent?): IBinder? {
-        return messenger.binder
-    }
-
-    private val messenger = Messenger(
-        object : Handler(Looper.getMainLooper()) {
-            override fun handleMessage(msg: Message) {
-                when (msg.what) {
-                    MSG_GET_STATUS -> {
-                        msg.replyTo?.let { replySnapshot(it) }
-                    }
-                    else -> super.handleMessage(msg)
-                }
-            }
-        }
-    )
-
-    private fun replySnapshot(client: Messenger) {
-        val snapshotJSON = latestSnapshot?.let {
-            json.encodeToString(it)
-        }
-        val bundle = Bundle().apply {
-            snapshotJSON?.let {
-                putString(MSG_KEY_SNAPSHOT, it)
-            }
-        }
-        val msg = Message.obtain(null, MSG_GET_STATUS).apply {
-            data = bundle
-        }
-        client.send(msg)
-    }
-    //endregion
-
-    //region C/JNI
+    //region Actions (C/JNI)
     override fun testWorking() {
         Log.d(logTag, "PartoutVpnServiceRuntime.testWorking()")
     }
@@ -316,6 +222,97 @@ class PartoutVpnServiceRuntime(
             Log.i(logTag, "VPN daemon cancelled")
         }
         deferDisconnect()
+    }
+    //endregion
+
+    //region Action helpers
+    private suspend fun loadOrPersistProfile(intent: Intent?): String {
+        val json = intent?.getStringExtra(EXTRA_PROFILE_JSON)
+        if (json.isNullOrBlank()) {
+            Log.i(logTag, "No profile from VPN start intent, loading last persisted")
+            return engine.readLastProfile()
+        }
+        Log.i(logTag, "Profile from VPN start intent, persisting it")
+        try {
+            engine.writeLastProfile(json)
+        } catch (e: Exception) {
+            e.throwIfCancellation()
+            Log.w(logTag, "Unable to persist profile JSON, continuing with intent profile", e)
+        }
+        return json
+    }
+
+    private fun sendSnapshot(snapshot: TunnelSnapshot) {
+        Log.d(logTag, "Report daemon snapshot: $snapshot")
+        val intent = Intent(ACTION_SNAPSHOT).apply {
+            setPackage(service.packageName)
+            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+        }
+        service.sendBroadcast(intent)
+        latestSnapshot = snapshot
+    }
+
+    private fun sendFinalSnapshot() {
+        latestSnapshot?.let {
+            sendSnapshot(it.disabled())
+        }
+    }
+
+    private suspend fun stopTunnel() {
+        if (!isRunning) { return }
+
+        Log.i(logTag, "Stopping VPN daemon")
+        val result = engine.stop()
+        if (result.code == 0) {
+            Log.i(logTag, "Stopped VPN daemon")
+        } else {
+            Log.e(logTag, "Unable to stop VPN daemon (code=${result.code}): ${result.payload}")
+        }
+        isRunning = false
+        sendFinalSnapshot()
+    }
+
+    private fun stopService() {
+        service.stopSelf()
+    }
+
+    private fun close() {
+        serviceScope.cancel()
+    }
+    //endregion
+
+    //region Messaging
+    @Suppress("UNUSED_PARAMETER")
+    fun onBind(intent: Intent?): IBinder? {
+        return messenger.binder
+    }
+
+    private val messenger = Messenger(
+        object : Handler(Looper.getMainLooper()) {
+            override fun handleMessage(msg: Message) {
+                when (msg.what) {
+                    MSG_GET_STATUS -> {
+                        msg.replyTo?.let { replySnapshot(it) }
+                    }
+                    else -> super.handleMessage(msg)
+                }
+            }
+        }
+    )
+
+    private fun replySnapshot(client: Messenger) {
+        val snapshotJSON = latestSnapshot?.let {
+            json.encodeToString(it)
+        }
+        val bundle = Bundle().apply {
+            snapshotJSON?.let {
+                putString(MSG_KEY_SNAPSHOT, it)
+            }
+        }
+        val msg = Message.obtain(null, MSG_GET_STATUS).apply {
+            data = bundle
+        }
+        client.send(msg)
     }
     //endregion
 

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -126,6 +126,7 @@ class PartoutVpnServiceRuntime(
     }
 
     private suspend fun sendFinalSnapshot() {
+        Log.d(logTag, "Report final daemon snapshot")
         val latest = commandMutex.withLock {
             latestSnapshot
         }
@@ -153,6 +154,7 @@ class PartoutVpnServiceRuntime(
     }
 
     private fun close() {
+        Log.d(logTag, "Cancelling VPN runtime")
         serviceScope.cancel()
     }
     //endregion

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -40,10 +40,10 @@ class PartoutVpnServiceRuntime(
     fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.i(logTag, "PartoutVpnServiceRuntime.onStartCommand()")
         if (intent?.action == ACTION_STOP_VPN) {
-            deferDisconnect()
+            disconnect()
             return Service.START_NOT_STICKY
         }
-        deferConnect(intent)
+        connect(intent)
         return Service.START_STICKY
     }
 
@@ -61,12 +61,12 @@ class PartoutVpnServiceRuntime(
 
     fun onRevoke() {
         Log.i(logTag, "PartoutVpnServiceRuntime.onRevoke()")
-        deferDisconnect()
+        disconnect()
     }
     //endregion
 
     //region Actions (Service)
-    private fun deferConnect(intent: Intent?) = launchCommand {
+    private fun connect(intent: Intent?) = launchCommand {
         val profileJSON = try {
             loadOrPersistProfile(intent)
         } catch (e: Exception) {
@@ -92,7 +92,17 @@ class PartoutVpnServiceRuntime(
         Log.i(logTag, "Started VPN daemon")
     }
 
-    private fun deferDisconnect() = launchCommand {
+    fun sendSnapshot(snapshot: TunnelSnapshot) = launchCommand {
+        Log.d(logTag, "Report daemon snapshot: $snapshot")
+        val intent = Intent(ACTION_SNAPSHOT).apply {
+            setPackage(service.packageName)
+            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+        }
+        service.sendBroadcast(intent)
+        latestSnapshot = snapshot
+    }
+
+    fun disconnect() = launchCommand {
         stopTunnel()
         stopService()
     }
@@ -115,18 +125,11 @@ class PartoutVpnServiceRuntime(
         return json
     }
 
-    private fun sendSnapshot(snapshot: TunnelSnapshot) {
-        Log.d(logTag, "Report daemon snapshot: $snapshot")
-        val intent = Intent(ACTION_SNAPSHOT).apply {
-            setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+    private suspend fun sendFinalSnapshot() {
+        val latest = commandMutex.withLock {
+            latestSnapshot
         }
-        service.sendBroadcast(intent)
-        latestSnapshot = snapshot
-    }
-
-    private fun sendFinalSnapshot() {
-        latestSnapshot?.let {
+        latest?.let {
             sendSnapshot(it.disabled())
         }
     }

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -31,14 +31,16 @@ class PartoutVpnServiceRuntime(
     val service: VpnService,
     private val engine: Engine
 ) {
+    // Execute actions in serial queue
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
+    private var isRunning = false
+
+    // Deliver snapshots with mutex
     private val snapshotLock = Any()
-    @Volatile
-    private var latestSnapshot: TunnelSnapshot? = null
     private var acceptsSnapshots = false
     private var activeSnapshotProfileId: String? = null
-    private var isRunning = false
+    @Volatile private var latestSnapshot: TunnelSnapshot? = null
 
     init {
         serviceScope.launch {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -32,8 +32,10 @@ class PartoutVpnServiceRuntime(
 ) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
+    private val snapshotLock = Any()
     @Volatile
     private var latestSnapshot: TunnelSnapshot? = null
+    private var acceptsSnapshots = true
     private var isRunning = false
 
     init {
@@ -90,6 +92,9 @@ class PartoutVpnServiceRuntime(
         // Stop current tunnel if running
         stopTunnel()
 
+        synchronized(snapshotLock) {
+            acceptsSnapshots = true
+        }
         isRunning = true
         Log.i(logTag, "Starting VPN daemon")
 
@@ -103,7 +108,8 @@ class PartoutVpnServiceRuntime(
         Log.i(logTag, "Started VPN daemon")
     }
 
-    fun sendSnapshot(snapshot: TunnelSnapshot) {
+    fun sendSnapshot(snapshot: TunnelSnapshot) = synchronized(snapshotLock) {
+        if (!acceptsSnapshots) { return }
         emitSnapshot(snapshot)
     }
 
@@ -130,11 +136,12 @@ class PartoutVpnServiceRuntime(
         return json
     }
 
-    private fun sendFinalSnapshot() {
+    private fun sendFinalSnapshot() = synchronized(snapshotLock) {
         Log.d(logTag, "Emit final daemon snapshot")
         latestSnapshot?.let {
             emitSnapshot(it.disabled())
         }
+        acceptsSnapshots = false
     }
 
     private suspend fun stopTunnel() {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -98,8 +98,8 @@ class PartoutVpnServiceRuntime(
             setPackage(service.packageName)
             putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
         }
-        service.sendBroadcast(intent)
         latestSnapshot = snapshot
+        service.sendBroadcast(intent)
     }
 
     fun disconnect() = launchCommand {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -62,12 +62,12 @@ class PartoutVpnServiceRuntime(
 
     fun onDestroy() {
         Log.i(logTag, "PartoutVpnServiceRuntime.onDestroy()")
-        if (isRunning) {
-            launchCommand {
-                stopTunnel()
-                close()
-            }
-        } else {
+        if (!isRunning) {
+            close()
+            return
+        }
+        launchCommand {
+            stopTunnel()
             close()
         }
     }

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -27,7 +27,7 @@ import kotlinx.serialization.json.Json
 
 class PartoutVpnServiceRuntime(
     private val logTag: String,
-    private val service: VpnService,
+    val service: VpnService,
     private val engine: Engine
 ) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -53,10 +53,10 @@ class PartoutVpnServiceRuntime(
     fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.i(logTag, "PartoutVpnServiceRuntime.onStartCommand()")
         if (intent?.action == ACTION_STOP_VPN) {
-            disconnect()
+            deferDisconnect()
             return Service.START_NOT_STICKY
         }
-        connect(intent)
+        deferConnect(intent)
         return Service.START_STICKY
     }
 
@@ -74,7 +74,7 @@ class PartoutVpnServiceRuntime(
 
     fun onRevoke() {
         Log.i(logTag, "PartoutVpnServiceRuntime.onRevoke()")
-        disconnect()
+        deferDisconnect()
     }
 
     // Actions
@@ -95,7 +95,7 @@ class PartoutVpnServiceRuntime(
         return json
     }
 
-    private fun connect(intent: Intent?) = launchCommand {
+    private fun deferConnect(intent: Intent?) = launchCommand {
         val profileJSON = try {
             loadOrPersistProfile(intent)
         } catch (e: Exception) {
@@ -121,7 +121,7 @@ class PartoutVpnServiceRuntime(
         Log.i(logTag, "Started VPN daemon")
     }
 
-    private fun disconnect() = launchCommand {
+    private fun deferDisconnect() = launchCommand {
         stopTunnel()
         stopService()
     }
@@ -301,7 +301,7 @@ class PartoutVpnServiceRuntime(
         } else {
             Log.i(logTag, "VPN daemon cancelled")
         }
-        disconnect()
+        deferDisconnect()
     }
 
     // Broadcasts emitters

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -44,11 +44,10 @@ class PartoutVpnServiceRuntime(
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandMutex = Mutex()
     private var descriptor: ParcelFileDescriptor? = null
-    private var isRunning = false
     private var latestSnapshot: TunnelSnapshot? = null
+    private var isRunning = false
 
-    // Service lifecycle
-
+    //region Lifecycle
     @Suppress("UNUSED_PARAMETER")
     fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.i(logTag, "PartoutVpnServiceRuntime.onStartCommand()")
@@ -76,25 +75,9 @@ class PartoutVpnServiceRuntime(
         Log.i(logTag, "PartoutVpnServiceRuntime.onRevoke()")
         deferDisconnect()
     }
+    //endregion
 
-    // Actions
-
-    private suspend fun loadOrPersistProfile(intent: Intent?): String {
-        val json = intent?.getStringExtra(EXTRA_PROFILE_JSON)
-        if (json.isNullOrBlank()) {
-            Log.i(logTag, "No profile from VPN start intent, loading last persisted")
-            return engine.readLastProfile()
-        }
-        Log.i(logTag, "Profile from VPN start intent, persisting it")
-        try {
-            engine.writeLastProfile(json)
-        } catch (e: Exception) {
-            e.throwIfCancellation()
-            Log.w(logTag, "Unable to persist profile JSON, continuing with intent profile", e)
-        }
-        return json
-    }
-
+    //region Actions (Service)
     private fun deferConnect(intent: Intent?) = launchCommand {
         val profileJSON = try {
             loadOrPersistProfile(intent)
@@ -125,6 +108,43 @@ class PartoutVpnServiceRuntime(
         stopTunnel()
         stopService()
     }
+    //endregion
+
+    //region Actions (JNI)
+    //endregion
+
+    //region Action helpers
+    private suspend fun loadOrPersistProfile(intent: Intent?): String {
+        val json = intent?.getStringExtra(EXTRA_PROFILE_JSON)
+        if (json.isNullOrBlank()) {
+            Log.i(logTag, "No profile from VPN start intent, loading last persisted")
+            return engine.readLastProfile()
+        }
+        Log.i(logTag, "Profile from VPN start intent, persisting it")
+        try {
+            engine.writeLastProfile(json)
+        } catch (e: Exception) {
+            e.throwIfCancellation()
+            Log.w(logTag, "Unable to persist profile JSON, continuing with intent profile", e)
+        }
+        return json
+    }
+
+    private fun sendSnapshot(snapshot: TunnelSnapshot) {
+        Log.d(logTag, "Report daemon snapshot: $snapshot")
+        val intent = Intent(ACTION_SNAPSHOT).apply {
+            setPackage(service.packageName)
+            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+        }
+        service.sendBroadcast(intent)
+        latestSnapshot = snapshot
+    }
+
+    private fun sendFinalSnapshot() {
+        latestSnapshot?.let {
+            sendSnapshot(it.disabled())
+        }
+    }
 
     private suspend fun stopTunnel() {
         if (!isRunning) { return }
@@ -140,26 +160,16 @@ class PartoutVpnServiceRuntime(
         sendFinalSnapshot()
     }
 
-    private fun launchCommand(action: suspend () -> Unit) {
-        serviceScope.launch {
-            commandMutex.withLock {
-                try {
-                    action()
-                } catch (e: Exception) {
-                    e.throwIfCancellation()
-                    Log.e(logTag, "Unhandled VPN command failure", e)
-                    stopService()
-                }
-            }
-        }
+    private fun stopService() {
+        service.stopSelf()
     }
 
     private fun close() {
         serviceScope.cancel()
     }
+    //endregion
 
-    // Messaging
-
+    //region Messaging
     @Suppress("UNUSED_PARAMETER")
     fun onBind(intent: Intent?): IBinder? {
         return messenger.binder
@@ -192,15 +202,13 @@ class PartoutVpnServiceRuntime(
         }
         client.send(msg)
     }
+    //endregion
 
-    // WARNING: These methods are called from a JNI background thread
-
-    // JNI
+    //region C/JNI (keep signatures!)
     fun testWorking() {
         Log.d(logTag, "PartoutVpnServiceRuntime.testWorking()")
     }
 
-    // JNI
     fun setTunnel(infoJSON: String): Int {
         Log.d(logTag, "PartoutVpnServiceRuntime.setTunnel()")
         if (descriptor != null) {
@@ -277,7 +285,6 @@ class PartoutVpnServiceRuntime(
         return fd
     }
 
-    // JNI
     fun configureSockets(fds: IntArray) {
         Log.d(logTag, "PartoutVpnServiceRuntime.configureSockets(${fds.toList()})")
         fds.forEach {
@@ -286,14 +293,12 @@ class PartoutVpnServiceRuntime(
         }
     }
 
-    // JNI
     fun onSnapshot(snapshotJSON: String) {
         Log.d(logTag, "PartoutVpnServiceRuntime.onSnapshot()")
         val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
         sendSnapshot(snapshot)
     }
 
-    // JNI
     fun cancelTunnel(errorMessage: String?) {
         Log.d(logTag, "PartoutVpnServiceRuntime.cancelTunnel()")
         if (errorMessage != null) {
@@ -303,27 +308,9 @@ class PartoutVpnServiceRuntime(
         }
         deferDisconnect()
     }
+    //endregion
 
-    // Broadcasts emitters
-
-    private fun sendSnapshot(snapshot: TunnelSnapshot) {
-        Log.d(logTag, "Report daemon snapshot: $snapshot")
-        val intent = Intent(ACTION_SNAPSHOT).apply {
-            setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
-        }
-        service.sendBroadcast(intent)
-        latestSnapshot = snapshot
-    }
-
-    private fun sendFinalSnapshot() {
-        latestSnapshot?.let {
-            sendSnapshot(it.disabled())
-        }
-    }
-
-    // Helpers
-
+    //region Engine
     data class Result(
         val code: Int,
         val payload: String?
@@ -335,9 +322,21 @@ class PartoutVpnServiceRuntime(
         suspend fun readLastProfile(): String
         suspend fun writeLastProfile(json: String)
     }
+    //endregion
 
-    private fun stopService() {
-        service.stopSelf()
+    //region Generic helpers
+    private fun launchCommand(action: suspend () -> Unit) {
+        serviceScope.launch {
+            commandMutex.withLock {
+                try {
+                    action()
+                } catch (e: Exception) {
+                    e.throwIfCancellation()
+                    Log.e(logTag, "Unhandled VPN command failure", e)
+                    stopService()
+                }
+            }
+        }
     }
 
     private fun TunnelSnapshot.disabled() = TunnelSnapshot(
@@ -353,7 +352,9 @@ class PartoutVpnServiceRuntime(
             throw this
         }
     }
+    //endregion
 
+    //region Constants
     companion object {
         const val ACTION_STOP_VPN = "io.partout.action.STOP_VPN"
         const val ACTION_SNAPSHOT = "io.partout.action.SNAPSHOT"
@@ -368,4 +369,5 @@ class PartoutVpnServiceRuntime(
             ignoreUnknownKeys = true
         }
     }
+    //endregion
 }

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -32,6 +32,7 @@ class PartoutVpnServiceRuntime(
 ) {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
+    @Volatile
     private var latestSnapshot: TunnelSnapshot? = null
     private var isRunning = false
 
@@ -102,7 +103,7 @@ class PartoutVpnServiceRuntime(
         Log.i(logTag, "Started VPN daemon")
     }
 
-    fun sendSnapshot(snapshot: TunnelSnapshot) = launchCommand {
+    fun sendSnapshot(snapshot: TunnelSnapshot) {
         emitSnapshot(snapshot)
     }
 
@@ -204,6 +205,26 @@ class PartoutVpnServiceRuntime(
     }
     //endregion
 
+    //region Snapshots
+    private fun emitSnapshot(snapshot: TunnelSnapshot) {
+        Log.d(logTag, "Emit daemon snapshot: $snapshot")
+        val intent = Intent(ACTION_SNAPSHOT).apply {
+            setPackage(service.packageName)
+            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
+        }
+        latestSnapshot = snapshot
+        service.sendBroadcast(intent)
+    }
+
+    private fun TunnelSnapshot.disabled() = TunnelSnapshot(
+        id,
+        false,
+        false,
+        status,
+        environment
+    )
+    //endregion
+
     //region Engine
     data class Result(
         val code: Int,
@@ -224,24 +245,6 @@ class PartoutVpnServiceRuntime(
             Log.w(logTag, "Unable to enqueue VPN command", it)
         }
     }
-
-    private fun emitSnapshot(snapshot: TunnelSnapshot) {
-        Log.d(logTag, "Emit daemon snapshot: $snapshot")
-        val intent = Intent(ACTION_SNAPSHOT).apply {
-            setPackage(service.packageName)
-            putExtra(EXTRA_SNAPSHOT_JSON, json.encodeToString(snapshot))
-        }
-        latestSnapshot = snapshot
-        service.sendBroadcast(intent)
-    }
-
-    private fun TunnelSnapshot.disabled() = TunnelSnapshot(
-        id,
-        false,
-        false,
-        status,
-        environment
-    )
 
     private fun Exception.throwIfCancellation() {
         if (this is CancellationException) {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -125,12 +125,9 @@ class PartoutVpnServiceRuntime(
         return json
     }
 
-    private suspend fun sendFinalSnapshot() {
+    private fun sendFinalSnapshot() {
         Log.d(logTag, "Report final daemon snapshot")
-        val latest = commandMutex.withLock {
-            latestSnapshot
-        }
-        latest?.let {
+        latestSnapshot?.let {
             sendSnapshot(it.disabled())
         }
     }

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -35,7 +35,7 @@ class PartoutVpnServiceRuntime(
     private val snapshotLock = Any()
     @Volatile
     private var latestSnapshot: TunnelSnapshot? = null
-    private var acceptsSnapshots = true
+    private var acceptsSnapshots = false
     private var isRunning = false
 
     init {
@@ -98,10 +98,24 @@ class PartoutVpnServiceRuntime(
         isRunning = true
         Log.i(logTag, "Starting VPN daemon")
 
-        val result = engine.start(this, profileJSON)
+        val result = try {
+            engine.start(this, profileJSON)
+        } catch (e: Exception) {
+            e.throwIfCancellation()
+            Log.e(logTag, "Unable to start VPN daemon", e)
+            stopService()
+            synchronized(snapshotLock) {
+                acceptsSnapshots = false
+            }
+            isRunning = false
+            return@launchCommand
+        }
         if (result.code != 0) {
             Log.e(logTag, "Unable to start VPN daemon (code=${result.code}): ${result.payload}")
             stopService()
+            synchronized(snapshotLock) {
+                acceptsSnapshots = false
+            }
             isRunning = false
             return@launchCommand
         }
@@ -109,8 +123,9 @@ class PartoutVpnServiceRuntime(
     }
 
     fun sendSnapshot(snapshot: TunnelSnapshot) = synchronized(snapshotLock) {
-        if (!acceptsSnapshots) { return }
-        emitSnapshot(snapshot)
+        if (acceptsSnapshots) {
+            emitSnapshot(snapshot)
+        }
     }
 
     fun disconnect() = launchCommand {

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -34,11 +34,11 @@ class JNITunnelController(
     private var descriptor: ParcelFileDescriptor? = null
 
     override fun testWorking() {
-        Log.d(logTag, "JNITunnelController.testWorking()")
+        Log.d(logTag, "testWorking()")
     }
 
     override fun setTunnel(infoJSON: String): Int {
-        Log.d(logTag, "JNITunnelController.setTunnel()")
+        Log.d(logTag, "setTunnel()")
         if (descriptor != null) {
             Log.e(logTag, "Tunnel descriptor already established")
             return -1
@@ -118,7 +118,7 @@ class JNITunnelController(
     }
 
     override fun configureSockets(fds: IntArray) {
-        Log.d(logTag, "JNITunnelController.configureSockets(${fds.toList()})")
+        Log.d(logTag, "configureSockets(${fds.toList()})")
         fds.forEach {
             val protected = service.protect(it)
             Log.d(logTag, "protect($it) = $protected")
@@ -126,13 +126,13 @@ class JNITunnelController(
     }
 
     override fun onSnapshot(snapshotJSON: String) {
-        Log.d(logTag, "JNITunnelController.onSnapshot()")
+        Log.d(logTag, "onSnapshot()")
         val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
         sendSnapshot(snapshot)
     }
 
     override fun cancelTunnel(errorMessage: String?) {
-        Log.d(logTag, "JNITunnelController.cancelTunnel()")
+        Log.d(logTag, "cancelTunnel()")
         if (errorMessage != null) {
             Log.e(logTag, "VPN daemon cancelled: $errorMessage")
         } else {

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -126,7 +126,7 @@ class JNITunnelController(
     }
 
     override fun onSnapshot(snapshotJSON: String) {
-        Log.d(logTag, "onSnapshot()")
+        Log.d(logTag, "onSnapshot(${snapshotJSON})")
         val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
         sendSnapshot(snapshot)
     }

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -31,13 +31,16 @@ class JNITunnelController(
     private val sendSnapshot: (TunnelSnapshot) -> Unit,
     private val disconnect: () -> Unit
 ): TunnelController {
+    private val lock = Any()
     private var descriptor: ParcelFileDescriptor? = null
+    private var isClosed = false
 
     override fun testWorking() {
         Log.d(logTag, "testWorking()")
     }
 
-    override fun setTunnel(infoJSON: String): Int {
+    override fun setTunnel(infoJSON: String): Int = synchronized(lock) {
+        if (isClosed) { return -1 }
         Log.d(logTag, "setTunnel()")
         if (descriptor != null) {
             Log.e(logTag, "Tunnel descriptor already established")
@@ -117,7 +120,8 @@ class JNITunnelController(
         return fd
     }
 
-    override fun configureSockets(fds: IntArray) {
+    override fun configureSockets(fds: IntArray) = synchronized(lock) {
+        if (isClosed) { return }
         Log.d(logTag, "configureSockets(${fds.toList()})")
         fds.forEach {
             val protected = service.protect(it)
@@ -125,13 +129,16 @@ class JNITunnelController(
         }
     }
 
-    override fun onSnapshot(snapshotJSON: String) {
+    override fun onSnapshot(snapshotJSON: String) = synchronized(lock) {
+        if (isClosed) { return }
         Log.d(logTag, "onSnapshot(${snapshotJSON})")
         val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
         sendSnapshot(snapshot)
     }
 
-    override fun cancelTunnel(errorMessage: String?) {
+    override fun cancelTunnel(errorMessage: String?) = synchronized(lock) {
+        if (isClosed) { return }
+        isClosed = true
         Log.d(logTag, "cancelTunnel()")
         if (errorMessage != null) {
             Log.e(logTag, "VPN daemon cancelled: $errorMessage")

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package io.partout.vpn
+
+import android.net.VpnService
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import io.partout.models.TaggedModuleDNS
+import io.partout.models.TaggedModuleHTTPProxy
+import io.partout.models.TaggedModuleIP
+import io.partout.models.TaggedModuleOnDemand
+import io.partout.models.TunnelRemoteInfoWrapper
+import io.partout.models.TunnelSnapshot
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+// Must match signatures in tun_android.c
+interface TunnelController {
+    fun testWorking()
+    fun setTunnel(infoJSON: String): Int
+    fun configureSockets(fds: IntArray)
+    fun onSnapshot(snapshotJSON: String)
+    fun cancelTunnel(errorMessage: String?)
+}
+
+class JNITunnelController(
+    private val logTag: String,
+    private val service: VpnService,
+    private val sendSnapshot: (TunnelSnapshot) -> Unit,
+    private val disconnect: () -> Unit
+): TunnelController {
+    private var descriptor: ParcelFileDescriptor? = null
+
+    override fun testWorking() {
+        Log.d(logTag, "JNITunnelController.testWorking()")
+    }
+
+    override fun setTunnel(infoJSON: String): Int {
+        Log.d(logTag, "JNITunnelController.setTunnel()")
+        if (descriptor != null) {
+            Log.e(logTag, "Tunnel descriptor already established")
+            return -1
+        }
+
+        val builder = service.Builder()
+        val info: TunnelRemoteInfoWrapper = try {
+            json.decodeFromString(infoJSON)
+        } catch (e: SerializationException) {
+            Log.e(logTag, "Unable to decode tunnel info JSON", e)
+            return -1
+        }
+        val remoteFds = info.fileDescriptors
+        var appliedAddressSettings = false
+        var appliedDnsSettings = false
+
+        info.modules?.forEach {
+            when (it) {
+                is TaggedModuleDNS -> {
+                    Log.i(logTag, "DNS: ${it.value}")
+                    appliedDnsSettings = DNSModuleApplying(it.value).apply(logTag, builder)
+                            || appliedDnsSettings
+                }
+
+                is TaggedModuleIP -> {
+                    Log.i(logTag, "IP: ${it.value}")
+                    appliedAddressSettings = IPModuleApplying(it.value).apply(logTag, builder)
+                            || appliedAddressSettings
+                }
+
+                is TaggedModuleHTTPProxy -> {
+                    Log.i(logTag, "HTTP Proxy: ${it.value}")
+                    HTTPProxyModuleApplying(it.value).apply(logTag, builder)
+                }
+
+                is TaggedModuleOnDemand -> {
+                    Log.i(logTag, "OnDemand: ${it.value}")
+                    OnDemandModuleApplying(it.value).apply(logTag, builder)
+                }
+
+                else -> {}
+            }
+        }
+
+        if (!appliedAddressSettings) {
+            Log.e(logTag, "No valid interface address")
+            return -1
+        }
+
+        remoteFds.forEach {
+            require(it in 0..Int.MAX_VALUE.toLong()) {
+                "Invalid Android file descriptor: $it"
+            }
+            val protected = service.protect(it.toInt())
+            Log.d(logTag, "protect($it) = $protected")
+        }
+
+        // IMPORTANT: this is a requirement for VirtualTunnelInterface.
+        // By default, establish() returns a non-blocking descriptor.
+        builder.setBlocking(true)
+
+        descriptor = try {
+            builder.establish()
+        } catch (e: RuntimeException) {
+            Log.e(logTag, "Unable to establish tunnel", e)
+            null
+        }
+        if (descriptor == null) {
+            Log.e(logTag, "Unable to establish tunnel")
+            return -1
+        }
+
+        val fd = descriptor?.detachFd() ?: -1
+        descriptor = null
+        Log.i(logTag, "Established tunnel descriptor: $fd")
+        return fd
+    }
+
+    override fun configureSockets(fds: IntArray) {
+        Log.d(logTag, "JNITunnelController.configureSockets(${fds.toList()})")
+        fds.forEach {
+            val protected = service.protect(it)
+            Log.d(logTag, "protect($it) = $protected")
+        }
+    }
+
+    override fun onSnapshot(snapshotJSON: String) {
+        Log.d(logTag, "JNITunnelController.onSnapshot()")
+        val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
+        sendSnapshot(snapshot)
+    }
+
+    override fun cancelTunnel(errorMessage: String?) {
+        Log.d(logTag, "JNITunnelController.cancelTunnel()")
+        if (errorMessage != null) {
+            Log.e(logTag, "VPN daemon cancelled: $errorMessage")
+        } else {
+            Log.i(logTag, "VPN daemon cancelled")
+        }
+        disconnect()
+    }
+
+    companion object {
+        private val json = Json {
+            ignoreUnknownKeys = true
+        }
+    }
+}


### PR DESCRIPTION
- Split runtime and JNI callbacks into separate objects to keep shared state in check
- Serialize commands execution
- Send immediate snapshots, but synchronized
- Discard late snapshots from former connected profile