### PR TITLE
WireGuard: Mask failed DNS endpoints in logs

### DIFF
--- a/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
+++ b/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
@@ -106,7 +106,10 @@ public final class _WireGuardConnectionV1: Connection, @unchecked Sendable {
                             continuation.resume(throwing: WireGuardConnectionError.couldNotDetermineFileDescriptor)
 
                         case .dnsResolution(let dnsErrors):
-                            let hostnamesWithDnsResolutionFailure = dnsErrors.map(\.address)
+                            let hostnamesWithDnsResolutionFailure = dnsErrors
+                                .map {
+                                    $0.address.asSensitiveAddress(self.ctx)
+                                }
                                 .joined(separator: ", ")
                             pp_log(ctx, .wireguard, .error, "DNS resolution failed for the following hostnames: \(hostnamesWithDnsResolutionFailure)")
                             continuation.resume(throwing: WireGuardConnectionError.dnsResolutionFailure)

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -175,7 +175,10 @@ private extension _WireGuardConnectionV2 {
             pp_log(ctx, .wireguard, .error, "Starting tunnel failed: could not determine file descriptor")
             return WireGuardConnectionError.couldNotDetermineFileDescriptor
         case .dnsResolution(let endpoints):
-            let hostnamesWithDnsResolutionFailure = endpoints.map(\.address.rawValue)
+            let hostnamesWithDnsResolutionFailure = endpoints
+                .map {
+                    $0.address.asSensitiveAddress(ctx)
+                }
                 .joined(separator: ", ")
             pp_log(ctx, .wireguard, .error, "DNS resolution failed for the following hostnames: \(hostnamesWithDnsResolutionFailure)")
             return WireGuardConnectionError.dnsResolutionFailure


### PR DESCRIPTION
Plain addresses were leaking in the logs.