### PR TITLE
Core: Fix spinlocks in BSDSocket

### DIFF
--- a/Sources/PartoutCore/Connection/BSDSocket.swift
+++ b/Sources/PartoutCore/Connection/BSDSocket.swift
@@ -251,6 +251,15 @@ private extension BSDSocket {
             while packets.count < maxReadBatchPackets, batchBytes < maxReadBatchBytes {
                 let readCount = pp_socket_read(socketHandle.sock, buffer, maxReadLength)
 
+                // Would-block is expected while draining, but not as the first read after readiness.
+                guard readCount != PP_SOCKET_WOULD_BLOCK else {
+                    if packets.isEmpty {
+                        terminate(with: socketHandle.preferredError())
+                        return
+                    }
+                    break
+                }
+
                 // Failure if < 0
                 guard readCount >= 0 else {
                     if !packets.isEmpty {
@@ -260,7 +269,15 @@ private extension BSDSocket {
                     return
                 }
                 // Non-blocking read
-                guard readCount != 0 else { break }
+                guard readCount != 0 else {
+                    if socketHandle.isStopping {
+                        if !packets.isEmpty {
+                            packetInbox.push(packets)
+                        }
+                        return
+                    }
+                    break
+                }
 
                 packets.append(Data(bytes: buffer, count: Int(readCount)))
                 batchBytes += Int(readCount)
@@ -288,7 +305,18 @@ private extension BSDSocket {
                         return Int(pp_socket_write(socketHandle.sock, baseAddress, packet.count))
                     }
                     // Non-blocking write
-                    guard writtenCount != 0 else { continue }
+                    guard writtenCount != PP_SOCKET_WOULD_BLOCK else {
+                        if socketHandle.isStopping {
+                            let error = socketHandle.preferredError()
+                            request.continuation.resume(throwing: error)
+                            return
+                        }
+                        error = socketHandle.preferredError()
+                        break
+                    }
+                    guard writtenCount != 0 else {
+                        continue
+                    }
 
                     // Report failure unless packet was written fully
                     if writtenCount != packet.count {

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -19,6 +19,8 @@ typedef enum {
 /* The opaque socket type. */
 typedef struct __pp_socket_struct *pp_socket;
 
+extern const int PP_SOCKET_WOULD_BLOCK;
+
 /* Create a socket wrapper from an already open native descriptor. The
  * wrapper acquires ownership and will close the descriptor on
  * pp_socket_close() or pp_socket_free(). */
@@ -34,7 +36,7 @@ pp_socket _Nullable pp_socket_open(const char *_Nonnull ip_addr,
                                    bool blocking,
                                    int timeout_ms);
 
-/* I/O. */
+/* I/O. Returns PP_SOCKET_WOULD_BLOCK when a non-blocking operation would block. */
 int pp_socket_read(pp_socket _Nonnull sock,
                    uint8_t *_Nonnull dst, size_t dst_len);
 int pp_socket_write(pp_socket _Nonnull sock,

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -147,6 +147,7 @@ pp_socket pp_socket_open(const char *ip_addr,
                                                        timeout_ms);
         if (ret != 0) {
             local_close_fd(new_fd);
+            new_fd = local_invalid_fd();
             local_print_error("connect()");
             continue;
         }

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -28,6 +28,8 @@ typedef int os_socket_fd;
 typedef socklen_t os_socklen_t;
 #endif
 
+const int PP_SOCKET_WOULD_BLOCK = -2;
+
 static bool local_platform_init(void);
 static os_socket_fd local_invalid_fd(void);
 static bool local_is_invalid_fd(os_socket_fd fd);
@@ -202,7 +204,7 @@ int pp_socket_read(pp_socket sock, uint8_t *dst, size_t dst_len) {
              * in which case the value -1 is returned and the external variable errno
              * set to EAGAIN. */
             if (local_is_would_block()) {
-                return 0;
+                return PP_SOCKET_WOULD_BLOCK;
             }
             local_print_error("recv()");
         }
@@ -229,7 +231,7 @@ int pp_socket_write(pp_socket sock, const uint8_t *src, size_t src_len) {
                 continue;
             }
             if (local_is_would_block()) {
-                return offset > 0 ? (int)offset : 0;
+                return offset > 0 ? (int)offset : PP_SOCKET_WOULD_BLOCK;
             }
             local_print_error("send()");
             return written_len;


### PR DESCRIPTION
Introduce a custom PP_SOCKET_WOULD_BLOCK value to undoubtly tell the difference between 0 bytes and "would block" scenarios.

Fixes #375