### PR TITLE
Android: Bind JNITunnelController to native network observers

### DIFF
--- a/Examples/Sources/test-posix-socket/main.swift
+++ b/Examples/Sources/test-posix-socket/main.swift
@@ -14,6 +14,12 @@ final class MyDest: LoggerDestination {
     }
 }
 
+final class DummyFactory: BetterPathStreamFactory {
+    func newStream() -> PassthroughStream<Void> {
+        PassthroughStream()
+    }
+}
+
 func tryTCPConnection() async throws {
     var log = PartoutLogger.Builder()
     log.setDestination(MyDest(), for: [.core])
@@ -24,9 +30,7 @@ func tryTCPConnection() async throws {
     let observer = BSDSocketObserver(
         .global,
         endpoint: endpoint,
-        betterPathBlock: {
-            PassthroughStream()
-        }
+        betterPathFactory: DummyFactory()
     )
     let sut = try await observer.waitForActivity(timeout: 5000)
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -41,7 +41,7 @@ public final class NativeTunnelController: TunnelController {
         betterPathProxy = BetterPathProxy()
 
         var delegate = pp_tun_ctrl_delegate(
-            ctx: Unmanaged.passUnretained(self).toOpaque(),
+            ctx: .fromSelf(self),
             on_reachable: { ctx, isReachable in
                 let this = ctx.toSelf
                 this.onReachable(isReachable)
@@ -212,6 +212,10 @@ private final class BetterPathProxy: BetterPathStreamFactory, @unchecked Sendabl
 // MARK: - Helpers
 
 private extension UnsafeMutableRawPointer {
+    static func fromSelf(_ controller: NativeTunnelController) -> Self {
+        Unmanaged.passUnretained(controller).toOpaque()
+    }
+
     var toSelf: NativeTunnelController {
         Unmanaged.fromOpaque(self).takeUnretainedValue()
     }

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -17,7 +17,7 @@ public final class NativeTunnelController: TunnelController {
 
     private let onReachableStream: CurrentValueStream<Bool>
 
-    private let pipeBetterPathFactory: PipeBetterPathFactory
+    private let betterPathProxy: BetterPathProxy
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -38,7 +38,7 @@ public final class NativeTunnelController: TunnelController {
         self.environment = environment
         self.maxReadLength = maxReadLength
         onReachableStream = CurrentValueStream(false)
-        pipeBetterPathFactory = PipeBetterPathFactory()
+        betterPathProxy = BetterPathProxy()
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: Unmanaged.passUnretained(self).toOpaque(),
@@ -172,7 +172,7 @@ extension NativeTunnelController: ReachabilityObserver {
     }
 
     public var betterPathFactory: BetterPathStreamFactory {
-        pipeBetterPathFactory
+        betterPathProxy
     }
 }
 
@@ -182,11 +182,11 @@ private extension NativeTunnelController {
     }
 
     func onBetterPath() {
-        pipeBetterPathFactory.onBetterPath()
+        betterPathProxy.onBetterPath()
     }
 }
 
-private final class PipeBetterPathFactory: BetterPathStreamFactory, @unchecked Sendable {
+private final class BetterPathProxy: BetterPathStreamFactory, @unchecked Sendable {
     private let lock = SemaphoreMutex()
     private var stream: PassthroughStream<Void>?
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -5,7 +5,7 @@
 internal import _PartoutCore_C
 
 /// A controller that operates on a virtual tun interface.
-public final class NativeTunnelController: TunnelController {
+public final class NativeTunnelController: TunnelController, ReachabilityObserver {
     private let ctx: PartoutLoggerContext
 
     nonisolated(unsafe)
@@ -14,6 +14,10 @@ public final class NativeTunnelController: TunnelController {
     private let environment: TunnelEnvironmentReader
 
     private let maxReadLength: Int
+
+    private let onReachableStream: CurrentValueStream<Bool>
+
+    public let onBetterPathStream: PassthroughStream<Void>
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -33,9 +37,19 @@ public final class NativeTunnelController: TunnelController {
 #endif
         self.environment = environment
         self.maxReadLength = maxReadLength
+        onReachableStream = CurrentValueStream(false)
+        onBetterPathStream = PassthroughStream()
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: Unmanaged.passUnretained(self).toOpaque(),
+            on_reachable: { ctx, isReachable in
+                let swift = Unmanaged<NativeTunnelController>.fromOpaque(ctx).takeUnretainedValue()
+                swift.onReachable(isReachable)
+            },
+            on_better_path: { ctx in
+                let swift = Unmanaged<NativeTunnelController>.fromOpaque(ctx).takeUnretainedValue()
+                swift.onBetterPath()
+            },
             environment_value: { ctx, key in
                 let swift = Unmanaged<NativeTunnelController>.fromOpaque(ctx).takeUnretainedValue()
                 guard let data = swift.environmentData(forKey: String(cString: key)),
@@ -137,6 +151,34 @@ public final class NativeTunnelController: TunnelController {
         error.partoutErrorCode.rawValue.withCString {
             pp_tun_ctrl_cancel_tunnel(ref, $0)
         }
+    }
+}
+
+// MARK: - Streams
+
+extension NativeTunnelController {
+    public func startObserving() {
+    }
+
+    public func stopObserving() {
+    }
+
+    public var isReachable: Bool {
+        onReachableStream.value
+    }
+
+    public var isReachableStream: AsyncStream<Bool> {
+        onReachableStream.subscribe()
+    }
+}
+
+private extension NativeTunnelController {
+    func onReachable(_ isReachable: Bool) {
+        onReachableStream.send(isReachable)
+    }
+
+    func onBetterPath() {
+        onBetterPathStream.send()
     }
 }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -43,16 +43,16 @@ public final class NativeTunnelController: TunnelController {
         var delegate = pp_tun_ctrl_delegate(
             ctx: Unmanaged.passUnretained(self).toOpaque(),
             on_reachable: { ctx, isReachable in
-                let swift = Unmanaged<NativeTunnelController>.fromOpaque(ctx).takeUnretainedValue()
-                swift.onReachable(isReachable)
+                let this = ctx.toSelf
+                this.onReachable(isReachable)
             },
             on_better_path: { ctx in
-                let swift = Unmanaged<NativeTunnelController>.fromOpaque(ctx).takeUnretainedValue()
-                swift.onBetterPath()
+                let this = ctx.toSelf
+                this.onBetterPath()
             },
             environment_value: { ctx, key in
-                let swift = Unmanaged<NativeTunnelController>.fromOpaque(ctx).takeUnretainedValue()
-                guard let data = swift.environmentData(forKey: String(cString: key)),
+                let this = ctx.toSelf
+                guard let data = this.environmentData(forKey: String(cString: key)),
                       let json = String(data: data, encoding: .utf8) else {
                     return nil
                 }
@@ -210,6 +210,12 @@ private final class BetterPathProxy: BetterPathStreamFactory, @unchecked Sendabl
 }
 
 // MARK: - Helpers
+
+private extension UnsafeMutableRawPointer {
+    var toSelf: NativeTunnelController {
+        Unmanaged.fromOpaque(self).takeUnretainedValue()
+    }
+}
 
 struct TunnelRemoteInfoWrapper: Encodable, Sendable {
     let originalModuleId: UniqueID

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -5,7 +5,7 @@
 internal import _PartoutCore_C
 
 /// A controller that operates on a virtual tun interface.
-public final class NativeTunnelController: TunnelController, ReachabilityObserver {
+public final class NativeTunnelController: TunnelController {
     private let ctx: PartoutLoggerContext
 
     nonisolated(unsafe)
@@ -17,7 +17,9 @@ public final class NativeTunnelController: TunnelController, ReachabilityObserve
 
     private let onReachableStream: CurrentValueStream<Bool>
 
-    public let onBetterPathStream: PassthroughStream<Void>
+    private let betterPathLock: SemaphoreMutex
+
+    private var onBetterPathStream: PassthroughStream<Void>?
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -38,7 +40,7 @@ public final class NativeTunnelController: TunnelController, ReachabilityObserve
         self.environment = environment
         self.maxReadLength = maxReadLength
         onReachableStream = CurrentValueStream(false)
-        onBetterPathStream = PassthroughStream()
+        betterPathLock = SemaphoreMutex()
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: Unmanaged.passUnretained(self).toOpaque(),
@@ -156,7 +158,7 @@ public final class NativeTunnelController: TunnelController, ReachabilityObserve
 
 // MARK: - Streams
 
-extension NativeTunnelController {
+extension NativeTunnelController: ReachabilityObserver {
     public func startObserving() {
     }
 
@@ -172,13 +174,29 @@ extension NativeTunnelController {
     }
 }
 
+extension NativeTunnelController: BetterPathStreamFactory {
+    public nonisolated func newStream() -> PassthroughStream<Void> {
+        let stream = PassthroughStream<Void>()
+        let oldStream = betterPathLock.with {
+            let old = onBetterPathStream
+            onBetterPathStream = stream
+            return old
+        }
+        oldStream?.finish()
+        return stream
+    }
+}
+
 private extension NativeTunnelController {
     func onReachable(_ isReachable: Bool) {
         onReachableStream.send(isReachable)
     }
 
     func onBetterPath() {
-        onBetterPathStream.send()
+        let stream = betterPathLock.with {
+            onBetterPathStream
+        }
+        stream?.send()
     }
 }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -17,9 +17,7 @@ public final class NativeTunnelController: TunnelController {
 
     private let onReachableStream: CurrentValueStream<Bool>
 
-    private let betterPathLock: SemaphoreMutex
-
-    private var onBetterPathStream: PassthroughStream<Void>?
+    private let pipeBetterPathFactory: PipeBetterPathFactory
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -40,7 +38,7 @@ public final class NativeTunnelController: TunnelController {
         self.environment = environment
         self.maxReadLength = maxReadLength
         onReachableStream = CurrentValueStream(false)
-        betterPathLock = SemaphoreMutex()
+        pipeBetterPathFactory = PipeBetterPathFactory()
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: Unmanaged.passUnretained(self).toOpaque(),
@@ -172,18 +170,9 @@ extension NativeTunnelController: ReachabilityObserver {
     public var isReachableStream: AsyncStream<Bool> {
         onReachableStream.subscribe()
     }
-}
 
-extension NativeTunnelController: BetterPathStreamFactory {
-    public nonisolated func newStream() -> PassthroughStream<Void> {
-        let stream = PassthroughStream<Void>()
-        let oldStream = betterPathLock.with {
-            let old = onBetterPathStream
-            onBetterPathStream = stream
-            return old
-        }
-        oldStream?.finish()
-        return stream
+    public var betterPathFactory: BetterPathStreamFactory {
+        pipeBetterPathFactory
     }
 }
 
@@ -193,10 +182,30 @@ private extension NativeTunnelController {
     }
 
     func onBetterPath() {
-        let stream = betterPathLock.with {
-            onBetterPathStream
+        pipeBetterPathFactory.onBetterPath()
+    }
+}
+
+private final class PipeBetterPathFactory: BetterPathStreamFactory, @unchecked Sendable {
+    private let lock = SemaphoreMutex()
+    private var stream: PassthroughStream<Void>?
+
+    nonisolated func newStream() -> PassthroughStream<Void> {
+        let new = PassthroughStream<Void>()
+        let oldStream = lock.with {
+            let old = stream
+            stream = new
+            return old
         }
-        stream?.send()
+        oldStream?.finish()
+        return new
+    }
+
+    func onBetterPath() {
+        let current = lock.with {
+            stream
+        }
+        current?.send()
     }
 }
 

--- a/Sources/PartoutCore/Connection/BSDSocket.swift
+++ b/Sources/PartoutCore/Connection/BSDSocket.swift
@@ -20,7 +20,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
 
     private let maxReadBatchBytes: Int
 
-    private let betterPathBlock: BetterPathBlock
+    private let betterPathFactory: BetterPathStreamFactory
 
     private let betterPathStream: PassthroughStream<Void>
 
@@ -46,7 +46,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
         _ ctx: PartoutLoggerContext,
         endpoint: ExtendedEndpoint,
         timeout: Int,
-        betterPathBlock: @escaping BetterPathBlock,
+        betterPathFactory: BetterPathStreamFactory,
         socketBufferLength: Int = 1 * 1024 * 1024,
         maxReadLength: Int = 128 * 1024,
         maxReadBatchPackets: Int = 256,
@@ -57,25 +57,20 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
             timeout: timeout,
             socketBufferLength: socketBufferLength
         )
-        do {
-            let closesOnEmptyRead = endpoint.plainSocketType == .tcp
-            let betterPathStream = try betterPathBlock()
-            return BSDSocket(
-                ctx: ctx,
-                endpoint: endpoint,
-                connectTimeout: timeout,
-                sock: sock,
-                closesOnEmptyRead: closesOnEmptyRead,
-                maxReadLength: maxReadLength,
-                maxReadBatchPackets: maxReadBatchPackets,
-                maxReadBatchBytes: maxReadBatchBytes,
-                betterPathBlock: betterPathBlock,
-                betterPathStream: betterPathStream
-            )
-        } catch {
-            pp_socket_free(sock)
-            throw error
-        }
+        let closesOnEmptyRead = endpoint.plainSocketType == .tcp
+        let betterPathStream = betterPathFactory.newStream()
+        return BSDSocket(
+            ctx: ctx,
+            endpoint: endpoint,
+            connectTimeout: timeout,
+            sock: sock,
+            closesOnEmptyRead: closesOnEmptyRead,
+            maxReadLength: maxReadLength,
+            maxReadBatchPackets: maxReadBatchPackets,
+            maxReadBatchBytes: maxReadBatchBytes,
+            betterPathFactory: betterPathFactory,
+            betterPathStream: betterPathStream
+        )
     }
 
     private init(
@@ -87,7 +82,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
         maxReadLength: Int,
         maxReadBatchPackets: Int,
         maxReadBatchBytes: Int,
-        betterPathBlock: @escaping BetterPathBlock,
+        betterPathFactory: BetterPathStreamFactory,
         betterPathStream: PassthroughStream<Void>
     ) {
         self.ctx = ctx
@@ -97,7 +92,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
         self.maxReadLength = maxReadLength
         self.maxReadBatchPackets = max(1, maxReadBatchPackets)
         self.maxReadBatchBytes = max(maxReadLength, maxReadBatchBytes)
-        self.betterPathBlock = betterPathBlock
+        self.betterPathFactory = betterPathFactory
         self.betterPathStream = betterPathStream
         socketHandle = SocketHandle(sock: sock)
         let queueLabelContext = socketHandle.fileDescriptor?.description ?? "unknown"
@@ -164,7 +159,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
             ctx,
             endpoint: endpoint,
             timeout: connectTimeout,
-            betterPathBlock: betterPathBlock,
+            betterPathFactory: betterPathFactory,
             maxReadLength: maxReadLength
         )
     }

--- a/Sources/PartoutCore/Connection/BSDSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/BSDSocketFactory.swift
@@ -6,17 +6,17 @@
 public final class BSDSocketFactory: NetworkInterfaceFactory {
     private let ctx: PartoutLoggerContext
 
-    private let betterPathBlock: BetterPathBlock
+    private let betterPathFactory: BetterPathStreamFactory
 
     public init(
         _ ctx: PartoutLoggerContext,
-        betterPathBlock: @escaping BetterPathBlock
+        betterPathFactory: BetterPathStreamFactory
     ) {
         self.ctx = ctx
-        self.betterPathBlock = betterPathBlock
+        self.betterPathFactory = betterPathFactory
     }
 
     public func linkObserver(to endpoint: ExtendedEndpoint) -> LinkObserver {
-        BSDSocketObserver(ctx, endpoint: endpoint, betterPathBlock: betterPathBlock)
+        BSDSocketObserver(ctx, endpoint: endpoint, betterPathFactory: betterPathFactory)
     }
 }

--- a/Sources/PartoutCore/Connection/BSDSocketObserver.swift
+++ b/Sources/PartoutCore/Connection/BSDSocketObserver.swift
@@ -10,19 +10,19 @@ public final class BSDSocketObserver: LinkObserver, @unchecked Sendable {
 
     private let endpoint: ExtendedEndpoint
 
-    private let betterPathBlock: BetterPathBlock
+    private let betterPathFactory: BetterPathStreamFactory
 
     private let maxReadLength: Int
 
     public init(
         _ ctx: PartoutLoggerContext,
         endpoint: ExtendedEndpoint,
-        betterPathBlock: @escaping BetterPathBlock,
+        betterPathFactory: BetterPathStreamFactory,
         maxReadLength: Int = 128 * 1024
     ) {
         self.ctx = ctx
         self.endpoint = endpoint
-        self.betterPathBlock = betterPathBlock
+        self.betterPathFactory = betterPathFactory
         self.maxReadLength = maxReadLength
     }
 
@@ -31,12 +31,7 @@ public final class BSDSocketObserver: LinkObserver, @unchecked Sendable {
             ctx,
             endpoint: endpoint,
             timeout: timeout,
-            betterPathBlock: { [weak self] in
-                guard let self else {
-                    throw PartoutError(.releasedObject)
-                }
-                return try betterPathBlock()
-            },
+            betterPathFactory: betterPathFactory,
             maxReadLength: maxReadLength
         )
     }

--- a/Sources/PartoutCore/Connection/BetterPathBlock.swift
+++ b/Sources/PartoutCore/Connection/BetterPathBlock.swift
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2026 Davide De Rosa
-//
-// SPDX-License-Identifier: GPL-3.0
-
-/// Returns a stream to observe events about better network paths.
-public typealias BetterPathBlock = @Sendable () throws -> PassthroughStream<Void>

--- a/Sources/PartoutCore/Connection/BetterPathStreamFactory.swift
+++ b/Sources/PartoutCore/Connection/BetterPathStreamFactory.swift
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+/// Spawns a stream to observe events about better network paths.
+public protocol BetterPathStreamFactory: Sendable {
+    nonisolated func newStream() -> PassthroughStream<Void>
+}

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -27,7 +27,7 @@ Given the main app and the daemon:
 
 ### Setting up a connection
 
-- ``BetterPathBlock``
+- ``BetterPathStreamFactory``
 - ``BSDSocketFactory``
 - ``Connection``
 - ``ConnectionParameters``

--- a/Sources/PartoutCore/Misc/SemaphoreMutex.swift
+++ b/Sources/PartoutCore/Misc/SemaphoreMutex.swift
@@ -16,4 +16,11 @@ public final class SemaphoreMutex: @unchecked Sendable {
     public func unlock() {
         semaphore.signal()
     }
+
+    public func with<T>(block: () -> T) -> T {
+        lock()
+        let result = block()
+        unlock()
+        return result
+    }
 }

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -27,6 +27,8 @@ const char *_Nullable pp_tun_name(const pp_tun _Nonnull tun);
 /* Tunnel controller. */
 typedef struct {
     void *_Nullable ctx;
+    void (*_Nonnull on_reachable)(void *_Nonnull ctx, bool is_reachable);
+    void (*_Nonnull on_better_path)(void *_Nonnull ctx);
     char *_Nullable (*_Nonnull environment_value)(void *_Nonnull ctx, const char *_Nonnull key);
 } pp_tun_ctrl_delegate;
 void pp_tun_ctrl_set_delegate(void *_Nullable ref,

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -294,8 +294,32 @@ void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
     free(tun_impl);
 }
 
+JNIEXPORT void JNICALL
+Java_io_partout_vpn_JNITunnelController_onNativeReachabilityUpdate(JNIEnv *env,
+                                                                   jobject thiz,
+                                                                   jlong delegate,
+                                                                   jboolean is_reachable) {
+    (void)thiz;
+    pp_tun_ctrl_delegate *ctrl_delegate = (pp_tun_ctrl_delegate *)(intptr_t)delegate;
+    if (!ctrl_delegate || !ctrl_delegate->ctx) return;
+    ctrl_delegate->on_reachable(ctrl_delegate->ctx, is_reachable);
+}
+
+JNIEXPORT void JNICALL
+Java_io_partout_vpn_JNITunnelController_onNativeBetterPathUpdate(JNIEnv *env,
+                                                                 jobject thiz,
+                                                                 jlong delegate) {
+    (void)thiz;
+    pp_tun_ctrl_delegate *ctrl_delegate = (pp_tun_ctrl_delegate *)(intptr_t)delegate;
+    if (!ctrl_delegate || !ctrl_delegate->ctx) return;
+    ctrl_delegate->on_better_path(ctrl_delegate->ctx);
+}
+
 JNIEXPORT jstring JNICALL
-Java_io_partout_vpn_JNITunnelController_getNativeEnvironmentValue(JNIEnv *env, jobject thiz, jlong delegate, jstring key) {
+Java_io_partout_vpn_JNITunnelController_getNativeEnvironmentValue(JNIEnv *env,
+                                                                  jobject thiz,
+                                                                  jlong delegate,
+                                                                  jstring key) {
     (void)thiz;
     pp_tun_ctrl_delegate *ctrl_delegate = (pp_tun_ctrl_delegate *)(intptr_t)delegate;
     if (!ctrl_delegate || !ctrl_delegate->ctx) return NULL;

--- a/Sources/PartoutOS/AppleNE/AppExtension/NEBetterPathStreamFactory.swift
+++ b/Sources/PartoutOS/AppleNE/AppExtension/NEBetterPathStreamFactory.swift
@@ -4,18 +4,16 @@
 
 @preconcurrency import Network
 
-/// A better path block implementation backed by `NWPathMonitor`.
-public struct NEBetterPathBlock: Sendable {
+/// A better path implementation backed by `NWPathMonitor`.
+public struct NEBetterPathStreamFactory: BetterPathStreamFactory {
     private let ctx: PartoutLoggerContext
 
     public init(_ ctx: PartoutLoggerContext) {
         self.ctx = ctx
     }
 
-    public var block: BetterPathBlock {
-        { [ctx] in
-            NWPathMonitorBetterPathStream(ctx).stream
-        }
+    public func newStream() -> PassthroughStream<Void> {
+        NWPathMonitorBetterPathStream(ctx).stream
     }
 }
 
@@ -37,7 +35,7 @@ private final class NWPathMonitorBetterPathStream: @unchecked Sendable {
     init(_ ctx: PartoutLoggerContext) {
         self.ctx = ctx
         monitor = NWPathMonitor()
-        monitorQueue = DispatchQueue(label: "NEBetterPathBlock")
+        monitorQueue = DispatchQueue(label: "NEBetterPathStreamFactory")
         stream = PassthroughStream()
         didSignal = false
         didStop = false

--- a/Sources/PartoutOS/Docs.docc/AppleNE.md
+++ b/Sources/PartoutOS/Docs.docc/AppleNE.md
@@ -32,7 +32,7 @@ The ``NEPTPForwarder`` wrapper is a simple way to build a basic [NEPacketTunnelP
 
 ### App Extension
 
-- ``NEBetterPathBlock``
+- ``NEBetterPathStreamFactory``
 - ``NEObservablePath``
 - ``NEPTPForwarder``
 - ``NESettingsApplying``

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -50,7 +50,7 @@ set(PARTOUT_SOURCES
 ./PartoutCore/Connection/BSDSocket.swift
 ./PartoutCore/Connection/BSDSocketFactory.swift
 ./PartoutCore/Connection/BSDSocketObserver.swift
-./PartoutCore/Connection/BetterPathBlock.swift
+./PartoutCore/Connection/BetterPathStreamFactory.swift
 ./PartoutCore/Connection/Connection.swift
 ./PartoutCore/Connection/ConnectionDaemon.swift
 ./PartoutCore/Connection/ConnectionParameters.swift
@@ -175,7 +175,7 @@ set(PARTOUT_SOURCES
 ./PartoutOS/AppleNE/App/NETunnelEnvironment.swift
 ./PartoutOS/AppleNE/App/NETunnelManagerRepository.swift
 ./PartoutOS/AppleNE/App/NETunnelStrategy.swift
-./PartoutOS/AppleNE/AppExtension/NEBetterPathBlock.swift
+./PartoutOS/AppleNE/AppExtension/NEBetterPathStreamFactory.swift
 ./PartoutOS/AppleNE/AppExtension/NEObservablePath.swift
 ./PartoutOS/AppleNE/AppExtension/NEPTPForwarder.swift
 ./PartoutOS/AppleNE/AppExtension/NESettingsApplying.swift

--- a/Tests/PartoutOSTests/AppleNE/NEBetterPathStreamFactoryTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NEBetterPathStreamFactoryTests.swift
@@ -5,7 +5,7 @@
 @testable import PartoutOS
 import Testing
 
-struct NEBetterPathBlockTests {
+struct NEBetterPathStreamFactoryTests {
     @Test
     func givenUnsatisfiedPath_whenPathBecomesSatisfied_thenIsBetter() {
         let oldPath = NWPathBetterPathPreference(

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -113,7 +113,7 @@ class PartoutVpnServiceRuntime(
         isRunning = true
         Log.i(logTag, "Starting VPN daemon")
         try {
-            val newController = JNITunnelController(jniLogTag, service, this, serviceScope)
+            val newController = JNITunnelController(jniLogTag, service, serviceScope, this)
             engine.start(intent, newController, profileJSON)
             controller = newController
             Log.i(logTag, "Started VPN daemon")

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -166,7 +166,7 @@ class PartoutVpnServiceRuntime(
         } catch (e: Exception) {
             Log.e(logTag, "Unable to stop VPN daemon", e)
         } finally {
-            controller?.close()
+            controller?.stopObserving()
             controller = null
         }
         isRunning = false

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -113,7 +113,7 @@ class PartoutVpnServiceRuntime(
         isRunning = true
         Log.i(logTag, "Starting VPN daemon")
         try {
-            val newController = JNITunnelController(jniLogTag, service, this)
+            val newController = JNITunnelController(jniLogTag, service, this, serviceScope)
             engine.start(intent, newController, profileJSON)
             controller = newController
             Log.i(logTag, "Started VPN daemon")
@@ -163,9 +163,11 @@ class PartoutVpnServiceRuntime(
         Log.i(logTag, "Stopping VPN daemon")
         try {
             engine.stop()
-            controller = null
         } catch (e: Exception) {
             Log.e(logTag, "Unable to stop VPN daemon", e)
+        } finally {
+            controller?.close()
+            controller = null
         }
         isRunning = false
         snapshotEmitter.emitFinal()

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -43,8 +43,8 @@ interface TunnelControllerDelegate {
 class JNITunnelController(
     private val logTag: String,
     private val service: VpnService,
-    private val delegate: TunnelControllerDelegate,
-    scope: CoroutineScope
+    scope: CoroutineScope,
+    private val delegate: TunnelControllerDelegate
 ) : TunnelController {
     // All accesses must be synchronized against the lock
     private val lock = Any()

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -13,11 +13,18 @@ import io.partout.models.TaggedModuleIP
 import io.partout.models.TaggedModuleOnDemand
 import io.partout.models.TunnelRemoteInfoWrapper
 import io.partout.models.TunnelSnapshot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 // Must match signatures in tun_android.c
 interface TunnelController {
+    // Runtime
+    fun close()
+
     // JNI -> Jotlin
     fun setDelegate(delegate: Long): Long
     fun setTunnel(infoJSON: String): Int
@@ -37,12 +44,16 @@ interface TunnelControllerDelegate {
 class JNITunnelController(
     private val logTag: String,
     private val service: VpnService,
-    private val delegate: TunnelControllerDelegate
-): TunnelController {
+    private val delegate: TunnelControllerDelegate,
+    private val scope: CoroutineScope
+) : TunnelController {
     private val lock = Any()
     private var descriptor: ParcelFileDescriptor? = null
     private var nativeDelegate: Long = 0
     private var isClosed = false
+
+    override fun close() {
+    }
 
     override fun setDelegate(delegate: Long): Long = synchronized(lock) {
         Log.d(logTag, "setDelegate($delegate)")

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -143,7 +143,7 @@ class JNITunnelController(
             require(it in 0..Int.MAX_VALUE.toLong()) {
                 "Invalid Android file descriptor: $it"
             }
-            val protected = service.protect(it.toInt())
+            val protected = service.protect(it)
             Log.d(logTag, "protect($it) = $protected")
         }
     }
@@ -152,7 +152,7 @@ class JNITunnelController(
         if (isNativeCancelled) { return }
         Log.d(logTag, "onSnapshot(${snapshotJSON})")
         val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
-        delegate?.sendSnapshot(snapshot)
+        delegate.sendSnapshot(snapshot)
         return@synchronized
     }
 
@@ -165,7 +165,7 @@ class JNITunnelController(
         } else {
             Log.i(logTag, "VPN daemon cancelled")
         }
-        delegate?.disconnect()
+        delegate.disconnect()
         return@synchronized
     }
 

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -14,16 +14,13 @@ import io.partout.models.TaggedModuleOnDemand
 import io.partout.models.TunnelRemoteInfoWrapper
 import io.partout.models.TunnelSnapshot
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 // Must match signatures in tun_android.c
 interface TunnelController {
     // Runtime
-    fun close()
+    fun stopObserving()
 
     // JNI -> Jotlin
     fun setDelegate(delegate: Long): Long
@@ -33,6 +30,8 @@ interface TunnelController {
     fun cancelTunnel(errorCode: String?)
 
     // Kotlin -> JNI
+    fun onReachabilityUpdate(isReachable: Boolean)
+    fun onBetterPathUpdate()
     fun getEnvironmentValue(key: String): String?
 }
 
@@ -45,14 +44,17 @@ class JNITunnelController(
     private val logTag: String,
     private val service: VpnService,
     private val delegate: TunnelControllerDelegate,
-    private val scope: CoroutineScope
+    scope: CoroutineScope
 ) : TunnelController {
+    // All accesses must be synchronized against the lock
     private val lock = Any()
-    private var descriptor: ParcelFileDescriptor? = null
-    private var nativeDelegate: Long = 0
-    private var isClosed = false
 
-    override fun close() {
+    // JNI interactions with Native (Swift)
+    private var nativeDelegate: Long = 0
+    private var isNativeCancelled = false
+    private var tunDescriptor: ParcelFileDescriptor? = null
+
+    override fun stopObserving() {
     }
 
     override fun setDelegate(delegate: Long): Long = synchronized(lock) {
@@ -63,9 +65,9 @@ class JNITunnelController(
     }
 
     override fun setTunnel(infoJSON: String): Int = synchronized(lock) {
-        if (isClosed) { return -1 }
+        if (isNativeCancelled) { return -1 }
         Log.d(logTag, "setTunnel()")
-        if (descriptor != null) {
+        if (tunDescriptor != null) {
             Log.e(logTag, "Tunnel descriptor already established")
             return -1
         }
@@ -117,25 +119,25 @@ class JNITunnelController(
         // By default, establish() returns a non-blocking descriptor.
         builder.setBlocking(true)
 
-        descriptor = try {
+        tunDescriptor = try {
             builder.establish()
         } catch (e: RuntimeException) {
             Log.e(logTag, "Unable to establish tunnel", e)
             null
         }
-        if (descriptor == null) {
+        if (tunDescriptor == null) {
             Log.e(logTag, "Unable to establish tunnel")
             return -1
         }
 
-        val fd = descriptor?.detachFd() ?: -1
-        descriptor = null
+        val fd = tunDescriptor?.detachFd() ?: -1
+        tunDescriptor = null
         Log.i(logTag, "Established tunnel descriptor: $fd")
         return fd
     }
 
     override fun configureSockets(fds: IntArray) = synchronized(lock) {
-        if (isClosed) { return }
+        if (isNativeCancelled) { return }
         Log.d(logTag, "configureSockets(${fds.toList()})")
         fds.forEach {
             require(it in 0..Int.MAX_VALUE.toLong()) {
@@ -147,7 +149,7 @@ class JNITunnelController(
     }
 
     override fun onSnapshot(snapshotJSON: String) = synchronized(lock) {
-        if (isClosed) { return }
+        if (isNativeCancelled) { return }
         Log.d(logTag, "onSnapshot(${snapshotJSON})")
         val snapshot = json.decodeFromString<TunnelSnapshot>(snapshotJSON)
         delegate?.sendSnapshot(snapshot)
@@ -155,8 +157,8 @@ class JNITunnelController(
     }
 
     override fun cancelTunnel(errorCode: String?) = synchronized(lock) {
-        if (isClosed) { return }
-        isClosed = true
+        if (isNativeCancelled) { return }
+        isNativeCancelled = true
         Log.d(logTag, "cancelTunnel()")
         if (errorCode != null) {
             Log.e(logTag, "VPN daemon cancelled: $errorCode")
@@ -167,11 +169,23 @@ class JNITunnelController(
         return@synchronized
     }
 
+    override fun onReachabilityUpdate(isReachable: Boolean) = synchronized(lock) {
+        Log.e(logTag, ">>> Network: onReachabilityUpdate($isReachable)")
+        onNativeReachabilityUpdate(nativeDelegate, isReachable)
+    }
+
+    override fun onBetterPathUpdate() = synchronized(lock) {
+        Log.e(logTag, ">>> Network: onBetterPathUpdate()")
+        onNativeBetterPathUpdate(nativeDelegate)
+    }
+
     override fun getEnvironmentValue(key: String): String? = synchronized(lock) {
-        Log.d(logTag, "environmentValue($key)")
+        Log.d(logTag, "getEnvironmentValue($key)")
         return getNativeEnvironmentValue(nativeDelegate, key)
     }
 
+    private external fun onNativeReachabilityUpdate(delegate: Long, isReachable: Boolean)
+    private external fun onNativeBetterPathUpdate(delegate: Long)
     private external fun getNativeEnvironmentValue(delegate: Long, key: String): String?
 
     companion object {


### PR DESCRIPTION
After #418, JNITunnelController has a `nativeDelegate` pointing to a NativeTunnelController vtable. Leverage the same vtable to add more callable methods from JNITunnelController to NativeTunnelController, namely:

- on_reachable(ctx, bool)
- on_better_path(ctx)

These callbacks will:

- Call into NativeTunnelController .onReachable() and .onBetterPath()
- Report new values to the local streams, onReachableStream and onBetterPathStream, respectively

The better path stream is a public field, while the reachability logic is exposed by making NativeTunnelController itself a ReachabilityObserver. NativeTunnelController becomes the proxy converting network events from the native language to Swift streams.