### PR TITLE
WireGuard: Clarify sockets lifecycle

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -148,8 +148,6 @@ struct TunnelRemoteInfoWrapper: Encodable, Sendable {
 
     let address: Address?
 
-    let fileDescriptors: [UInt64]
-
     let requiresVirtualDevice: Bool
 
     let modules: [TaggedModule]?
@@ -157,7 +155,6 @@ struct TunnelRemoteInfoWrapper: Encodable, Sendable {
     init(_ info: TunnelRemoteInfo) {
         originalModuleId = info.originalModuleId
         address = info.address
-        fileDescriptors = info.fileDescriptors
         requiresVirtualDevice = info.requiresVirtualDevice
         modules = info.modules?.compactMap(\.taggedModule)
     }

--- a/Sources/PartoutCore/Connection/TunnelRemoteInfo.swift
+++ b/Sources/PartoutCore/Connection/TunnelRemoteInfo.swift
@@ -14,17 +14,13 @@ public struct TunnelRemoteInfo: Sendable {
     /// The extra modules returned by the connection.
     public let modules: [Module]?
 
-    /// The file descriptors of the underlying connections.
-    public let fileDescriptors: [UInt64]
-
     /// True if the controller should create a virtual I/O device.
     public let requiresVirtualDevice: Bool
 
-    public init(originalModuleId: UniqueID, address: Address?, modules: [Module]?, fileDescriptors: [UInt64], requiresVirtualDevice: Bool = true) {
+    public init(originalModuleId: UniqueID, address: Address?, modules: [Module]?, requiresVirtualDevice: Bool = true) {
         self.originalModuleId = originalModuleId
         self.address = address
         self.modules = modules
-        self.fileDescriptors = fileDescriptors
         self.requiresVirtualDevice = requiresVirtualDevice
     }
 }

--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
@@ -199,10 +199,10 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,
                     address: addressObject,
-                    modules: builder.modules(),
-                    fileDescriptors: remoteFd.map { [$0] } ?? []
+                    modules: builder.modules()
                 )
             )
+            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             await session.setTunnel(tunnelInterface)
             self.tunnelInterface = tunnelInterface
 

--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
@@ -195,6 +195,7 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
         )
         builder.print()
         do {
+            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             let tunnelInterface = try await controller.setTunnelSettings(
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,
@@ -202,7 +203,6 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
                     modules: builder.modules()
                 )
             )
-            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             await session.setTunnel(tunnelInterface)
             self.tunnelInterface = tunnelInterface
 

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -188,10 +188,10 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,
                     address: addressObject,
-                    modules: builder.modules(),
-                    fileDescriptors: remoteFd.map { [$0] } ?? []
+                    modules: builder.modules()
                 )
             )
+            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             await session.setTunnel(tunnelInterface)
             self.tunnelInterface = tunnelInterface
 

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -184,6 +184,7 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
         )
         builder.print()
         do {
+            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             let tunnelInterface = try await controller.setTunnelSettings(
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,
@@ -191,7 +192,6 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
                     modules: builder.modules()
                 )
             )
-            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             await session.setTunnel(tunnelInterface)
             self.tunnelInterface = tunnelInterface
 

--- a/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
+++ b/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
@@ -194,8 +194,7 @@ private extension _WireGuardConnectionV1 {
                     _ = try await connection.controller.setTunnelSettings(with: TunnelRemoteInfo(
                         originalModuleId: connection.moduleId,
                         address: addressObject,
-                        modules: [module],
-                        fileDescriptors: []
+                        modules: [module]
                     ))
                     completionHandler?(nil)
                     pp_log(connection.ctx, .wireguard, .info, "Tunnel interface is now UP")

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -119,7 +119,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
         return wgSettings
     }
 
