### PR TITLE
Core: Fix Tunnel tasks cancellation

### DIFF
--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -46,6 +46,13 @@ public actor Tunnel {
         observeObjects()
 #endif
     }
+
+    deinit {
+        pendingInstall?.cancel()
+        subscriptions.forEach {
+            $0.cancel()
+        }
+    }
 }
 
 // MARK: - TunnelStrategy
@@ -171,9 +178,8 @@ private extension Tunnel {
             guard let ctx = self?.ctx else { return }
             guard let stream = self?.strategy.didUpdateActiveProfiles else { return }
             for await snapshots in stream {
-                guard let self else { break }
                 guard !Task.isCancelled else { break }
-                await handleStrategySnapshots(snapshots)
+                await self?.handleStrategySnapshots(snapshots)
             }
             pp_log(ctx, .core, .debug, "Cancelled Tunnel.strategy.didUpdateActiveProfiles (observed)")
         })
@@ -181,9 +187,8 @@ private extension Tunnel {
             subscriptions.append(Task { [weak self] in
                 guard let ctx = self?.ctx else { return }
                 while true {
-                    guard let self else { break }
                     guard !Task.isCancelled else { break }
-                    await refreshSnapshotEnvironments()
+                    await self?.refreshSnapshotEnvironments()
                     try? await Task.sleep(milliseconds: refreshInterval)
                 }
                 pp_log(ctx, .core, .debug, "Cancelled Tunnel.timerSubscription")

--- a/Tests/PartoutCoreTests/TunnelTests.swift
+++ b/Tests/PartoutCoreTests/TunnelTests.swift
@@ -41,9 +41,6 @@ struct TunnelTests {
         let pending = Task {
             var emitted: [TunnelStatus] = []
             for await snapshots in stream {
-                if emitted.count == expected.count {
-                    return emitted
-                }
                 guard let status = snapshots.first?.value.status else {
                     continue
                 }
@@ -52,8 +49,14 @@ struct TunnelTests {
                     continue
                 }
                 emitted.append(status)
+                if emitted.count == expected.count {
+                    return emitted
+                }
             }
             return emitted
+        }
+        defer {
+            pending.cancel()
         }
 
         try await sut.prepare(purge: false)
@@ -78,14 +81,16 @@ struct TunnelTests {
 
         let exp = Expectation()
         let stream = sut.snapshotsStream
-        var didCall = false
-        Task {
+        let pending = Task {
             for await _ in stream {
-                if !didCall, sut.snapshots[profile.id]?.environment?.lastErrorCode != nil {
-                    didCall = true
+                if sut.snapshots[profile.id]?.environment?.lastErrorCode != nil {
                     await exp.fulfill()
+                    return
                 }
             }
+        }
+        defer {
+            pending.cancel()
         }
 
         try await sut.disconnect(from: profile.id)
@@ -114,16 +119,23 @@ struct TunnelTests {
         #expect(active.first?.key == profile.id)
 
         let expDataCount = DataCount(500, 700)
-        env.setEnvironmentValue(expDataCount, forKey: TunnelEnvironmentKeys.dataCount)
-
-        for await next in stream {
-            let dataCount = next[profile.id]?.environment?.dataCount
-            guard dataCount == expDataCount else {
-                continue
+        let exp = Expectation()
+        let pending = Task {
+            for await next in stream {
+                let dataCount = next[profile.id]?.environment?.dataCount
+                guard dataCount == expDataCount else {
+                    continue
+                }
+                await exp.fulfill()
+                return
             }
-            // Success
-            return
         }
+        defer {
+            pending.cancel()
+        }
+
+        env.setEnvironmentValue(expDataCount, forKey: TunnelEnvironmentKeys.dataCount)
+        try await exp.fulfillment(timeout: 500)
     }
 
     @Test


### PR DESCRIPTION
The test workflow hangs occasionally. This PR:

- Delays `self` retention in infinite loops
- Enforces tasks cancellation on deinit
- Fixes the way tests wait for expectations