### PR TITLE
Core: Fix issues with DNS resolver

### DIFF
--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -71,13 +71,11 @@ private extension POSIXDNSStrategy {
 
         var records: [DNSRecord] = []
         var currentPointer = infoPointer
-        while let info = currentPointer?.pointee {
-            guard !Task.isCancelled else {
-                return nil
-            }
-            guard let addr = info.ai_addr else {
-                continue
-            }
+        while let pointer = currentPointer {
+            var info = pointer.pointee
+            currentPointer = info.ai_next
+            guard !Task.isCancelled else { return nil }
+            guard let addr = info.ai_addr else { continue }
             let addrLength = socklen_t(info.ai_addrlen)
             var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
 #if os(Windows)
@@ -100,7 +98,6 @@ private extension POSIXDNSStrategy {
                 let address = hostBuffer.string
                 records.append(DNSRecord(address: address, isIPv6: addrLength == 128))
             }
-            currentPointer = info.ai_next
         }
         return records
     }

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -50,6 +50,8 @@ private extension POSIXDNSStrategy {
         hints.ai_flags = AI_ALL
 #endif
         hints.ai_family = AF_UNSPEC // IPv4/IPv6
+        // XXX: Choosing either would dedup results
+//        hints.ai_socktype = SOCK_STREAM SOCK_DGRAM
         var infoPointer: UnsafeMutablePointer<addrinfo>?
         let result = hostname.withCString {
             getaddrinfo($0, nil, &hints, &infoPointer)

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -75,7 +75,7 @@ private extension POSIXDNSStrategy {
         var records: [DNSRecord] = []
         var currentPointer = infoPointer
         while let pointer = currentPointer {
-            var info = pointer.pointee
+            let info = pointer.pointee
             currentPointer = info.ai_next
             guard !Task.isCancelled else { return nil }
             guard let addr = info.ai_addr else { continue }

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -96,7 +96,8 @@ private extension POSIXDNSStrategy {
             )
             if result == 0 {
                 let address = hostBuffer.string
-                records.append(DNSRecord(address: address, isIPv6: addrLength == 128))
+                let isIPv6 = info.ai_family == AF_INET6
+                records.append(DNSRecord(address: address, isIPv6: isIPv6))
             }
         }
         return records

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -43,7 +43,6 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
 
 private extension POSIXDNSStrategy {
     static func resolveAndBlock(hostname: String) throws -> [DNSRecord]? {
-        let addr = hostname.cString(using: .utf8)
         var hints = addrinfo()
 #if canImport(Darwin)
         // We set this to ALL so that we get v4 addresses even on DNS64 networks
@@ -52,7 +51,9 @@ private extension POSIXDNSStrategy {
 #endif
         hints.ai_family = AF_UNSPEC // IPv4/IPv6
         var infoPointer: UnsafeMutablePointer<addrinfo>?
-        let result = getaddrinfo(addr, nil, &hints, &infoPointer)
+        let result = hostname.withCString {
+            getaddrinfo($0, nil, &hints, &infoPointer)
+        }
         guard result == 0 else {
             switch result {
             case EAI_BADFLAGS:

--- a/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
+++ b/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
@@ -27,21 +27,81 @@ public actor SimpleDNSResolver: DNSResolver {
             return try await pendingResolutionTask.value
         }
         let newStrategy = strategy(hostname)
-        let timeoutTask = Task {
-            try await Task.sleep(milliseconds: timeout)
-            guard !Task.isCancelled else { return }
-            await newStrategy.cancelResolution()
-        }
         let resolutionTask = Task {
             try await newStrategy.startResolution()
-            let result = try await newStrategy.waitForResolution()
-            timeoutTask.cancel()
-            return result
+            return try await Self.waitForResolution(newStrategy, timeout: timeout)
         }
         pendingResolutions[hostname] = resolutionTask
         defer {
             pendingResolutions.removeValue(forKey: hostname)
         }
         return try await resolutionTask.value
+    }
+}
+
+private extension SimpleDNSResolver {
+    nonisolated static func waitForResolution(_ strategy: SimpleDNSStrategy, timeout: Int) async throws -> [DNSRecord] {
+        try await withCheckedThrowingContinuation { continuation in
+            let state = DNSResolutionState(continuation: continuation)
+            // Keep this unstructured: POSIX getaddrinfo() may ignore cancellation, and a task group
+            // would still wait for that child before returning the timeout.
+            let waitTask = Task {
+                do {
+                    let records = try await strategy.waitForResolution()
+                    await state.resume(with: .success(records))
+                } catch {
+                    await state.resume(with: .failure(error))
+                }
+            }
+            let timeoutTask = Task {
+                do {
+                    try await Task.sleep(milliseconds: timeout)
+                } catch {
+                    return
+                }
+                await strategy.cancelResolution()
+                await state.resume(with: .failure(PartoutError(.timeout)))
+            }
+            Task {
+                await state.setTasks(waitTask: waitTask, timeoutTask: timeoutTask)
+            }
+        }
+    }
+}
+
+private actor DNSResolutionState {
+    private var continuation: CheckedContinuation<[DNSRecord], Error>?
+
+    private var waitTask: Task<Void, Never>?
+
+    private var timeoutTask: Task<Void, Never>?
+
+    init(continuation: CheckedContinuation<[DNSRecord], Error>) {
+        self.continuation = continuation
+    }
+
+    func setTasks(waitTask: Task<Void, Never>, timeoutTask: Task<Void, Never>) {
+        guard continuation != nil else {
+            waitTask.cancel()
+            timeoutTask.cancel()
+            return
+        }
+        self.waitTask = waitTask
+        self.timeoutTask = timeoutTask
+    }
+
+    func resume(with result: Result<[DNSRecord], Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        waitTask?.cancel()
+        timeoutTask?.cancel()
+        waitTask = nil
+        timeoutTask = nil
+        switch result {
+        case .success(let records):
+            continuation.resume(returning: records)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
     }
 }

--- a/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
+++ b/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
@@ -43,8 +43,9 @@ private extension SimpleDNSResolver {
     nonisolated static func waitForResolution(_ strategy: SimpleDNSStrategy, timeout: Int) async throws -> [DNSRecord] {
         try await withCheckedThrowingContinuation { continuation in
             let state = DNSResolutionState(continuation: continuation)
-            // Keep this unstructured: POSIX getaddrinfo() may ignore cancellation, and a task group
-            // would still wait for that child before returning the timeout.
+            // Keep this unstructured. Blocking DNS resolution may ignore
+            // cancellation, and a task group would still wait for that
+            // child before returning the timeout.
             let waitTask = Task {
                 do {
                     let records = try await strategy.waitForResolution()

--- a/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
+++ b/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
@@ -31,6 +31,21 @@ struct SimpleDNSResolverTests {
             #expect(Bool(false), "Unexpected error: \(error)")
         }
     }
+
+    @Test
+    func givenResolverIgnoringCancellation_whenTimeout_thenStillReturns() async throws {
+        let sut = SimpleDNSResolver { _ in
+            CancellationIgnoringStrategy()
+        }
+        do {
+            _ = try await sut.resolve("foobar.com", timeout: 100)
+            #expect(Bool(false), ".resolve must fail")
+        } catch let error as PartoutError {
+            #expect(error.code == .timeout)
+        } catch {
+            #expect(Bool(false), "Unexpected error: \(error)")
+        }
+    }
 }
 
 // MARK: -
@@ -69,5 +84,18 @@ private actor MockStrategy: SimpleDNSStrategy {
     func cancelResolution() {
         print("cancelResolution")
         resolutionTask?.cancel()
+    }
+}
+
+private actor CancellationIgnoringStrategy: SimpleDNSStrategy {
+    func startResolution() {
+    }
+
+    func waitForResolution() async throws -> [DNSRecord] {
+        try await Task.sleep(milliseconds: 10_000)
+        return []
+    }
+
+    func cancelResolution() {
     }
 }


### PR DESCRIPTION
- Fix deadlock in SimpleDNSResolver preventing timeout when the resolution locks up the pending task
- Fix infinite loop in POSIXDNSStrategy
- Fix condition for resolved IPv6 records
- Prefer .withCString() over .cString()