-    func generateRemoteInfo(moduleId: UniqueID, descriptors: [Int32]) -> TunnelRemoteInfo {
+    func generateRemoteInfo(moduleId: UniqueID) -> TunnelRemoteInfo {
         /* iOS requires a tunnel endpoint, whereas in WireGuard it's valid for
          * a tunnel to have no endpoint, or for there to be many endpoints, in
          * which case, displaying a single one in settings doesn't really
@@ -170,7 +170,6 @@ final class TunnelRemoteInfoGenerator: Sendable {
             originalModuleId: moduleId,
             address: remoteAddress,
             modules: modules,
-            fileDescriptors: descriptors.map(UInt64.init),
             requiresVirtualDevice: requiresVirtualDevice
         )
     }

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -140,9 +140,7 @@ actor WireGuardAdapter {
             let settingsGenerator = makeSettingsGenerator(with: tunnelConfiguration)
             let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
             try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
-                moduleId: moduleId,
-                // FIXME: #407, These are always empty at this stage
-                descriptors: socketDescriptors
+                moduleId: moduleId
             ))
             let handle = try startWireGuardBackend(wgConfig: wgConfig)
             state = .started(handle, settingsGenerator)
@@ -301,8 +299,7 @@ actor WireGuardAdapter {
                 await settingsGenerator.resetResolvedEndpoints()
                 let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
                 try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
-                    moduleId: moduleId,
-                    descriptors: socketDescriptors
+                    moduleId: moduleId
                 ))
                 let handle = try startWireGuardBackend(wgConfig: wgConfig)
                 state = .started(handle, settingsGenerator)

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -243,17 +243,19 @@ actor WireGuardAdapter {
 #if os(iOS)
         backend.disableSomeRoamingForBrokenMobileSemantics(handle)
 #endif
-        // FIXME: #407, Socket descriptors require handle, which only exists after backend.turnOn. How do start() and .temporaryShutdown use socketDescriptors? They are empty, always empty on start()
-        let socketFds = {
-            var rawFds = backend.socketDescriptors(handle)
-            if rawFds.isEmpty {
-                rawFds = fallbackFileDescriptor.map { [$0] } ?? []
-            }
-            return rawFds
-        }()
-        pp_log(ctx, .wireguard, .info, "Socket descriptors: \(socketFds)")
-        delegate?.adapterShouldConfigureSockets(self, descriptors: socketFds.map(UInt64.init))
+        configureSockets(for: handle)
         return handle
+    }
+
+    @discardableResult
+    private func configureSockets(for handle: Int32) -> [UInt64] {
+        let descriptors = backend.socketDescriptors(handle)
+            .filter { $0 >= 0 }
+            .map { UInt64($0) }
+        pp_log(ctx, .wireguard, .info, "Socket descriptors: \(descriptors)")
+        guard !descriptors.isEmpty else { return [] }
+        delegate?.adapterShouldConfigureSockets(self, descriptors: descriptors)
+        return descriptors
     }
 
     /// Resolves the hostnames in the given tunnel configuration and return settings generator.

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -57,16 +57,10 @@ actor WireGuardAdapter {
     /// Adapter state.
     private var state: WireGuardAdapterState = .stopped
 
-    private var socketDescriptors: [Int32] {
-        guard case .started(let handle, _) = state else { return [] }
-        return backend.socketDescriptors(handle)
-    }
-
     /// Tunnel device file descriptor.
     private var tunnelFileDescriptor: Int32? {
         didSet {
             logHandler(.verbose, "Tunnel file descriptor: \(tunnelFileDescriptor.debugDescription)")
-            logHandler(.verbose, "Socket file descriptors: \(socketDescriptors)")
         }
     }
 

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -138,8 +138,7 @@ struct ProfileNetworkSettingsTests {
         let sut = profile.networkSettings(with: .init(
             originalModuleId: bogusModule.id,
             address: Address(rawValue: "5.6.7.8")!,
-            modules: [bogusModule],
-            fileDescriptors: []
+            modules: [bogusModule]
         ))
 
         #expect(sut.tunnelRemoteAddress == "5.6.7.8")
@@ -164,8 +163,7 @@ struct ProfileNetworkSettingsTests {
                             Route(defaultWithGateway: nil)
                         ])
                 ).build()
-            ],
-            fileDescriptors: []
+            ]
         )
         let ipModule = IPModule.Builder(
             ipv4: IPSettings(subnet: Subnet(rawValue: "1.2.3.4/32")!)

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -170,7 +170,7 @@ struct TunnelRemoteInfoGeneratorTests {
             tunnelConfiguration: configuration,
             dnsTimeout: 1
         )
-        let info = sut.generateRemoteInfo(moduleId: UniqueID(), descriptors: [])
+        let info = sut.generateRemoteInfo(moduleId: UniqueID())
         let ipModule = try #require(info.modules?.compactMap { $0 as? IPModule }.first)
 
         #expect(ipModule.ipv4?.includedRoutes.first?.destination?.rawValue == "10.0.0.0/24")

--- a/cross/android/io/partout/models/TunnelRemoteInfoWrapper.kt
+++ b/cross/android/io/partout/models/TunnelRemoteInfoWrapper.kt
@@ -24,7 +24,6 @@ import kotlinx.serialization.Contextual
 /**
  * 
  *
- * @param fileDescriptors 
  * @param originalModuleId 
  * @param requiresVirtualDevice 
  * @param address 
@@ -33,9 +32,6 @@ import kotlinx.serialization.Contextual
 @Serializable
 
 data class TunnelRemoteInfoWrapper (
-
-    @SerialName(value = "fileDescriptors")
-    val fileDescriptors: kotlin.collections.List<kotlin.Long>,
 
     @SerialName(value = "originalModuleId")
     val originalModuleId: kotlin.String,

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -66,7 +66,6 @@ class JNITunnelController(
             Log.e(logTag, "Unable to decode tunnel info JSON", e)
             return -1
         }
-        val remoteFds = info.fileDescriptors
         var appliedAddressSettings = false
         var appliedDnsSettings = false
 
@@ -103,14 +102,6 @@ class JNITunnelController(
             return -1
         }
 
-        remoteFds.forEach {
-            require(it in 0..Int.MAX_VALUE.toLong()) {
-                "Invalid Android file descriptor: $it"
-            }
-            val protected = service.protect(it.toInt())
-            Log.d(logTag, "protect($it) = $protected")
-        }
-
         // IMPORTANT: this is a requirement for VirtualTunnelInterface.
         // By default, establish() returns a non-blocking descriptor.
         builder.setBlocking(true)
@@ -136,7 +127,10 @@ class JNITunnelController(
         if (isClosed) { return }
         Log.d(logTag, "configureSockets(${fds.toList()})")
         fds.forEach {
-            val protected = service.protect(it)
+            require(it in 0..Int.MAX_VALUE.toLong()) {
+                "Invalid Android file descriptor: $it"
+            }
+            val protected = service.protect(it.toInt())
             Log.d(logTag, "protect($it) = $protected")
         }
     }

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -772,10 +772,6 @@ components:
       properties:
         address:
           "$ref": "#/components/schemas/Address"
-        fileDescriptors:
-          items:
-            "$ref": "#/components/schemas/UInt64"
-          type: array
         modules:
           items:
             "$ref": "#/components/schemas/TaggedModule"
@@ -786,7 +782,6 @@ components:
           type: boolean
       required:
         - originalModuleId
-        - fileDescriptors
         - requiresVirtualDevice
       type: object
     TunnelSnapshot:


### PR DESCRIPTION
TunnelRemoteInfo had a .fileDescriptors field that didn't serve a consistent purpose, because OpenVPN has the socket descriptors at setTunnelSettings() time, whereas WireGuard can only have them after setTunnelSettings(). The WireGuard implementation was, in fact, feeding a disguised descriptors array that was always empty.

Therefore:

- Core: Drop TunnelRemoteInfo(Wrapper).fileDescriptors
- OpenVPN: Protect the file descriptors with configureSockets() before setTunnelSettings()
- WireGuard: Delete the dead code

Later, on Android, wgBumpSockets() will need to be waited on before a new call to configureSockets(), which in turn invokes VpnService.protect() on the updated descriptors.

Fixes #407 