### PR TITLE
Android: Track availability of better networks

### DIFF
--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -4,6 +4,7 @@
 
 package io.partout.vpn
 
+import android.net.Network
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
 import android.util.Log
@@ -61,6 +62,16 @@ class JNITunnelController(
     private val reachabilityObserver = ReachabilityObserver(service)
     private var reachabilityJob: Job? = null
     private var networkInfo = NetworkInfo.empty
+    private var lastEmittedNetwork: Network? = null
+    private var lastEmittedNetworkPreference: NetworkPathPreference? = null
+
+    private data class ReachabilitySelection(
+        val network: Network?,
+        val preference: NetworkPathPreference?
+    ) {
+        val networkHandle: Long?
+            get() = network?.networkHandle
+    }
 
     // Retain tun across reconnections
     private var tunDescriptor: ParcelFileDescriptor? = null
@@ -82,10 +93,11 @@ class JNITunnelController(
         val oldDelegate = nativeDelegate
         nativeDelegate = delegate
         if (delegate != 0L) {
-            onNativeReachabilityUpdate(
-                delegate,
-                networkInfo.bestNetworks().firstOrNull()?.networkHandle ?: INVALID_NETWORK_HANDLE
-            )
+            val selection = networkInfo.reachabilitySelection()
+            emitReachabilityUpdate(selection)
+            rememberEmittedNetwork(selection)
+        } else {
+            clearEmittedNetwork()
         }
         return oldDelegate
     }
@@ -247,9 +259,12 @@ class JNITunnelController(
 
     override fun onReachabilityUpdate(info: NetworkInfo) = synchronized(lock) {
         networkInfo = info
-        val networkHandle = info.bestNetworks().firstOrNull()?.networkHandle
-        Log.e(logTag, ">>> Network: onReachabilityUpdate($networkHandle)")
-        onNativeReachabilityUpdate(nativeDelegate, networkHandle ?: INVALID_NETWORK_HANDLE)
+        val selection = info.reachabilitySelection()
+        emitReachabilityUpdate(selection)
+        if (selection.isBetterThanLastEmitted()) {
+            emitBetterPathUpdate(selection)
+        }
+        rememberEmittedNetwork(selection)
     }
 
     override fun getEnvironmentValue(key: String): String? = synchronized(lock) {
@@ -258,6 +273,7 @@ class JNITunnelController(
     }
 
     private external fun onNativeReachabilityUpdate(delegate: Long, networkHandle: Long)
+    private external fun onNativeBetterPathUpdate(delegate: Long)
     private external fun getNativeEnvironmentValue(delegate: Long, key: String): String?
 
     companion object {
@@ -267,5 +283,48 @@ class JNITunnelController(
         private val json = Json {
             ignoreUnknownKeys = true
         }
+    }
+
+    private fun NetworkInfo.reachabilitySelection(): ReachabilitySelection {
+        val currentNetwork = bestNetworks().firstOrNull()
+        return ReachabilitySelection(
+            network = currentNetwork,
+            preference = preferenceFor(currentNetwork)
+        )
+    }
+
+    private fun ReachabilitySelection.isBetterThanLastEmitted(): Boolean {
+        val currentPreference = preference ?: return false
+        val previousPreference = lastEmittedNetworkPreference ?: return false
+        if (lastEmittedNetwork == null) {
+            return false
+        }
+        return currentPreference > previousPreference
+    }
+
+    private fun emitReachabilityUpdate(selection: ReachabilitySelection) {
+        Log.e(logTag, ">>> Network: onReachabilityUpdate(${selection.networkHandle})")
+        onNativeReachabilityUpdate(
+            nativeDelegate,
+            selection.networkHandle ?: INVALID_NETWORK_HANDLE
+        )
+    }
+
+    private fun emitBetterPathUpdate(selection: ReachabilitySelection) {
+        Log.e(logTag, ">>> Network: onBetterPathUpdate(${selection.networkHandle})")
+        onNativeBetterPathUpdate(nativeDelegate)
+    }
+
+    private fun rememberEmittedNetwork(selection: ReachabilitySelection) {
+        if (nativeDelegate == 0L) {
+            return
+        }
+        lastEmittedNetwork = selection.network
+        lastEmittedNetworkPreference = selection.preference
+    }
+
+    private fun clearEmittedNetwork() {
+        lastEmittedNetwork = null
+        lastEmittedNetworkPreference = null
     }
 }

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -16,8 +16,10 @@ import io.partout.models.TunnelRemoteInfoWrapper
 import io.partout.models.TunnelSnapshot
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
@@ -61,6 +63,7 @@ class JNITunnelController(
     // Network observers
     private val reachabilityObserver = ReachabilityObserver(service)
     private var reachabilityJob: Job? = null
+    private var betterPathJob: Job? = null
     private var networkInfo = NetworkInfo.empty
     private var lastEmittedNetwork: Network? = null
     private var lastEmittedNetworkPreference: NetworkPathPreference? = null
@@ -86,6 +89,7 @@ class JNITunnelController(
     override fun stopObserving() {
         reachabilityJob?.cancel()
         reachabilityJob = null
+        cancelBetterPathUpdate()
     }
 
     override fun setDelegate(delegate: Long): Long = synchronized(lock) {
@@ -98,6 +102,7 @@ class JNITunnelController(
             rememberEmittedNetwork(selection)
         } else {
             clearEmittedNetwork()
+            cancelBetterPathUpdate()
         }
         return oldDelegate
     }
@@ -237,6 +242,7 @@ class JNITunnelController(
 
         // Prevent further calls
         isNativeCancelled = true
+        cancelBetterPathUpdate()
 
         // Close former tunnel
         runCatching {
@@ -262,7 +268,9 @@ class JNITunnelController(
         val selection = info.reachabilitySelection()
         emitReachabilityUpdate(selection)
         if (selection.isBetterThanLastEmitted()) {
-            emitBetterPathUpdate(selection)
+            scheduleBetterPathUpdate(selection)
+        } else {
+            cancelBetterPathUpdate()
         }
         rememberEmittedNetwork(selection)
     }
@@ -279,6 +287,7 @@ class JNITunnelController(
     companion object {
         private const val INVALID_TUN_FD = -1
         private const val INVALID_NETWORK_HANDLE = -1L
+        private const val BETTER_PATH_DELAY_MS = 300L
 
         private val json = Json {
             ignoreUnknownKeys = true
@@ -313,6 +322,27 @@ class JNITunnelController(
     private fun emitBetterPathUpdate(selection: ReachabilitySelection) {
         Log.e(logTag, ">>> Network: onBetterPathUpdate(${selection.networkHandle})")
         onNativeBetterPathUpdate(nativeDelegate)
+    }
+
+    private fun scheduleBetterPathUpdate(selection: ReachabilitySelection) {
+        betterPathJob?.cancel()
+        betterPathJob = scope.launch {
+            delay(BETTER_PATH_DELAY_MS)
+            synchronized(lock) {
+                if (!isNativeCancelled &&
+                    nativeDelegate != 0L &&
+                    selection == networkInfo.reachabilitySelection()
+                ) {
+                    emitBetterPathUpdate(selection)
+                }
+                betterPathJob = null
+            }
+        }
+    }
+
+    private fun cancelBetterPathUpdate() {
+        betterPathJob?.cancel()
+        betterPathJob = null
     }
 
     private fun rememberEmittedNetwork(selection: ReachabilitySelection) {

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -4,7 +4,6 @@
 
 package io.partout.vpn
 
-import android.net.Network
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
 import android.util.Log
@@ -36,8 +35,7 @@ interface TunnelController {
     fun cancelTunnel(errorCode: String?)
 
     // Kotlin -> JNI
-    fun onReachabilityUpdate(network: Network?)
-    fun onBetterPathUpdate()
+    fun onReachabilityUpdate(info: NetworkInfo)
     fun getEnvironmentValue(key: String): String?
 }
 
@@ -62,7 +60,7 @@ class JNITunnelController(
     // Network observers
     private val reachabilityObserver = ReachabilityObserver(service)
     private var reachabilityJob: Job? = null
-    private var reachableNetwork: Network? = null
+    private var networkInfo = NetworkInfo.empty
 
     // Retain tun across reconnections
     private var tunDescriptor: ParcelFileDescriptor? = null
@@ -86,7 +84,7 @@ class JNITunnelController(
         if (delegate != 0L) {
             onNativeReachabilityUpdate(
                 delegate,
-                reachableNetwork?.networkHandle ?: INVALID_NETWORK_HANDLE
+                networkInfo.bestNetworks().firstOrNull()?.networkHandle ?: INVALID_NETWORK_HANDLE
             )
         }
         return oldDelegate
@@ -247,15 +245,11 @@ class JNITunnelController(
         return@synchronized
     }
 
-    override fun onReachabilityUpdate(network: Network?) = synchronized(lock) {
-        val networkHandle = network?.networkHandle
+    override fun onReachabilityUpdate(info: NetworkInfo) = synchronized(lock) {
+        networkInfo = info
+        val networkHandle = info.bestNetworks().firstOrNull()?.networkHandle
         Log.e(logTag, ">>> Network: onReachabilityUpdate($networkHandle)")
         onNativeReachabilityUpdate(nativeDelegate, networkHandle ?: INVALID_NETWORK_HANDLE)
-    }
-
-    override fun onBetterPathUpdate() = synchronized(lock) {
-        Log.e(logTag, ">>> Network: onBetterPathUpdate()")
-        onNativeBetterPathUpdate(nativeDelegate)
     }
 
     override fun getEnvironmentValue(key: String): String? = synchronized(lock) {
@@ -264,7 +258,6 @@ class JNITunnelController(
     }
 
     private external fun onNativeReachabilityUpdate(delegate: Long, networkHandle: Long)
-    private external fun onNativeBetterPathUpdate(delegate: Long)
     private external fun getNativeEnvironmentValue(delegate: Long, key: String): String?
 
     companion object {

--- a/cross/android/io/partout/vpn/ReachabilityObserver.kt
+++ b/cross/android/io/partout/vpn/ReachabilityObserver.kt
@@ -19,10 +19,18 @@ interface ReachabilityObserverProtocol {
 
 class NetworkInfo private constructor(
     val currentNetworks: Set<Network>,
+    private val preferences: Map<Network, NetworkPathPreference>,
     private val sortedNetworks: List<Network>
 ) {
     fun bestNetworks(): List<Network> {
         return sortedNetworks
+    }
+
+    internal fun preferenceFor(network: Network?): NetworkPathPreference? {
+        if (network == null) {
+            return null
+        }
+        return preferences[network]
     }
 
     override fun equals(other: Any?): Boolean {
@@ -32,11 +40,14 @@ class NetworkInfo private constructor(
         if (other !is NetworkInfo) {
             return false
         }
-        return currentNetworks == other.currentNetworks && sortedNetworks == other.sortedNetworks
+        return currentNetworks == other.currentNetworks &&
+                preferences == other.preferences &&
+                sortedNetworks == other.sortedNetworks
     }
 
     override fun hashCode(): Int {
         var result = currentNetworks.hashCode()
+        result = 31 * result + preferences.hashCode()
         result = 31 * result + sortedNetworks.hashCode()
         return result
     }
@@ -46,7 +57,7 @@ class NetworkInfo private constructor(
     }
 
     companion object {
-        internal val empty = NetworkInfo(emptySet(), emptyList())
+        internal val empty = NetworkInfo(emptySet(), emptyMap(), emptyList())
 
         internal fun from(
             currentNetworks: Set<Network>,
@@ -57,7 +68,7 @@ class NetworkInfo private constructor(
                 val rhsPreference = preferences[rhs] ?: NetworkPathPreference.unavailable
                 rhsPreference.compareTo(lhsPreference)
             }
-            return NetworkInfo(currentNetworks, sortedNetworks)
+            return NetworkInfo(currentNetworks, preferences, sortedNetworks)
         }
     }
 }

--- a/cross/android/io/partout/vpn/ReachabilityObserver.kt
+++ b/cross/android/io/partout/vpn/ReachabilityObserver.kt
@@ -14,7 +14,52 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 interface ReachabilityObserverProtocol {
-    fun flow(): Flow<Network?>
+    fun flow(): Flow<NetworkInfo>
+}
+
+class NetworkInfo private constructor(
+    val currentNetworks: Set<Network>,
+    private val sortedNetworks: List<Network>
+) {
+    fun bestNetworks(): List<Network> {
+        return sortedNetworks
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other !is NetworkInfo) {
+            return false
+        }
+        return currentNetworks == other.currentNetworks && sortedNetworks == other.sortedNetworks
+    }
+
+    override fun hashCode(): Int {
+        var result = currentNetworks.hashCode()
+        result = 31 * result + sortedNetworks.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "NetworkInfo(currentNetworks=$currentNetworks, bestNetworks=$sortedNetworks)"
+    }
+
+    companion object {
+        internal val empty = NetworkInfo(emptySet(), emptyList())
+
+        internal fun from(
+            currentNetworks: Set<Network>,
+            preferences: Map<Network, NetworkPathPreference>
+        ): NetworkInfo {
+            val sortedNetworks = currentNetworks.sortedWith { lhs, rhs ->
+                val lhsPreference = preferences[lhs] ?: NetworkPathPreference.unavailable
+                val rhsPreference = preferences[rhs] ?: NetworkPathPreference.unavailable
+                rhsPreference.compareTo(lhsPreference)
+            }
+            return NetworkInfo(currentNetworks, sortedNetworks)
+        }
+    }
 }
 
 class ReachabilityObserver(
@@ -23,39 +68,41 @@ class ReachabilityObserver(
     private val connectivityManager: ConnectivityManager =
         appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 ) : ReachabilityObserverProtocol {
-    override fun flow(): Flow<Network?> = callbackFlow {
+    override fun flow(): Flow<NetworkInfo> = callbackFlow {
         val lock = Any()
         val reachableNetworks = linkedSetOf<Network>()
-        var lastNetwork: Network? = null
+        val preferences = mutableMapOf<Network, NetworkPathPreference>()
+        var lastNetworkInfo: NetworkInfo? = null
         var didEmit = false
 
-        class Evaluation(val network: Network?)
-
-        fun currentNetwork(): Network? {
-            return reachableNetworks.firstOrNull()
-        }
-
-        fun evaluateLocked(): Evaluation? {
-            val network = currentNetwork()
-            if (didEmit && network == lastNetwork) {
+        fun evaluateLocked(): NetworkInfo? {
+            val networkInfo = NetworkInfo.from(
+                reachableNetworks.toSet(),
+                preferences.toMap()
+            )
+            if (didEmit && networkInfo == lastNetworkInfo) {
                 return null
             }
             didEmit = true
-            lastNetwork = network
-            return Evaluation(network)
+            lastNetworkInfo = networkInfo
+            return networkInfo
         }
 
         fun update(network: Network, capabilities: NetworkCapabilities?) {
             val evaluation = synchronized(lock) {
                 if (capabilities.isUsableUnderlying()) {
                     reachableNetworks.add(network)
+                    capabilities?.asNetworkPathPreference()?.let {
+                        preferences[network] = it
+                    }
                 } else {
                     reachableNetworks.remove(network)
+                    preferences.remove(network)
                 }
                 evaluateLocked()
             }
             evaluation?.let {
-                trySend(it.network)
+                trySend(it)
             }
         }
 
@@ -88,7 +135,7 @@ class ReachabilityObserver(
             evaluateLocked()
         }
         initialEvaluation?.let {
-            trySend(it.network)
+            trySend(it)
         }
 
         awaitClose {
@@ -108,4 +155,86 @@ class ReachabilityObserver(
                 hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED) &&
                 hasCapability(NetworkCapabilities.NET_CAPABILITY_TRUSTED)
     }
+}
+
+internal data class NetworkPathPreference(
+    private val statusScore: Int,
+    private val isUnrestricted: Boolean,
+    private val isInexpensive: Boolean,
+    private val transportScore: Int
+) : Comparable<NetworkPathPreference> {
+
+    constructor(capabilities: NetworkCapabilities) : this(
+        statusScore = capabilities.statusScore,
+        isUnrestricted = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED),
+        isInexpensive = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED),
+        transportScore = capabilities.transportScore
+    )
+
+    override fun compareTo(other: NetworkPathPreference): Int {
+        if (statusScore != other.statusScore) {
+            return statusScore.compareTo(other.statusScore)
+        }
+        if (isUnrestricted != other.isUnrestricted) {
+            return isUnrestricted.comparePreference(other.isUnrestricted)
+        }
+        if (isInexpensive != other.isInexpensive) {
+            return isInexpensive.comparePreference(other.isInexpensive)
+        }
+        return transportScore.compareTo(other.transportScore)
+    }
+
+    companion object {
+        val unavailable = NetworkPathPreference(
+            statusScore = 0,
+            isUnrestricted = false,
+            isInexpensive = false,
+            transportScore = 0
+        )
+    }
+}
+
+internal fun NetworkCapabilities.asNetworkPathPreference(): NetworkPathPreference? {
+    if (!hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+        return null
+    }
+    if (!hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)) {
+        return null
+    }
+    return NetworkPathPreference(this)
+}
+
+private val NetworkCapabilities.statusScore: Int
+    get() {
+        if (hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) {
+            return 2
+        }
+        if (hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+            return 1
+        }
+        return 0
+    }
+
+private val NetworkCapabilities.transportScore: Int
+    get() {
+        if (hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+            return 5
+        }
+        if (hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+            return 4
+        }
+        if (hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+            return 3
+        }
+        if (hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
+            return 2
+        }
+        return 0
+    }
+
+private fun Boolean.comparePreference(other: Boolean): Int {
+    if (this == other) {
+        return 0
+    }
+    return if (this) 1 else -1
 }


### PR DESCRIPTION
Besides the "first reachable network", when multiple networks are available, let ReachabilityObserver track a set of "better network(s)" sorted by objective preference. The availability of a better network must not cause a VPN reconnection per se, but the VPN implementation should be given the option.

WireGuard *should* not need this as any path update triggers a bump/reconfiguration.