### PR TITLE
Core: Track native reachability info

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -17,6 +17,10 @@ public final class NativeTunnelController: TunnelController {
 
     private let onReachableStream: CurrentValueStream<Bool>
 
+    private let reachabilityLock: SemaphoreMutex
+
+    private var reachability: pp_tun_ctrl_reachability?
+
     private let betterPathProxy: BetterPathProxy
 
     public init(
@@ -38,13 +42,14 @@ public final class NativeTunnelController: TunnelController {
         self.environment = environment
         self.maxReadLength = maxReadLength
         onReachableStream = CurrentValueStream(true)
+        reachabilityLock = SemaphoreMutex()
         betterPathProxy = BetterPathProxy()
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: .fromSelf(self),
-            on_reachable: { ctx, isReachable in
+            on_reachable: { ctx, reachability in
                 let this = ctx.toSelf
-                this.onReachable(isReachable)
+                this.onReachability(reachability)
             },
             on_better_path: { ctx in
                 let this = ctx.toSelf
@@ -177,7 +182,16 @@ extension NativeTunnelController: ReachabilityObserver {
 }
 
 private extension NativeTunnelController {
-    func onReachable(_ isReachable: Bool) {
+    func onReachability(_ reachability: UnsafePointer<pp_tun_ctrl_reachability>) {
+        let isReachable = reachability.pointee.reachable
+#if os(Android)
+        pp_log(ctx, .core, .fault, ">>> Network reachable: \(isReachable), network_handle=\(reachability.pointee.network_handle)")
+#else
+        pp_log(ctx, .core, .fault, ">>> Network reachable: \(isReachable)")
+#endif
+        reachabilityLock.with {
+            self.reachability = reachability.pointee
+        }
         onReachableStream.send(isReachable)
     }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -185,9 +185,9 @@ private extension NativeTunnelController {
     func onReachability(_ reachability: UnsafePointer<pp_tun_ctrl_reachability>) {
         let isReachable = reachability.pointee.reachable
 #if os(Android)
-        pp_log(ctx, .core, .fault, ">>> Network reachable: \(isReachable), network_handle=\(reachability.pointee.network_handle)")
+        pp_log(ctx, .core, .info, "Network reachability changed: reachable=\(isReachable), network_handle=\(reachability.pointee.network_handle)")
 #else
-        pp_log(ctx, .core, .fault, ">>> Network reachable: \(isReachable)")
+        pp_log(ctx, .core, .info, "Network reachability changed: reachable=\(isReachable)")
 #endif
         reachabilityLock.with {
             self.reachability = reachability.pointee

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -37,7 +37,7 @@ public final class NativeTunnelController: TunnelController {
 #endif
         self.environment = environment
         self.maxReadLength = maxReadLength
-        onReachableStream = CurrentValueStream(false)
+        onReachableStream = CurrentValueStream(true)
         betterPathProxy = BetterPathProxy()
 
         var delegate = pp_tun_ctrl_delegate(

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -26,8 +26,15 @@ const char *_Nullable pp_tun_name(const pp_tun _Nonnull tun);
 
 /* Tunnel controller. */
 typedef struct {
+    bool reachable;
+#if PARTOUT_ANDROID
+    uint64_t network_handle;
+#endif
+} pp_tun_ctrl_reachability;
+typedef struct {
     void *_Nullable ctx;
-    void (*_Nonnull on_reachable)(void *_Nonnull ctx, bool is_reachable);
+    void (*_Nonnull on_reachable)(void *_Nonnull ctx,
+                                  const pp_tun_ctrl_reachability *_Nonnull reachability);
     void (*_Nonnull on_better_path)(void *_Nonnull ctx);
     char *_Nullable (*_Nonnull environment_value)(void *_Nonnull ctx, const char *_Nonnull key);
 } pp_tun_ctrl_delegate;

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -298,11 +298,15 @@ JNIEXPORT void JNICALL
 Java_io_partout_vpn_JNITunnelController_onNativeReachabilityUpdate(JNIEnv *env,
                                                                    jobject thiz,
                                                                    jlong delegate,
-                                                                   jboolean is_reachable) {
+                                                                   jlong net_handle) {
     (void)thiz;
     pp_tun_ctrl_delegate *ctrl_delegate = (pp_tun_ctrl_delegate *)(intptr_t)delegate;
     if (!ctrl_delegate || !ctrl_delegate->ctx) return;
-    ctrl_delegate->on_reachable(ctrl_delegate->ctx, is_reachable);
+    const pp_tun_ctrl_reachability reachability = {
+        .reachable = net_handle != -1,
+        .network_handle = net_handle
+    };
+    ctrl_delegate->on_reachable(ctrl_delegate->ctx, &reachability);
 }
 
 JNIEXPORT void JNICALL

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -115,14 +115,17 @@ class PartoutVpnServiceRuntime(
         try {
             val newController = JNITunnelController(jniLogTag, service, serviceScope, this)
             engine.start(intent, newController, profileJSON)
-            controller = newController
+            // Does not throw from now
             Log.i(logTag, "Started VPN daemon")
+            controller = newController
+            newController.startObserving()
         } catch (e: Exception) {
+            snapshotEmitter.shutdown()
+            controller = null
+            isRunning = false
             e.throwIfCancellation()
             Log.e(logTag, "Unable to start VPN daemon", e)
             stopService()
-            snapshotEmitter.shutdown()
-            isRunning = false
             return@launchCommand
         }
     }

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -113,7 +113,7 @@ class PartoutVpnServiceRuntime(
         isRunning = true
         Log.i(logTag, "Starting VPN daemon")
         try {
-            val newController = JNITunnelController(jniLogTag, service, serviceScope, this)
+            val newController = JNITunnelController(jniLogTag, service, this)
             engine.start(intent, newController, profileJSON)
             // Does not throw from now
             Log.i(logTag, "Started VPN daemon")

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -4,6 +4,7 @@
 
 package io.partout.vpn
 
+import android.net.Network
 import android.net.VpnService
 import android.os.ParcelFileDescriptor
 import android.util.Log
@@ -30,7 +31,7 @@ interface TunnelController {
     fun cancelTunnel(errorCode: String?)
 
     // Kotlin -> JNI
-    fun onReachabilityUpdate(isReachable: Boolean)
+    fun onReachabilityUpdate(network: Network?)
     fun onBetterPathUpdate()
     fun getEnvironmentValue(key: String): String?
 }
@@ -169,9 +170,10 @@ class JNITunnelController(
         return@synchronized
     }
 
-    override fun onReachabilityUpdate(isReachable: Boolean) = synchronized(lock) {
-        Log.e(logTag, ">>> Network: onReachabilityUpdate($isReachable)")
-        onNativeReachabilityUpdate(nativeDelegate, isReachable)
+    override fun onReachabilityUpdate(network: Network?) = synchronized(lock) {
+        val networkHandle = network?.networkHandle
+        Log.e(logTag, ">>> Network: onReachabilityUpdate($networkHandle)")
+        onNativeReachabilityUpdate(nativeDelegate, networkHandle ?: -1)
     }
 
     override fun onBetterPathUpdate() = synchronized(lock) {
@@ -184,7 +186,7 @@ class JNITunnelController(
         return getNativeEnvironmentValue(nativeDelegate, key)
     }
 
-    private external fun onNativeReachabilityUpdate(delegate: Long, isReachable: Boolean)
+    private external fun onNativeReachabilityUpdate(delegate: Long, networkHandle: Long)
     private external fun onNativeBetterPathUpdate(delegate: Long)
     private external fun getNativeEnvironmentValue(delegate: Long, key: String): String?
 

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -14,7 +14,6 @@ import io.partout.models.TaggedModuleIP
 import io.partout.models.TaggedModuleOnDemand
 import io.partout.models.TunnelRemoteInfoWrapper
 import io.partout.models.TunnelSnapshot
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
@@ -45,7 +44,6 @@ interface TunnelControllerDelegate {
 class JNITunnelController(
     private val logTag: String,
     private val service: VpnService,
-    private val scope: CoroutineScope,
     private val delegate: TunnelControllerDelegate
 ) : TunnelController {
     // All accesses must be synchronized against the lock

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.Json
 // Must match signatures in tun_android.c
 interface TunnelController {
     // Runtime
+    fun startObserving()
     fun stopObserving()
 
     // JNI -> Jotlin
@@ -44,7 +45,7 @@ interface TunnelControllerDelegate {
 class JNITunnelController(
     private val logTag: String,
     private val service: VpnService,
-    scope: CoroutineScope,
+    private val scope: CoroutineScope,
     private val delegate: TunnelControllerDelegate
 ) : TunnelController {
     // All accesses must be synchronized against the lock
@@ -54,6 +55,9 @@ class JNITunnelController(
     private var nativeDelegate: Long = 0
     private var isNativeCancelled = false
     private var tunDescriptor: ParcelFileDescriptor? = null
+
+    override fun startObserving() {
+    }
 
     override fun stopObserving() {
     }


### PR DESCRIPTION
Rather than a simple boolean, collect more information about reachability according to the native platform. For example, Android should carry a handle to the current network for non-VPN sockets like DNS.

Also, start NativeTunnelController as initially reachable.