### PR TITLE
Android: Use proper NDK DNS resolver

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -52,7 +52,7 @@ public final class NativeTunnelController: TunnelController, Sendable {
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: .fromSelf(self),
-            on_reachable: { ctx, reachability in
+            on_reachability: { ctx, reachability in
                 let this = ctx.toSelf
                 this.onReachability(reachability)
             },

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -168,13 +168,17 @@ public final class NativeTunnelController: TunnelController, Sendable {
 
 extension NativeTunnelController: DNSResolver {
     public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
-        let localReachability: ReachabilityInfo?
+        let fallbackReachability: ReachabilityInfo?
 #if os(Android)
-        localReachability = reachabilityHolder?.get()
+        fallbackReachability = reachabilityHolder?.get()
 #else
-        localReachability = reachability
+        fallbackReachability = reachability
 #endif
-        return try await dns.resolve(hostname, reachability: localReachability, timeout: timeout)
+        return try await dns.resolve(
+            hostname,
+            reachability: reachability ?? fallbackReachability,
+            timeout: timeout
+        )
     }
 }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -51,9 +51,9 @@ public final class NativeTunnelController: TunnelController, Sendable {
             strategy: {
                 POSIXDNSStrategy(hostname: $0)
             },
-            networkHandle: { [weak reachabilityHolder] in
+            reachability: { [weak reachabilityHolder] in
 #if os(Android)
-                reachabilityHolder?.get()?.network_handle
+                reachabilityHolder?.get()
 #else
                 nil
 #endif
@@ -225,9 +225,19 @@ private final class ReachabilityHolder: @unchecked Sendable {
     private let lock = SemaphoreMutex()
     private var reachability: pp_tun_ctrl_reachability?
 
-    nonisolated func get() -> pp_tun_ctrl_reachability? {
+    nonisolated func get() -> ReachabilityInfo? {
         lock.with {
-            reachability
+            guard let reachability else { return nil }
+#if os(Android)
+            return ReachabilityInfo(
+                isReachable: reachability.reachable,
+                networkHandle: reachability.network_handle
+            )
+#else
+            return ReachabilityInfo(
+                isReachable: reachability.reachable
+            )
+#endif
         }
     }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -42,23 +42,13 @@ public final class NativeTunnelController: TunnelController, Sendable {
         self.environment = environment
         self.maxReadLength = maxReadLength
         onReachableStream = CurrentValueStream(true)
-        let reachabilityHolder = ReachabilityHolder()
-        self.reachabilityHolder = reachabilityHolder
+        reachabilityHolder = ReachabilityHolder()
         betterPathProxy = BetterPathProxy()
 
         // Native resolver requires network handle on Android
-        dns = SimpleDNSResolver(
-            strategy: {
-                POSIXDNSStrategy(hostname: $0)
-            },
-            reachability: { [weak reachabilityHolder] in
-#if os(Android)
-                reachabilityHolder?.get()
-#else
-                nil
-#endif
-            }
-        )
+        dns = SimpleDNSResolver {
+            POSIXDNSStrategy(hostname: $0)
+        }
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: .fromSelf(self),
@@ -177,8 +167,14 @@ public final class NativeTunnelController: TunnelController, Sendable {
 // MARK: - DNS
 
 extension NativeTunnelController: DNSResolver {
-    public func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord] {
-        try await dns.resolve(hostname, timeout: timeout)
+    public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
+        let localReachability: ReachabilityInfo?
+#if os(Android)
+        localReachability = reachabilityHolder?.get()
+#else
+        localReachability = reachability
+#endif
+        return try await dns.resolve(hostname, reachability: localReachability, timeout: timeout)
     }
 }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -170,7 +170,7 @@ extension NativeTunnelController: DNSResolver {
     public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
         let fallbackReachability: ReachabilityInfo?
 #if os(Android)
-        fallbackReachability = reachabilityHolder?.get()
+        fallbackReachability = reachabilityHolder.get()
 #else
         fallbackReachability = reachability
 #endif

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -5,7 +5,7 @@
 internal import _PartoutCore_C
 
 /// A controller that operates on a virtual tun interface.
-public final class NativeTunnelController: TunnelController, @unchecked Sendable {
+public final class NativeTunnelController: TunnelController, Sendable {
     private let ctx: PartoutLoggerContext
 
     nonisolated(unsafe)
@@ -17,9 +17,7 @@ public final class NativeTunnelController: TunnelController, @unchecked Sendable
 
     private let onReachableStream: CurrentValueStream<Bool>
 
-    private let reachabilityLock: SemaphoreMutex
-
-    private var reachability: pp_tun_ctrl_reachability?
+    private let reachabilityHolder: ReachabilityHolder
 
     private let betterPathProxy: BetterPathProxy
 
@@ -44,11 +42,23 @@ public final class NativeTunnelController: TunnelController, @unchecked Sendable
         self.environment = environment
         self.maxReadLength = maxReadLength
         onReachableStream = CurrentValueStream(true)
-        reachabilityLock = SemaphoreMutex()
+        let reachabilityHolder = ReachabilityHolder()
+        self.reachabilityHolder = reachabilityHolder
         betterPathProxy = BetterPathProxy()
-        dns = SimpleDNSResolver {
-            POSIXDNSStrategy(hostname: $0)
-        }
+
+        // Native resolver requires network handle on Android
+        dns = SimpleDNSResolver(
+            strategy: {
+                POSIXDNSStrategy(hostname: $0)
+            },
+            networkHandle: { [weak reachabilityHolder] in
+#if os(Android)
+                reachabilityHolder?.get()?.network_handle
+#else
+                nil
+#endif
+            }
+        )
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: .fromSelf(self),
@@ -202,14 +212,29 @@ private extension NativeTunnelController {
 #else
         pp_log(ctx, .core, .info, "Network reachability changed: reachable=\(isReachable)")
 #endif
-        reachabilityLock.with {
-            self.reachability = reachability.pointee
-        }
+        reachabilityHolder.set(reachability)
         onReachableStream.send(isReachable)
     }
 
     func onBetterPath() {
         betterPathProxy.onBetterPath()
+    }
+}
+
+private final class ReachabilityHolder: @unchecked Sendable {
+    private let lock = SemaphoreMutex()
+    private var reachability: pp_tun_ctrl_reachability?
+
+    nonisolated func get() -> pp_tun_ctrl_reachability? {
+        lock.with {
+            reachability
+        }
+    }
+
+    nonisolated func set(_ new: UnsafePointer<pp_tun_ctrl_reachability>) {
+        lock.with {
+            reachability = new.pointee
+        }
     }
 }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -5,7 +5,7 @@
 internal import _PartoutCore_C
 
 /// A controller that operates on a virtual tun interface.
-public final class NativeTunnelController: TunnelController {
+public final class NativeTunnelController: TunnelController, @unchecked Sendable {
     private let ctx: PartoutLoggerContext
 
     nonisolated(unsafe)
@@ -22,6 +22,8 @@ public final class NativeTunnelController: TunnelController {
     private var reachability: pp_tun_ctrl_reachability?
 
     private let betterPathProxy: BetterPathProxy
+
+    private let dns: DNSResolver
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -44,6 +46,9 @@ public final class NativeTunnelController: TunnelController {
         onReachableStream = CurrentValueStream(true)
         reachabilityLock = SemaphoreMutex()
         betterPathProxy = BetterPathProxy()
+        dns = SimpleDNSResolver {
+            POSIXDNSStrategy(hostname: $0)
+        }
 
         var delegate = pp_tun_ctrl_delegate(
             ctx: .fromSelf(self),
@@ -156,6 +161,14 @@ public final class NativeTunnelController: TunnelController {
         error.partoutErrorCode.rawValue.withCString {
             pp_tun_ctrl_cancel_tunnel(ref, $0)
         }
+    }
+}
+
+// MARK: - DNS
+
+extension NativeTunnelController: DNSResolver {
+    public func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord] {
+        try await dns.resolve(hostname, timeout: timeout)
     }
 }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -41,7 +41,7 @@ public final class NativeTunnelController: TunnelController, Sendable {
 #endif
         self.environment = environment
         self.maxReadLength = maxReadLength
-        onReachableStream = CurrentValueStream(true)
+        onReachableStream = CurrentValueStream(false)
         reachabilityHolder = ReachabilityHolder()
         betterPathProxy = BetterPathProxy()
 

--- a/Sources/PartoutCore/Connection/DNSResolver.swift
+++ b/Sources/PartoutCore/Connection/DNSResolver.swift
@@ -24,7 +24,18 @@ public protocol DNSResolver: AnyObject, Sendable {
      Resolves a hostname asynchronously.
 
      - Parameter hostname: The hostname to resolve.
+     - Parameter reachability: The optional ``ReachabilityInfo``.
      - Parameter timeout: The timeout in milliseconds.
      */
-    func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord]
+    func resolve(
+        _ hostname: String,
+        reachability: ReachabilityInfo?,
+        timeout: Int
+    ) async throws -> [DNSRecord]
+}
+
+extension DNSResolver {
+    public func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord] {
+        try await resolve(hostname, reachability: nil, timeout: timeout)
+    }
 }

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -16,14 +16,14 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
     public func startResolution() async throws {
     }
 
-    public func waitForResolution(networkHandle: UInt64?) async throws -> [DNSRecord] {
+    public func waitForResolution(reachability: ReachabilityInfo?) async throws -> [DNSRecord] {
         let records: [DNSRecord]?
         if let task {
             records = try await task.value
         } else {
             let hostname = self.hostname
             let newTask = Task.detached { @Sendable in
-                try Self.resolveAndBlock(hostname: hostname, networkHandle: networkHandle)
+                try Self.resolveAndBlock(hostname: hostname, reachability: reachability)
             }
             task = newTask
             records = try await newTask.value
@@ -41,9 +41,9 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
 }
 
 private extension POSIXDNSStrategy {
-    static func resolveAndBlock(hostname: String, networkHandle: UInt64?) throws -> [DNSRecord]? {
+    static func resolveAndBlock(hostname: String, reachability: ReachabilityInfo?) throws -> [DNSRecord]? {
 #if os(Android)
-        guard let networkHandle else {
+        guard let networkHandle = reachability?.networkHandle else {
             throw PartoutError(.networkUnreachable)
         }
         pp_log_g(.core, .info, "resolveAndBlock() with Android network handle: \(networkHandle)")

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -22,8 +22,9 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
             records = try await task.value
         } else {
             let hostname = self.hostname
+            let reachabilityCopy = reachability
             let newTask = Task.detached { @Sendable in
-                try Self.resolveAndBlock(hostname: hostname, reachability: reachability)
+                try Self.resolveAndBlock(hostname: hostname, reachability: reachabilityCopy)
             }
             task = newTask
             records = try await newTask.value

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -7,7 +7,6 @@ internal import _PartoutCore_C
 /// Implementation of ``SimpleDNSStrategy`` with the POSIX C library.
 public actor POSIXDNSStrategy: SimpleDNSStrategy {
     private let hostname: String
-
     private var task: Task<[DNSRecord]?, Error>?
 
     public init(hostname: String) {
@@ -17,14 +16,14 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
     public func startResolution() async throws {
     }
 
-    public func waitForResolution() async throws -> [DNSRecord] {
+    public func waitForResolution(networkHandle: UInt64?) async throws -> [DNSRecord] {
         let records: [DNSRecord]?
         if let task {
             records = try await task.value
         } else {
             let hostname = self.hostname
             let newTask = Task.detached { @Sendable in
-                try Self.resolveAndBlock(hostname: hostname)
+                try Self.resolveAndBlock(hostname: hostname, networkHandle: networkHandle)
             }
             task = newTask
             records = try await newTask.value
@@ -42,7 +41,13 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
 }
 
 private extension POSIXDNSStrategy {
-    static func resolveAndBlock(hostname: String) throws -> [DNSRecord]? {
+    static func resolveAndBlock(hostname: String, networkHandle: UInt64?) throws -> [DNSRecord]? {
+#if os(Android)
+        guard let networkHandle else {
+            throw PartoutError(.networkUnreachable)
+        }
+        pp_log_g(.core, .info, "resolveAndBlock() with Android network handle: \(networkHandle)")
+#endif
         var hints = addrinfo()
 #if canImport(Darwin)
         // We set this to ALL so that we get v4 addresses even on DNS64 networks
@@ -54,7 +59,11 @@ private extension POSIXDNSStrategy {
 //        hints.ai_socktype = SOCK_STREAM SOCK_DGRAM
         var infoPointer: UnsafeMutablePointer<addrinfo>?
         let result = hostname.withCString {
+#if os(Android)
+            android_getaddrinfofornetwork(networkHandle, $0, nil, &hints, &infoPointer)
+#else
             getaddrinfo($0, nil, &hints, &infoPointer)
+#endif
         }
         guard result == 0 else {
             switch result {

--- a/Sources/PartoutCore/Connection/ReachabilityInfo.swift
+++ b/Sources/PartoutCore/Connection/ReachabilityInfo.swift
@@ -5,11 +5,9 @@
 /// Platform-specific metadata about network reachability.
 public struct ReachabilityInfo: Sendable {
     public let isReachable: Bool
-#if os(Android)
-    public let networkHandle: UInt64?
-#endif
 
 #if os(Android)
+    public let networkHandle: UInt64?
     public init(isReachable: Bool, networkHandle: UInt64?) {
         self.isReachable = isReachable
         self.networkHandle = networkHandle

--- a/Sources/PartoutCore/Connection/ReachabilityInfo.swift
+++ b/Sources/PartoutCore/Connection/ReachabilityInfo.swift
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+/// Platform-specific metadata about network reachability.
+public struct ReachabilityInfo: Sendable {
+    public let isReachable: Bool
+#if os(Android)
+    public let networkHandle: UInt64?
+#endif
+
+#if os(Android)
+    public init(isReachable: Bool, networkHandle: UInt64?) {
+        self.isReachable = isReachable
+        self.networkHandle = networkHandle
+    }
+#else
+    public init(isReachable: Bool) {
+        self.isReachable = isReachable
+    }
+#endif
+}

--- a/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
+++ b/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
@@ -6,30 +6,30 @@
 public protocol SimpleDNSStrategy: Sendable {
     func startResolution() async throws
 
-    func waitForResolution(networkHandle: UInt64?) async throws -> [DNSRecord]
+    func waitForResolution(reachability: ReachabilityInfo?) async throws -> [DNSRecord]
 
     func cancelResolution() async
 }
 
 /// ``DNSResolver`` with support for timeout cancellation.
 public actor SimpleDNSResolver: DNSResolver {
-    public typealias NetworkHandleBlock = () -> UInt64?
+    public typealias ReachabilityBlock = () -> ReachabilityInfo?
 
     private let strategy: (String) -> SimpleDNSStrategy
-    private let networkHandle: NetworkHandleBlock
+    private let reachability: ReachabilityBlock
 
     private var pendingResolutions: [String: Task<[DNSRecord], Error>]
 
     public init(strategy: @escaping (String) -> SimpleDNSStrategy) {
-        self.init(strategy: strategy, networkHandle: { nil })
+        self.init(strategy: strategy, reachability: { nil })
     }
 
     public init(
         strategy: @escaping (String) -> SimpleDNSStrategy,
-        networkHandle: @escaping NetworkHandleBlock
+        reachability: @escaping ReachabilityBlock
     ) {
         self.strategy = strategy
-        self.networkHandle = networkHandle
+        self.reachability = reachability
         pendingResolutions = [:]
     }
 
@@ -42,7 +42,7 @@ public actor SimpleDNSResolver: DNSResolver {
             try await newStrategy.startResolution()
             return try await Self.waitForResolution(
                 newStrategy,
-                networkHandle: networkHandle(),
+                reachability: reachability(),
                 timeout: timeout
             )
         }
@@ -57,7 +57,7 @@ public actor SimpleDNSResolver: DNSResolver {
 private extension SimpleDNSResolver {
     nonisolated static func waitForResolution(
         _ strategy: SimpleDNSStrategy,
-        networkHandle: UInt64?,
+        reachability: ReachabilityInfo?,
         timeout: Int
     ) async throws -> [DNSRecord] {
         try await withCheckedThrowingContinuation { continuation in
@@ -67,7 +67,9 @@ private extension SimpleDNSResolver {
             // child before returning the timeout.
             let waitTask = Task {
                 do {
-                    let records = try await strategy.waitForResolution(networkHandle: networkHandle)
+                    let records = try await strategy.waitForResolution(
+                        reachability: reachability
+                    )
                     await state.resume(with: .success(records))
                 } catch {
                     await state.resume(with: .failure(error))

--- a/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
+++ b/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
@@ -13,27 +13,16 @@ public protocol SimpleDNSStrategy: Sendable {
 
 /// ``DNSResolver`` with support for timeout cancellation.
 public actor SimpleDNSResolver: DNSResolver {
-    public typealias ReachabilityBlock = () -> ReachabilityInfo?
-
     private let strategy: (String) -> SimpleDNSStrategy
-    private let reachability: ReachabilityBlock
 
     private var pendingResolutions: [String: Task<[DNSRecord], Error>]
 
     public init(strategy: @escaping (String) -> SimpleDNSStrategy) {
-        self.init(strategy: strategy, reachability: { nil })
-    }
-
-    public init(
-        strategy: @escaping (String) -> SimpleDNSStrategy,
-        reachability: @escaping ReachabilityBlock
-    ) {
         self.strategy = strategy
-        self.reachability = reachability
         pendingResolutions = [:]
     }
 
-    public func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord] {
+    public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
         if let pendingResolutionTask = pendingResolutions[hostname] {
             return try await pendingResolutionTask.value
         }
@@ -42,7 +31,7 @@ public actor SimpleDNSResolver: DNSResolver {
             try await newStrategy.startResolution()
             return try await Self.waitForResolution(
                 newStrategy,
-                reachability: reachability(),
+                reachability: reachability,
                 timeout: timeout
             )
         }

--- a/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
+++ b/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
@@ -6,19 +6,30 @@
 public protocol SimpleDNSStrategy: Sendable {
     func startResolution() async throws
 
-    func waitForResolution() async throws -> [DNSRecord]
+    func waitForResolution(networkHandle: UInt64?) async throws -> [DNSRecord]
 
     func cancelResolution() async
 }
 
 /// ``DNSResolver`` with support for timeout cancellation.
 public actor SimpleDNSResolver: DNSResolver {
+    public typealias NetworkHandleBlock = () -> UInt64?
+
     private let strategy: (String) -> SimpleDNSStrategy
+    private let networkHandle: NetworkHandleBlock
 
     private var pendingResolutions: [String: Task<[DNSRecord], Error>]
 
     public init(strategy: @escaping (String) -> SimpleDNSStrategy) {
+        self.init(strategy: strategy, networkHandle: { nil })
+    }
+
+    public init(
+        strategy: @escaping (String) -> SimpleDNSStrategy,
+        networkHandle: @escaping NetworkHandleBlock
+    ) {
         self.strategy = strategy
+        self.networkHandle = networkHandle
         pendingResolutions = [:]
     }
 
@@ -29,7 +40,11 @@ public actor SimpleDNSResolver: DNSResolver {
         let newStrategy = strategy(hostname)
         let resolutionTask = Task {
             try await newStrategy.startResolution()
-            return try await Self.waitForResolution(newStrategy, timeout: timeout)
+            return try await Self.waitForResolution(
+                newStrategy,
+                networkHandle: networkHandle(),
+                timeout: timeout
+            )
         }
         pendingResolutions[hostname] = resolutionTask
         defer {
@@ -40,7 +55,11 @@ public actor SimpleDNSResolver: DNSResolver {
 }
 
 private extension SimpleDNSResolver {
-    nonisolated static func waitForResolution(_ strategy: SimpleDNSStrategy, timeout: Int) async throws -> [DNSRecord] {
+    nonisolated static func waitForResolution(
+        _ strategy: SimpleDNSStrategy,
+        networkHandle: UInt64?,
+        timeout: Int
+    ) async throws -> [DNSRecord] {
         try await withCheckedThrowingContinuation { continuation in
             let state = DNSResolutionState(continuation: continuation)
             // Keep this unstructured. Blocking DNS resolution may ignore
@@ -48,7 +67,7 @@ private extension SimpleDNSResolver {
             // child before returning the timeout.
             let waitTask = Task {
                 do {
-                    let records = try await strategy.waitForResolution()
+                    let records = try await strategy.waitForResolution(networkHandle: networkHandle)
                     await state.resume(with: .success(records))
                 } catch {
                     await state.resume(with: .failure(error))

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -42,6 +42,7 @@ Given the main app and the daemon:
 - ``DNSRecord``
 - ``DNSResolver``
 - ``POSIXDNSStrategy``
+- ``ReachabilityInfo``
 - ``SimpleDNSResolver``
 - ``SimpleDNSStrategy``
 

--- a/Sources/PartoutCore/Testing/MockDNSResolver.swift
+++ b/Sources/PartoutCore/Testing/MockDNSResolver.swift
@@ -10,7 +10,7 @@ public final class MockDNSResolver: DNSResolver, @unchecked Sendable {
     public init() {
     }
 
-    public func resolve(_ hostname: String, timeout: Int) throws -> [DNSRecord] {
+    public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
         if let error {
             throw error
         }

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -13,6 +13,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if PARTOUT_ANDROID
+#include <android/multinetwork.h>
+#endif
+
 /* Logging counterpart of Swift pp_log. */
 
 typedef enum {

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -33,8 +33,8 @@ typedef struct {
 } pp_tun_ctrl_reachability;
 typedef struct {
     void *_Nullable ctx;
-    void (*_Nonnull on_reachable)(void *_Nonnull ctx,
-                                  const pp_tun_ctrl_reachability *_Nonnull reachability);
+    void (*_Nonnull on_reachability)(void *_Nonnull ctx,
+                                     const pp_tun_ctrl_reachability *_Nonnull reachability);
     void (*_Nonnull on_better_path)(void *_Nonnull ctx);
     char *_Nullable (*_Nonnull environment_value)(void *_Nonnull ctx, const char *_Nonnull key);
 } pp_tun_ctrl_delegate;

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -306,7 +306,7 @@ Java_io_partout_vpn_JNITunnelController_onNativeReachabilityUpdate(JNIEnv *env,
         .reachable = net_handle != -1,
         .network_handle = net_handle
     };
-    ctrl_delegate->on_reachable(ctrl_delegate->ctx, &reachability);
+    ctrl_delegate->on_reachability(ctrl_delegate->ctx, &reachability);
 }
 
 JNIEXPORT void JNICALL

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
@@ -22,7 +22,7 @@ extension _OpenVPNConnectionV2 {
 
         // Hardcode portable implementations
         let prng = PlatformPRNG()
-        let dns = SimpleDNSResolver {
+        let dns = parameters.controller as? DNSResolver ?? SimpleDNSResolver {
             POSIXDNSStrategy(hostname: $0)
         }
         let sessionFactory = {

--- a/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
@@ -46,10 +46,11 @@ extension WireGuard.Configuration {
     }
 
     func resolvePeers(
+        dns: DNSResolver?,
         timeout: Int,
         logHandler: @escaping WireGuardAdapter.LogHandler
     ) async throws -> [Endpoint: Endpoint] {
-        let resolver = SimpleDNSResolver {
+        let resolver = dns ?? SimpleDNSResolver {
             POSIXDNSStrategy(hostname: $0)
         }
         return try await resolvePeers(

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -15,13 +15,21 @@ final class TunnelRemoteInfoGenerator: Sendable {
 
     private let tunnelConfiguration: WireGuard.Configuration
 
+    private let dns: DNSResolver?
+
     private let dnsTimeout: Int
 
     private let resolvedEndpoints: ResolvedEndpointsCache
 
-    init(_ ctx: PartoutLoggerContext, tunnelConfiguration: WireGuard.Configuration, dnsTimeout: Int) {
+    init(
+        _ ctx: PartoutLoggerContext,
+        tunnelConfiguration: WireGuard.Configuration,
+        dns: DNSResolver?,
+        dnsTimeout: Int
+    ) {
         self.ctx = ctx
         self.tunnelConfiguration = tunnelConfiguration
+        self.dns = dns
         self.dnsTimeout = dnsTimeout
         resolvedEndpoints = ResolvedEndpointsCache()
     }
@@ -36,7 +44,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
 
         let resolutionMap: [Endpoint: Endpoint]
         do {
-            resolutionMap = try await resolvePeers(logHandler: logHandler)
+            resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
         } catch {
             logHandler(.error, "Unable to resolve peer endpoints: \(error.localizedDescription)")
             return wgSettings
@@ -83,7 +91,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
             wgSettings.append("replace_peers=true\n")
         }
 
-        let resolutionMap = try await resolvePeers(logHandler: logHandler)
+        let resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
 
         for peer in tunnelConfiguration.peers {
             let publicKey = try peer.publicKey.rawValue.hexStringFromBase64()
@@ -176,11 +184,12 @@ final class TunnelRemoteInfoGenerator: Sendable {
 }
 
 private extension TunnelRemoteInfoGenerator {
-    func resolvePeers(logHandler: @escaping WireGuardAdapter.LogHandler) async throws -> [Endpoint: Endpoint] {
+    func resolvePeers(dns: DNSResolver?, logHandler: @escaping WireGuardAdapter.LogHandler) async throws -> [Endpoint: Endpoint] {
         if let resolutionMap = await resolvedEndpoints.value {
             return resolutionMap
         }
         let resolutionMap = try await tunnelConfiguration.resolvePeers(
+            dns: dns,
             timeout: dnsTimeout,
             logHandler: logHandler
         )

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -37,6 +37,8 @@ actor WireGuardAdapter {
     /// The ID of the original ``WireGuardModule``.
     private let moduleId: UniqueID
 
+    private let dns: DNSResolver?
+
     private let dnsTimeout: Int
 
     /// Backend implementation.
@@ -76,6 +78,7 @@ actor WireGuardAdapter {
         _ ctx: PartoutLoggerContext,
         with delegate: WireGuardAdapterDelegate,
         moduleId: UniqueID,
+        dns: DNSResolver?,
         dnsTimeout: Int,
         reachability: ReachabilityObserver,
         logHandler: @escaping LogHandler
@@ -83,6 +86,7 @@ actor WireGuardAdapter {
         self.ctx = ctx
         self.delegate = delegate
         self.moduleId = moduleId
+        self.dns = dns
         self.dnsTimeout = dnsTimeout
         backend = WireGuardBackend()
         self.reachability = reachability
@@ -265,6 +269,7 @@ actor WireGuardAdapter {
         TunnelRemoteInfoGenerator(
             ctx,
             tunnelConfiguration: tunnelConfiguration,
+            dns: dns,
             dnsTimeout: dnsTimeout
         )
     }

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -72,6 +72,7 @@ public actor _WireGuardConnectionV2: Connection {
             ctx,
             with: self,
             moduleId: moduleId,
+            dns: controller as? DNSResolver,
             dnsTimeout: dnsTimeout,
             reachability: reachability,
             logHandler: { [weak self] logLevel, message in

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -67,6 +67,7 @@ set(PARTOUT_SOURCES
 ./PartoutCore/Connection/NetworkInterfaceFactory.swift
 ./PartoutCore/Connection/NetworkObserver.swift
 ./PartoutCore/Connection/POSIXDNSStrategy.swift
+./PartoutCore/Connection/ReachabilityInfo.swift
 ./PartoutCore/Connection/ReachabilityObserver.swift
 ./PartoutCore/Connection/SharedTunnelEnvironment.swift
 ./PartoutCore/Connection/SimpleConnectionDaemon.swift

--- a/Tests/PartoutCoreTests/DNSResolverTests.swift
+++ b/Tests/PartoutCoreTests/DNSResolverTests.swift
@@ -7,21 +7,21 @@ import Testing
 
 struct DNSResolverTests {
     @Test
-    func givenResolver_whenResolve_thenReturnsResolvedAddress() throws {
+    func givenResolver_whenResolve_thenReturnsResolvedAddress() async throws {
         let expRecords = [DNSRecord(address: "1.2.3.4", isIPv6: false)]
 
         let sut = MockDNSResolver()
         sut.resolvedRecords = ["www.google.com": expRecords]
-        let records = try sut.resolve("www.google.com", timeout: 1000)
+        let records = try await sut.resolve("www.google.com", timeout: 1000)
         #expect(records == expRecords)
     }
 
     @Test
-    func givenBrokenResolver_whenResolve_thenFails() throws {
+    func givenBrokenResolver_whenResolve_thenFails() async throws {
         let sut = MockDNSResolver()
         sut.error = PartoutError(.dnsFailure)
         do {
-            _ = try sut.resolve("www.google.com", timeout: 1000)
+            _ = try await sut.resolve("www.google.com", timeout: 1000)
         } catch let error as PartoutError {
             #expect(error.code == .dnsFailure)
         } catch {
@@ -30,11 +30,11 @@ struct DNSResolverTests {
     }
 
     @Test
-    func givenSlowResolver_whenResolve_thenFailsWithTimeout() throws {
+    func givenSlowResolver_whenResolve_thenFailsWithTimeout() async throws {
         let sut = MockDNSResolver()
         sut.error = PartoutError(.timeout)
         do {
-            _ = try sut.resolve("www.google.com", timeout: 1000)
+            _ = try await sut.resolve("www.google.com", timeout: 1000)
         } catch let error as PartoutError {
             #expect(error.code == .timeout)
         } catch {

--- a/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
+++ b/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
@@ -74,7 +74,7 @@ private actor MockStrategy: SimpleDNSStrategy {
         }
     }
 
-    func waitForResolution() async throws -> [DNSRecord] {
+    func waitForResolution(reachability: ReachabilityInfo?) async throws -> [DNSRecord] {
         print("waitForResolution")
         let result = try await resolutionTask?.value
         print("endResolution")
@@ -91,7 +91,7 @@ private actor CancellationIgnoringStrategy: SimpleDNSStrategy {
     func startResolution() {
     }
 
-    func waitForResolution() async throws -> [DNSRecord] {
+    func waitForResolution(reachability: ReachabilityInfo?) async throws -> [DNSRecord] {
         try await Task.sleep(milliseconds: 10_000)
         return []
     }

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -204,7 +204,7 @@ private actor RecordingDNSResolver: DNSResolver {
         resolvedRecords[hostname] = records
     }
 
-    func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord] {
+    func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
         hostnames.append(hostname)
         return resolvedRecords[hostname] ?? []
     }

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -103,6 +103,7 @@ struct TunnelRemoteInfoGeneratorTests {
         let sut = TunnelRemoteInfoGenerator(
             .global,
             tunnelConfiguration: configuration,
+            dns: nil,
             dnsTimeout: 1000
         )
         let logs = LogCollector()
@@ -141,6 +142,7 @@ struct TunnelRemoteInfoGeneratorTests {
         let sut = TunnelRemoteInfoGenerator(
             .global,
             tunnelConfiguration: configuration,
+            dns: nil,
             dnsTimeout: 1
         )
 
@@ -168,6 +170,7 @@ struct TunnelRemoteInfoGeneratorTests {
         let sut = TunnelRemoteInfoGenerator(
             .global,
             tunnelConfiguration: configuration,
+            dns: nil,
             dnsTimeout: 1
         )
         let info = sut.generateRemoteInfo(moduleId: UniqueID())

--- a/toolchains/android.toolchain.cmake
+++ b/toolchains/android.toolchain.cmake
@@ -93,6 +93,7 @@ set(CMAKE_Swift_FLAGS "\
     -l_FoundationCollections \
     -l_FoundationCShims \
     -lswiftSynchronization \
+    -landroid \
     -lc++_shared \
     -llog \
     -lm"


### PR DESCRIPTION
getaddrinfo() is not the correct way to use DNS on Android, because it could bind to the VPN interface rather than the underlying network. The NDK provides android_getaddrinfofornetwork() instead, whose only additional requirement is the network handle collected in #429, and possibly of a non-VPN network.

This is how we route DNS requests through NativeTunnelController:

- Change the DNSResolver contract to accept an optional ReachabilityInfo parameter, to e.g., receive the network handle on Android
- Make NativeTunnelController a DNSResolver by providing the native reachability info itself
- In SimpleConnectionDaemon, try to use the TunnelController as the DNSResolver
- Accept an optional custom DNSResolver in OpenVPN/WireGuard connections, i.e., the daemon TunnelController