### PR TITLE
WireGuard: Reconfigure sockets after bump in V2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let envDocs = env["PP_BUILD_DOCS"] == "1"
 let areas = Area.allCases
 let cryptoMode: CryptoMode? = .openSSL
 let openSSLVersion: Version = "3.6.300" // 3.6.2
-let wgGoVersion: Version = "0.0.2025063103"
+let wgGoVersion: Version = "0.0.20260530"
 let cmakeOutput = envCMakeOutput ?? "bin/windows-arm64"
 let useFoundationCompatibility: FoundationCompatibility = .off
 // let useFoundationCompatibility: FoundationCompatibility = OS.current != .apple ? .on : .off
@@ -252,7 +252,7 @@ if areas.contains(.wireGuard) {
     case .apple:
         // Require static wg-go backend
         package.dependencies.append(
-            .package(url: "https://github.com/partout-io/wg-go-apple", from: wgGoVersion)
+            .package(url: "https://github.com/partout-io/wg-go-apple", exact: wgGoVersion)
         )
         package.targets.append(
             .target(

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
@@ -54,7 +54,11 @@ final class WireGuardBackend: @unchecked Sendable {
         String(unsafeCString: pp_wg_get_config(handle))
     }
 
-    func bumpSockets(_ handle: Int32) async {
+    func bumpSockets(_ handle: Int32) {
+        pp_wg_bump_sockets(handle)
+    }
+
+    func bumpSocketsAsync(_ handle: Int32) async {
         await withCheckedContinuation { continuation in
             pp_wg_bump_sockets(handle)
             continuation.resume()

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
@@ -54,8 +54,11 @@ final class WireGuardBackend: @unchecked Sendable {
         String(unsafeCString: pp_wg_get_config(handle))
     }
 
-    func bumpSockets(_ handle: Int32) {
-        pp_wg_bump_sockets(handle)
+    func bumpSockets(_ handle: Int32) async {
+        await withCheckedContinuation { continuation in
+            pp_wg_bump_sockets(handle)
+            continuation.resume()
+        }
     }
 
     func disableSomeRoamingForBrokenMobileSemantics(_ handle: Int32) {

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
@@ -55,12 +55,12 @@ final class WireGuardBackend: @unchecked Sendable {
     }
 
     func bumpSockets(_ handle: Int32) {
-        pp_wg_bump_sockets(handle)
+        pp_wg_bump_sockets(handle, false)
     }
 
     func bumpSocketsAsync(_ handle: Int32) async {
         await withCheckedContinuation { continuation in
-            pp_wg_bump_sockets(handle)
+            pp_wg_bump_sockets(handle, true)
             continuation.resume()
         }
     }

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
@@ -58,7 +58,7 @@ final class WireGuardBackend: @unchecked Sendable {
         pp_wg_bump_sockets(handle, false)
     }
 
-    func bumpSocketsAsync(_ handle: Int32) async {
+    func bumpSocketsAndWait(_ handle: Int32) async {
         await withCheckedContinuation { continuation in
             pp_wg_bump_sockets(handle, true)
             continuation.resume()

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -281,6 +281,7 @@ actor WireGuardAdapter {
 #if os(macOS)
         if case .started(let handle, _) = self.state {
             backend.bumpSockets(handle)
+            configureSockets(for: handle)
         }
 #else
         switch state {
@@ -291,6 +292,7 @@ actor WireGuardAdapter {
                 backend.setConfig(handle, settings: wgConfig)
                 backend.disableSomeRoamingForBrokenMobileSemantics(handle)
                 backend.bumpSockets(handle)
+                configureSockets(for: handle)
             } else {
                 logHandler(.verbose, "Connectivity offline, pausing backend.")
 

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -280,7 +280,7 @@ actor WireGuardAdapter {
 
 #if os(macOS)
         if case .started(let handle, _) = self.state {
-            await backend.bumpSocketsAsync(handle)
+            await backend.bumpSocketsAndWait(handle)
             configureSockets(for: handle)
         }
 #else
@@ -291,7 +291,7 @@ actor WireGuardAdapter {
 
                 backend.setConfig(handle, settings: wgConfig)
                 backend.disableSomeRoamingForBrokenMobileSemantics(handle)
-                await backend.bumpSocketsAsync(handle)
+                await backend.bumpSocketsAndWait(handle)
                 configureSockets(for: handle)
             } else {
                 logHandler(.verbose, "Connectivity offline, pausing backend.")

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -281,8 +281,8 @@ actor WireGuardAdapter {
 #if os(macOS)
         if case .started(let handle, _) = self.state {
             Task {
-                self.backend.bumpSockets(handle)
-                self.configureSockets(for: handle)
+                backend.bumpSockets(handle)
+                configureSockets(for: handle)
             }
         }
 #else

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -280,10 +280,8 @@ actor WireGuardAdapter {
 
 #if os(macOS)
         if case .started(let handle, _) = self.state {
-            Task {
-                backend.bumpSockets(handle)
-                configureSockets(for: handle)
-            }
+            await backend.bumpSockets(handle)
+            configureSockets(for: handle)
         }
 #else
         switch state {
@@ -293,10 +291,8 @@ actor WireGuardAdapter {
 
                 backend.setConfig(handle, settings: wgConfig)
                 backend.disableSomeRoamingForBrokenMobileSemantics(handle)
-                Task {
-                    backend.bumpSockets(handle)
-                    configureSockets(for: handle)
-                }
+                await backend.bumpSockets(handle)
+                configureSockets(for: handle)
             } else {
                 logHandler(.verbose, "Connectivity offline, pausing backend.")
 

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -280,8 +280,10 @@ actor WireGuardAdapter {
 
 #if os(macOS)
         if case .started(let handle, _) = self.state {
-            backend.bumpSockets(handle)
-            configureSockets(for: handle)
+            Task {
+                self.backend.bumpSockets(handle)
+                self.configureSockets(for: handle)
+            }
         }
 #else
         switch state {
@@ -291,8 +293,10 @@ actor WireGuardAdapter {
 
                 backend.setConfig(handle, settings: wgConfig)
                 backend.disableSomeRoamingForBrokenMobileSemantics(handle)
-                backend.bumpSockets(handle)
-                configureSockets(for: handle)
+                Task {
+                    backend.bumpSockets(handle)
+                    configureSockets(for: handle)
+                }
             } else {
                 logHandler(.verbose, "Connectivity offline, pausing backend.")
 

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -280,7 +280,7 @@ actor WireGuardAdapter {
 
 #if os(macOS)
         if case .started(let handle, _) = self.state {
-            await backend.bumpSockets(handle)
+            await backend.bumpSocketsAsync(handle)
             configureSockets(for: handle)
         }
 #else
@@ -291,7 +291,7 @@ actor WireGuardAdapter {
 
                 backend.setConfig(handle, settings: wgConfig)
                 backend.disableSomeRoamingForBrokenMobileSemantics(handle)
-                await backend.bumpSockets(handle)
+                await backend.bumpSocketsAsync(handle)
                 configureSockets(for: handle)
             } else {
                 logHandler(.verbose, "Connectivity offline, pausing backend.")

--- a/Sources/PartoutWireGuardConnection_C/include/wireguard/wireguard.h
+++ b/Sources/PartoutWireGuardConnection_C/include/wireguard/wireguard.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "portable/conditionals.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 int pp_wg_init();
@@ -22,7 +23,7 @@ int pp_wg_turn_on(const char *settings, int32_t tun_fd);
 void pp_wg_turn_off(int handle);
 int64_t pp_wg_set_config(int handle, const char *settings);
 char *pp_wg_get_config(int handle);
-void pp_wg_bump_sockets(int handle);
+void pp_wg_bump_sockets(int handle, bool sync);
 void pp_wg_tweak_mobile_roaming(int handle);
 #if PARTOUT_ANDROID
 int pp_wg_get_socket_v4(int handle);

--- a/Sources/PartoutWireGuardConnection_C/wireguard.c
+++ b/Sources/PartoutWireGuardConnection_C/wireguard.c
@@ -50,8 +50,12 @@ char *pp_wg_get_config(int handle) {
     return wgGetConfig(handle);
 }
 
-void pp_wg_bump_sockets(int handle) {
-    return wgBumpSockets(handle);
+void pp_wg_bump_sockets(int handle, bool sync) {
+    if (sync) {
+        return wgBumpSocketsAndWait(handle);
+    } else {
+        return wgBumpSockets(handle);
+    }
 }
 
 void pp_wg_tweak_mobile_roaming(int handle) {

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -147,6 +147,7 @@ class JNITunnelController(
                 "Invalid Android file descriptor: $it"
             }
             val protected = service.protect(it)
+            // FIXME: Throw exception on protect() failure?
             Log.d(logTag, "protect($it) = $protected")
         }
     }

--- a/vendors/wg-go/include/wg_go.h
+++ b/vendors/wg-go/include/wg_go.h
@@ -23,5 +23,6 @@ extern void wgTurnOff(int handle);
 extern int64_t wgSetConfig(int handle, const char *settings);
 extern char *wgGetConfig(int handle);
 extern void wgBumpSockets(int handle);
+extern void wgBumpSocketsAndWait(int handle);
 extern void wgDisableSomeRoamingForBrokenMobileSemantics(int handle);
 extern const char *wgVersion();

--- a/vendors/wg-go/src/api.go
+++ b/vendors/wg-go/src/api.go
@@ -158,8 +158,8 @@ func wgBumpSockets(tunnelHandle int32) {
 	}()
 }
 
-//export wgBumpSocketsSync
-func wgBumpSocketsSync(tunnelHandle int32) {
+//export wgBumpSocketsAndWait
+func wgBumpSocketsAndWait(tunnelHandle int32) {
 	dev, ok := tunnelHandles[tunnelHandle]
 	if !ok {
 		return

--- a/vendors/wg-go/src/api.go
+++ b/vendors/wg-go/src/api.go
@@ -144,18 +144,16 @@ func wgBumpSockets(tunnelHandle int32) {
 	if !ok {
 		return
 	}
-	go func() {
-		for i := 0; i < 10; i++ {
-			err := dev.BindUpdate()
-			if err == nil {
-				dev.SendKeepalivesToPeersWithCurrentKeypair()
-				return
-			}
-			dev.Errorf("Unable to update bind, try %d: %v", i+1, err)
-			time.Sleep(time.Second / 2)
+	for i := 0; i < 10; i++ {
+		err := dev.BindUpdate()
+		if err == nil {
+			dev.SendKeepalivesToPeersWithCurrentKeypair()
+			return
 		}
-		dev.Errorf("Gave up trying to update bind; tunnel is likely dysfunctional")
-	}()
+		dev.Errorf("Unable to update bind, try %d: %v", i+1, err)
+		time.Sleep(time.Second / 2)
+	}
+	dev.Errorf("Gave up trying to update bind; tunnel is likely dysfunctional")
 }
 
 //export wgDisableSomeRoamingForBrokenMobileSemantics

--- a/vendors/wg-go/src/api.go
+++ b/vendors/wg-go/src/api.go
@@ -144,6 +144,26 @@ func wgBumpSockets(tunnelHandle int32) {
 	if !ok {
 		return
 	}
+	go func() {
+		for i := 0; i < 10; i++ {
+			err := dev.BindUpdate()
+			if err == nil {
+				dev.SendKeepalivesToPeersWithCurrentKeypair()
+				return
+			}
+			dev.Errorf("Unable to update bind, try %d: %v", i+1, err)
+			time.Sleep(time.Second / 2)
+		}
+		dev.Errorf("Gave up trying to update bind; tunnel is likely dysfunctional")
+	}()
+}
+
+//export wgBumpSocketsSync
+func wgBumpSocketsSync(tunnelHandle int32) {
+	dev, ok := tunnelHandles[tunnelHandle]
+	if !ok {
+		return
+	}
 	for i := 0; i < 10; i++ {
 		err := dev.BindUpdate()
 		if err == nil {


### PR DESCRIPTION
Add a synchronous version of `wgBumpSockets` to not return until sockets are rebound. Otherwise, the subsequent `wgGetSocket*()` in `socketDescriptors` will likely return the old socket fds. Beware that synchronous also means blocking due to the inner call to `time.Sleep`, so we retain the asynchronous behavior, but we shift it from Go to Swift so that we can `await` the bump to finish without blocking the actor.

V1 keeps the current behavior, but V2 needs this fix for Android to reinvoke `protect()` on the new sockets.