### PR TITLE
Core: Fix inconsistent requirements for virtual device

### DIFF
--- a/Sources/PartoutCore/Connection/TunnelRemoteInfo.swift
+++ b/Sources/PartoutCore/Connection/TunnelRemoteInfo.swift
@@ -17,7 +17,7 @@ public struct TunnelRemoteInfo: Sendable {
     /// True if the controller should create a virtual I/O device.
     public let requiresVirtualDevice: Bool
 
-    public init(originalModuleId: UniqueID, address: Address?, modules: [Module]?, requiresVirtualDevice: Bool = true) {
+    public init(originalModuleId: UniqueID, address: Address?, modules: [Module]?, requiresVirtualDevice: Bool) {
         self.originalModuleId = originalModuleId
         self.address = address
         self.modules = modules

--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
@@ -200,7 +200,8 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,
                     address: addressObject,
-                    modules: builder.modules()
+                    modules: builder.modules(),
+                    requiresVirtualDevice: true
                 )
             )
             await session.setTunnel(tunnelInterface)

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -189,7 +189,8 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,
                     address: addressObject,
-                    modules: builder.modules()
+                    modules: builder.modules(),
+                    requiresVirtualDevice: true
                 )
             )
             await session.setTunnel(tunnelInterface)

--- a/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
+++ b/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
@@ -194,7 +194,8 @@ private extension _WireGuardConnectionV1 {
                     _ = try await connection.controller.setTunnelSettings(with: TunnelRemoteInfo(
                         originalModuleId: connection.moduleId,
                         address: addressObject,
-                        modules: [module]
+                        modules: [module],
+                        requiresVirtualDevice: false
                     ))
                     completionHandler?(nil)
                     pp_log(connection.ctx, .wireguard, .info, "Tunnel interface is now UP")

--- a/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
+++ b/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
@@ -194,8 +194,7 @@ private extension _WireGuardConnectionV1 {
                     _ = try await connection.controller.setTunnelSettings(with: TunnelRemoteInfo(
                         originalModuleId: connection.moduleId,
                         address: addressObject,
-                        modules: [module],
-                        requiresVirtualDevice: false
+                        modules: [module]
                     ))
                     completionHandler?(nil)
                     pp_log(connection.ctx, .wireguard, .info, "Tunnel interface is now UP")

--- a/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
+++ b/Sources/PartoutWireGuardConnection/V1/_WireGuardConnectionV1.swift
@@ -194,7 +194,8 @@ private extension _WireGuardConnectionV1 {
                     _ = try await connection.controller.setTunnelSettings(with: TunnelRemoteInfo(
                         originalModuleId: connection.moduleId,
                         address: addressObject,
-                        modules: [module]
+                        modules: [module],
+                        requiresVirtualDevice: false // Code is Apple-only, tun created by NE
                     ))
                     completionHandler?(nil)
                     pp_log(connection.ctx, .wireguard, .info, "Tunnel interface is now UP")

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -169,16 +169,11 @@ final class TunnelRemoteInfoGenerator: Sendable {
             modules.append(dns)
         }
 
-#if os(Windows)
-        let requiresVirtualDevice = false
-#else
-        let requiresVirtualDevice = true
-#endif
         return TunnelRemoteInfo(
             originalModuleId: moduleId,
             address: remoteAddress,
             modules: modules,
-            requiresVirtualDevice: requiresVirtualDevice
+            requiresVirtualDevice: false
         )
     }
 }

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -169,11 +169,16 @@ final class TunnelRemoteInfoGenerator: Sendable {
             modules.append(dns)
         }
 
+#if os(Windows)
+        let requiresVirtualDevice = false
+#else
+        let requiresVirtualDevice = true
+#endif
         return TunnelRemoteInfo(
             originalModuleId: moduleId,
             address: remoteAddress,
             modules: modules,
-            requiresVirtualDevice: false
+            requiresVirtualDevice: requiresVirtualDevice
         )
     }
 }

--- a/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/ProfileNetworkSettingsTests.swift
@@ -138,7 +138,8 @@ struct ProfileNetworkSettingsTests {
         let sut = profile.networkSettings(with: .init(
             originalModuleId: bogusModule.id,
             address: Address(rawValue: "5.6.7.8")!,
-            modules: [bogusModule]
+            modules: [bogusModule],
+            requiresVirtualDevice: false
         ))
 
         #expect(sut.tunnelRemoteAddress == "5.6.7.8")
@@ -163,7 +164,8 @@ struct ProfileNetworkSettingsTests {
                             Route(defaultWithGateway: nil)
                         ])
                 ).build()
-            ]
+            ],
+            requiresVirtualDevice: false
         )
         let ipModule = IPModule.Builder(
             ipv4: IPSettings(subnet: Subnet(rawValue: "1.2.3.4/32")!)


### PR DESCRIPTION
The meaning of `requiresVirtualDevice` in controllers:

- Apple NE: NETunnelController ignores it because Network Extension manages tun
- Cross-platform: NativeTunnelController uses it to create a tun device and a VirtualTunnelInterface with it

Protocols:

- OpenVPN
  - tun is always required by the implementation
  - In Network Extension, tun is not manually created, we use NETunnelInterface
  - Elsewhere, tun is created and provides VirtualTunnelInterface
- WireGuard
  - V1 (Apple NE)
    - tun is created by Network Extension
    - wg-go looks it up
  - V2 (Cross-platform)
    - Apple NE: same as V1
    - macOS/Linux/Android: create tun for wg-go to look it up
    - Windows: wg-go creates tun, therefore do not create a second tun device
  - VirtualTunnelInterface is unused

This PR should not affect Passepartout because `requiresVirtualDevice` is harmless in the Network Extension environment.