### PR TITLE
Android: Make tun I/O non-blocking

### DIFF
--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -182,6 +182,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     continuation.resume()
                 }
             }
+        } catch let error as IOError {
+            throw error
         } catch {
             guard isActive else {
                 throw PartoutError(.tunNotActive)

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -97,7 +97,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         return
                     }
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
-                    if readCount < 0, errno == EAGAIN {
+                    if readCount < 0, errno == EAGAIN || errno == EWOULDBLOCK {
                         continuation.resume(throwing: IOError.readWouldBlock)
                         return
                     }
@@ -167,7 +167,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         let writtenCount = toWrite.withUnsafeBytes {
                             pp_tun_write(self.tun, $0.bytePointer, toWrite.count)
                         }
-                        if writtenCount < 0, errno == EAGAIN {
+                        if writtenCount < 0, errno == EAGAIN || errno == EWOULDBLOCK {
                             continuation.resume(
                                 throwing: IOError.writeWouldBlock(failedPacketIndex: current)
                             )

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -7,7 +7,7 @@ internal import _PartoutCore_C
 /// An interface that interacts with a Layer 3 virtual tun device, commonly found in UNIX-like systems.
 final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     private enum IOError: Error {
-        case nonBlocking
+        case wouldBlock
     }
 
     private let ctx: PartoutLoggerContext
@@ -23,7 +23,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 
     private let writeQueue: DispatchQueue
 
-    private let yieldNonBlocking: Int
+    private let nonBlockingBackoff: Int
 
     // FIXME: #188, how to avoid silent copy? (enforce reference)
     private var readBuf: [UInt8]
@@ -50,7 +50,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         _ ctx: PartoutLoggerContext,
         tun: pp_tun,
         maxReadLength: Int,
-        yieldNonBlocking: Int = 100
+        nonBlockingBackoff: Int = 100
     ) {
         self.ctx = ctx
         self.tun = tun
@@ -65,7 +65,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         let label = deviceName?.description ?? descriptor?.description ?? "*"
         readQueue = DispatchQueue(label: "VirtualTunnelInterface[R:\(label)]")
         writeQueue = DispatchQueue(label: "VirtualTunnelInterface[W:\(label)]")
-        self.yieldNonBlocking = yieldNonBlocking
+        self.nonBlockingBackoff = nonBlockingBackoff
         readBuf = [UInt8](repeating: 0, count: maxReadLength)
 
         _isActive = true
@@ -98,7 +98,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
                     guard readCount > 0 else {
                         guard errno != EAGAIN else {
-                            continuation.resume(throwing: IOError.nonBlocking)
+                            continuation.resume(throwing: IOError.wouldBlock)
                             return
                         }
                         continuation.resume(throwing: PartoutError(.ioFailure))
@@ -108,8 +108,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     continuation.resume(returning: [newPacket])
                 }
             }
-        } catch IOError.nonBlocking {
-            await yield()
+        } catch IOError.wouldBlock {
+            await backoffAfterWouldBlock()
             return []
         } catch {
             guard isActive else {
@@ -147,7 +147,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         }
                         guard writtenCount > 0 else {
                             guard errno != EAGAIN else {
-                                continuation.resume(throwing: IOError.nonBlocking)
+                                continuation.resume(throwing: IOError.wouldBlock)
                                 return
                             }
                             continuation.resume(throwing: PartoutError(.ioFailure))
@@ -157,8 +157,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     continuation.resume()
                 }
             }
-        } catch IOError.nonBlocking {
-            await yield()
+        } catch IOError.wouldBlock {
+            await backoffAfterWouldBlock()
         } catch {
             guard isActive else {
                 throw PartoutError(.tunNotActive)
@@ -187,9 +187,9 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 }
 
 private extension VirtualTunnelInterface {
-    func yield() async {
-        guard yieldNonBlocking > 0 else { return }
-        try? await Task.sleep(milliseconds: yieldNonBlocking)
+    func backoffAfterWouldBlock() async {
+        guard nonBlockingBackoff > 0 else { return }
+        try? await Task.sleep(milliseconds: nonBlockingBackoff)
     }
 }
 

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -189,7 +189,10 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 private extension VirtualTunnelInterface {
     func backoffAfterWouldBlock() async {
         guard !Task.isCancelled else { return }
-        guard nonBlockingBackoff > 0 else { return }
+        guard nonBlockingBackoff > 0 else {
+            await Task.yield()
+            return
+        }
         try? await Task.sleep(milliseconds: nonBlockingBackoff)
     }
 }

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -97,7 +97,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         return
                     }
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
-                    if readCount < 0, errno == EAGAIN || errno == EWOULDBLOCK {
+                    guard !ioWouldBlock(readCount) else {
                         continuation.resume(throwing: IOError.readWouldBlock)
                         return
                     }
@@ -167,7 +167,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         let writtenCount = toWrite.withUnsafeBytes {
                             pp_tun_write(self.tun, $0.bytePointer, toWrite.count)
                         }
-                        if writtenCount < 0, errno == EAGAIN || errno == EWOULDBLOCK {
+                        guard !ioWouldBlock(writtenCount) else {
                             continuation.resume(
                                 throwing: IOError.writeWouldBlock(failedPacketIndex: current)
                             )
@@ -218,6 +218,10 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         await readQueue.waitUntilIdle()
         await writeQueue.waitUntilIdle()
     }
+}
+
+private func ioWouldBlock(_ count: Int32) -> Bool {
+    count < 0 && errno == EAGAIN || errno == EWOULDBLOCK
 }
 
 private extension DispatchQueue {

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -188,6 +188,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 
 private extension VirtualTunnelInterface {
     func backoffAfterWouldBlock() async {
+        guard !Task.isCancelled else { return }
         guard nonBlockingBackoff > 0 else { return }
         try? await Task.sleep(milliseconds: nonBlockingBackoff)
     }

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -161,7 +161,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         let writtenCount = toWrite.withUnsafeBytes {
                             pp_tun_write(self.tun, $0.bytePointer, toWrite.count)
                         }
-                        guard writtenCount > 0 else {
+                        guard writtenCount == toWrite.count else {
                             guard errno != EAGAIN else {
                                 continuation.resume(throwing: IOError.wouldBlock)
                                 return

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -221,7 +221,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 }
 
 private func ioWouldBlock(_ count: Int32) -> Bool {
-    count < 0 && errno == EAGAIN || errno == EWOULDBLOCK
+    count < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)
 }
 
 private extension DispatchQueue {

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -122,6 +122,22 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     }
 
     func writePackets(_ packets: [Data]) async throws {
+        let maxAttempts = 2
+        for attempt in 0..<maxAttempts {
+            do {
+                try await writePacketsImmediately(packets)
+                return
+            } catch IOError.wouldBlock {
+                guard attempt + 1 < maxAttempts else {
+                    return // Drop after bounded retry
+                }
+                await backoffAfterWouldBlock()
+                try Task.checkCancellation()
+            }
+        }
+    }
+
+    private func writePacketsImmediately(_ packets: [Data]) async throws {
         guard isActive else {
             throw PartoutError(.tunNotActive)
         }
@@ -157,8 +173,6 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     continuation.resume()
                 }
             }
-        } catch IOError.wouldBlock {
-            await backoffAfterWouldBlock()
         } catch {
             guard isActive else {
                 throw PartoutError(.tunNotActive)
@@ -167,6 +181,15 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
             await shutdown()
             throw error
         }
+    }
+
+    private func backoffAfterWouldBlock() async {
+        guard !Task.isCancelled else { return }
+        guard nonBlockingBackoff > 0 else {
+            await Task.yield()
+            return
+        }
+        try? await Task.sleep(milliseconds: nonBlockingBackoff)
     }
 
     func shutdown() async {
@@ -183,17 +206,6 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     func waitUntilIdle() async {
         await readQueue.waitUntilIdle()
         await writeQueue.waitUntilIdle()
-    }
-}
-
-private extension VirtualTunnelInterface {
-    func backoffAfterWouldBlock() async {
-        guard !Task.isCancelled else { return }
-        guard nonBlockingBackoff > 0 else {
-            await Task.yield()
-            return
-        }
-        try? await Task.sleep(milliseconds: nonBlockingBackoff)
     }
 }
 

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -189,6 +189,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
             await shutdown()
             throw error
         }
+        // All packets were written
+        return packets.count
     }
 
     private func backoffAfterWouldBlock() async throws {

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -97,11 +97,11 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         return
                     }
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
+                    if readCount < 0, errno == EAGAIN {
+                        continuation.resume(throwing: IOError.readWouldBlock)
+                        return
+                    }
                     guard readCount > 0 else {
-                        guard errno != EAGAIN else {
-                            continuation.resume(throwing: IOError.readWouldBlock)
-                            return
-                        }
                         continuation.resume(throwing: PartoutError(.ioFailure))
                         return
                     }
@@ -168,13 +168,13 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         let writtenCount = toWrite.withUnsafeBytes {
                             pp_tun_write(self.tun, $0.bytePointer, toWrite.count)
                         }
+                        if writtenCount < 0, errno == EAGAIN {
+                            continuation.resume(
+                                throwing: IOError.writeWouldBlock(failedPacketIndex: current)
+                            )
+                            return
+                        }
                         guard writtenCount == toWrite.count else {
-                            guard errno != EAGAIN else {
-                                continuation.resume(
-                                    throwing: IOError.writeWouldBlock(failedPacketIndex: current)
-                                )
-                                return
-                            }
                             continuation.resume(throwing: PartoutError(.ioFailure))
                             return
                         }

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -109,7 +109,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                 }
             }
         } catch IOError.wouldBlock {
-            await backoffAfterWouldBlock()
+            try await backoffAfterWouldBlock()
             return []
         } catch {
             guard isActive else {
@@ -131,7 +131,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                 guard attempt + 1 < maxAttempts else {
                     return // Drop after bounded retry
                 }
-                await backoffAfterWouldBlock()
+                try await backoffAfterWouldBlock()
                 try Task.checkCancellation()
             }
         }
@@ -183,13 +183,14 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         }
     }
 
-    private func backoffAfterWouldBlock() async {
-        guard !Task.isCancelled else { return }
+    private func backoffAfterWouldBlock() async throws {
+        try Task.checkCancellation()
         guard nonBlockingBackoff > 0 else {
             await Task.yield()
+            try Task.checkCancellation()
             return
         }
-        try? await Task.sleep(milliseconds: nonBlockingBackoff)
+        try await Task.sleep(milliseconds: nonBlockingBackoff)
     }
 
     func shutdown() async {

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -93,7 +93,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                             continuation.resume(returning: [])
                             return
                         }
-                        continuation.resume(throwing: PartoutError(.linkFailure))
+                        continuation.resume(throwing: PartoutError(.ioFailure))
                         return
                     }
                     let newPacket = Data(readBuf[0..<Int(readCount)])
@@ -139,7 +139,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                                 continuation.resume()
                                 return
                             }
-                            continuation.resume(throwing: PartoutError(.linkFailure))
+                            continuation.resume(throwing: PartoutError(.ioFailure))
                             return
                         }
                     }

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -50,7 +50,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         _ ctx: PartoutLoggerContext,
         tun: pp_tun,
         maxReadLength: Int,
-        nonBlockingBackoff: Int = 100
+        nonBlockingBackoff: Int = 20
     ) {
         self.ctx = ctx
         self.tun = tun

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -7,7 +7,8 @@ internal import _PartoutCore_C
 /// An interface that interacts with a Layer 3 virtual tun device, commonly found in UNIX-like systems.
 final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     private enum IOError: Error {
-        case wouldBlock
+        case readWouldBlock
+        case writeWouldBlock(lastPacketIndex: Int)
     }
 
     private let ctx: PartoutLoggerContext
@@ -98,7 +99,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
                     guard readCount > 0 else {
                         guard errno != EAGAIN else {
-                            continuation.resume(throwing: IOError.wouldBlock)
+                            continuation.resume(throwing: IOError.readWouldBlock)
                             return
                         }
                         continuation.resume(throwing: PartoutError(.ioFailure))
@@ -108,7 +109,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     continuation.resume(returning: [newPacket])
                 }
             }
-        } catch IOError.wouldBlock {
+        } catch IOError.readWouldBlock {
             try await backoffAfterWouldBlock()
             return []
         } catch {
@@ -122,12 +123,14 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     }
 
     func writePackets(_ packets: [Data]) async throws {
+        var from = 0
         let maxAttempts = 2
         for attempt in 0..<maxAttempts {
             do {
-                try await writePacketsImmediately(packets)
+                try await writePacketsImmediately(packets, from: from)
                 return
-            } catch IOError.wouldBlock {
+            } catch IOError.writeWouldBlock(let lastPacketIndex) {
+                from = lastPacketIndex
                 guard attempt + 1 < maxAttempts else {
                     return // Drop after bounded retry
                 }
@@ -137,7 +140,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         }
     }
 
-    private func writePacketsImmediately(_ packets: [Data]) async throws {
+    private func writePacketsImmediately(_ packets: [Data], from: Int) async throws -> Int {
         guard isActive else {
             throw PartoutError(.tunNotActive)
         }
@@ -152,7 +155,10 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         continuation.resume(throwing: PartoutError(.tunNotActive))
                         return
                     }
+                    var i = 0
                     for toWrite in packets {
+                        guard i >= from else { continue }
+                        i += 1
                         guard !toWrite.isEmpty else { continue }
                         guard self.isActive else {
                             continuation.resume(throwing: PartoutError(.tunNotActive))
@@ -163,7 +169,9 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         }
                         guard writtenCount == toWrite.count else {
                             guard errno != EAGAIN else {
-                                continuation.resume(throwing: IOError.wouldBlock)
+                                continuation.resume(
+                                    throwing: IOError.writeWouldBlock(lastPacketIndex: i)
+                                )
                                 return
                             }
                             continuation.resume(throwing: PartoutError(.ioFailure))

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -89,6 +89,10 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     }
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
                     guard readCount > 0 else {
+                        guard errno != EAGAIN else {
+                            continuation.resume(returning: [])
+                            return
+                        }
                         continuation.resume(throwing: PartoutError(.linkFailure))
                         return
                     }
@@ -131,6 +135,10 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                             pp_tun_write(self.tun, $0.bytePointer, toWrite.count)
                         }
                         guard writtenCount > 0 else {
+                            guard errno != EAGAIN else {
+                                continuation.resume()
+                                return
+                            }
                             continuation.resume(throwing: PartoutError(.linkFailure))
                             return
                         }

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -8,7 +8,7 @@ internal import _PartoutCore_C
 final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     private enum IOError: Error {
         case readWouldBlock
-        case writeWouldBlock(lastPacketIndex: Int)
+        case writeWouldBlock(failedPacketIndex: Int)
     }
 
     private let ctx: PartoutLoggerContext
@@ -129,8 +129,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
             do {
                 try await writePacketsImmediately(packets, from: from)
                 return
-            } catch IOError.writeWouldBlock(let lastPacketIndex) {
-                from = lastPacketIndex
+            } catch IOError.writeWouldBlock(let failedPacketIndex) {
+                from = failedPacketIndex
                 guard attempt + 1 < maxAttempts else {
                     return // Drop after bounded retry
                 }
@@ -140,7 +140,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         }
     }
 
-    private func writePacketsImmediately(_ packets: [Data], from: Int) async throws -> Int {
+    private func writePacketsImmediately(_ packets: [Data], from: Int) async throws {
         guard isActive else {
             throw PartoutError(.tunNotActive)
         }
@@ -155,10 +155,11 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         continuation.resume(throwing: PartoutError(.tunNotActive))
                         return
                     }
-                    var i = 0
+                    var next = 0
                     for toWrite in packets {
-                        guard i >= from else { continue }
-                        i += 1
+                        let current = next
+                        next += 1
+                        guard current >= from else { continue }
                         guard !toWrite.isEmpty else { continue }
                         guard self.isActive else {
                             continuation.resume(throwing: PartoutError(.tunNotActive))
@@ -170,7 +171,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         guard writtenCount == toWrite.count else {
                             guard errno != EAGAIN else {
                                 continuation.resume(
-                                    throwing: IOError.writeWouldBlock(lastPacketIndex: i)
+                                    throwing: IOError.writeWouldBlock(failedPacketIndex: current)
                                 )
                                 return
                             }
@@ -189,8 +190,6 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
             await shutdown()
             throw error
         }
-        // All packets were written
-        return packets.count
     }
 
     private func backoffAfterWouldBlock() async throws {

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -6,6 +6,10 @@ internal import _PartoutCore_C
 
 /// An interface that interacts with a Layer 3 virtual tun device, commonly found in UNIX-like systems.
 final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
+    private enum IOError: Error {
+        case nonBlocking
+    }
+
     private let ctx: PartoutLoggerContext
 
     nonisolated(unsafe)
@@ -18,6 +22,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     private let readQueue: DispatchQueue
 
     private let writeQueue: DispatchQueue
+
+    private let yieldNonBlocking: Int
 
     // FIXME: #188, how to avoid silent copy? (enforce reference)
     private var readBuf: [UInt8]
@@ -43,7 +49,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     init(
         _ ctx: PartoutLoggerContext,
         tun: pp_tun,
-        maxReadLength: Int
+        maxReadLength: Int,
+        yieldNonBlocking: Int = 100
     ) {
         self.ctx = ctx
         self.tun = tun
@@ -58,6 +65,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         let label = deviceName?.description ?? descriptor?.description ?? "*"
         readQueue = DispatchQueue(label: "VirtualTunnelInterface[R:\(label)]")
         writeQueue = DispatchQueue(label: "VirtualTunnelInterface[W:\(label)]")
+        self.yieldNonBlocking = yieldNonBlocking
         readBuf = [UInt8](repeating: 0, count: maxReadLength)
 
         _isActive = true
@@ -90,7 +98,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     let readCount = pp_tun_read(tun, &readBuf, readBuf.count)
                     guard readCount > 0 else {
                         guard errno != EAGAIN else {
-                            continuation.resume(returning: [])
+                            continuation.resume(throwing: IOError.nonBlocking)
                             return
                         }
                         continuation.resume(throwing: PartoutError(.ioFailure))
@@ -100,6 +108,9 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     continuation.resume(returning: [newPacket])
                 }
             }
+        } catch IOError.nonBlocking {
+            await yield()
+            return []
         } catch {
             guard isActive else {
                 throw PartoutError(.tunNotActive)
@@ -136,7 +147,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                         }
                         guard writtenCount > 0 else {
                             guard errno != EAGAIN else {
-                                continuation.resume()
+                                continuation.resume(throwing: IOError.nonBlocking)
                                 return
                             }
                             continuation.resume(throwing: PartoutError(.ioFailure))
@@ -146,6 +157,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     continuation.resume()
                 }
             }
+        } catch IOError.nonBlocking {
+            await yield()
         } catch {
             guard isActive else {
                 throw PartoutError(.tunNotActive)
@@ -170,6 +183,13 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
     func waitUntilIdle() async {
         await readQueue.waitUntilIdle()
         await writeQueue.waitUntilIdle()
+    }
+}
+
+private extension VirtualTunnelInterface {
+    func yield() async {
+        guard yieldNonBlocking > 0 else { return }
+        try? await Task.sleep(milliseconds: yieldNonBlocking)
     }
 }
 

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -135,7 +135,6 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
                     return // Drop after bounded retry
                 }
                 try await backoffAfterWouldBlock()
-                try Task.checkCancellation()
             }
         }
     }

--- a/Sources/PartoutCore/Connection/BSDSocket.swift
+++ b/Sources/PartoutCore/Connection/BSDSocket.swift
@@ -647,11 +647,11 @@ private extension ExtendedEndpoint {
 
 private extension SocketHandle {
     func preferredError() -> PartoutError {
-        isStopping ? PartoutError(.linkNotActive) : PartoutError(.linkFailure)
+        isStopping ? PartoutError(.linkNotActive) : PartoutError(.ioFailure)
     }
 
     func preferredError(withReadCount readCount: Int32) -> PartoutError {
         // In non-blocking TCP, "0 bytes" means "link inactive"
-        isStopping || readCount == 0 ? PartoutError(.linkNotActive) : PartoutError(.linkFailure)
+        isStopping || readCount == 0 ? PartoutError(.linkNotActive) : PartoutError(.ioFailure)
     }
 }

--- a/Sources/PartoutCore/Partout+Core.swift
+++ b/Sources/PartoutCore/Partout+Core.swift
@@ -93,11 +93,11 @@ extension PartoutError.Code {
     /// No more endpoints available to try.
     public static let exhaustedEndpoints = Self("exhaustedEndpoints")
 
+    /// I/O failure.
+    public static let ioFailure = Self("ioFailure")
+
     /// Link device is not active.
     public static let linkNotActive = Self("linkNotActive")
-
-    /// Link I/O failure.
-    public static let linkFailure = Self("linkFailure")
 
     /// Network changed.
     public static let networkChanged = Self("networkChanged")

--- a/Sources/PartoutOpenVPNConnection/Internal/Error+Recoverable.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Error+Recoverable.swift
@@ -17,7 +17,7 @@ extension Error {
 
 private let ppRecoverableCodes: [PartoutError.Code] = [
     .timeout,
-    .linkFailure,
+    .ioFailure,
     .networkChanged,
     .OpenVPN.connectionFailure,
     .OpenVPN.recoverableAuthentication,

--- a/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/Negotiator.swift
@@ -367,7 +367,7 @@ private extension Negotiator {
                 try await link.writePackets(rawList)
             } catch {
                 pp_log(ctx, .openvpn, .error, "Failed LINK write during control flush: \(error)")
-                await options.onError(key, PartoutError(.linkFailure, error))
+                await options.onError(key, PartoutError(.ioFailure, error))
             }
         }
     }
@@ -505,7 +505,7 @@ private extension Negotiator {
             pp_log(ctx, .openvpn, .info, "Ack successfully written to LINK for packetId \(controlPacket.packetId)")
         } catch {
             pp_log(ctx, .openvpn, .error, "Failed LINK write during send ack for packetId \(controlPacket.packetId): \(error)")
-            await options.onError(key, PartoutError(.linkFailure, error))
+            await options.onError(key, PartoutError(.ioFailure, error))
         }
     }
 

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Data.swift
@@ -48,7 +48,7 @@ extension OpenVPNSession {
             throw cError
         } catch {
             pp_log(ctx, .openvpn, .error, "Data: Failed LINK write during send data: \(error)")
-            await shutdown(PartoutError(.linkFailure, error))
+            await shutdown(PartoutError(.ioFailure, error))
         }
     }
 }

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
@@ -50,7 +50,7 @@ extension OpenVPNSession {
                 }
                 if let error {
                     pp_log(self.ctx, .openvpn, .error, "Failed LINK read: \(error)")
-                    await self.shutdown(PartoutError(.linkFailure, error))
+                    await self.shutdown(PartoutError(.ioFailure, error))
                     return
                 }
                 guard let packets, !packets.isEmpty else {
@@ -123,7 +123,7 @@ extension OpenVPNSession {
                     try await receiveLink(packets: packets)
                 } catch {
                     pp_log(ctx, .openvpn, .error, "Failed LINK read: \(error)")
-                    await self.shutdown(PartoutError(.linkFailure, error))
+                    await self.shutdown(PartoutError(.ioFailure, error))
                     return
                 }
             }

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession+Loop.swift
@@ -86,7 +86,7 @@ extension OpenVPNSession {
                 do {
                     let packets = try await tunnel.readPackets()
                     guard !packets.isEmpty else {
-                        pp_log(ctx, .openvpn, .debug, "Skip TUN loop after empty packets")
+//                        pp_log(ctx, .openvpn, .debug, "Skip TUN loop after empty packets")
                         continue
                     }
                     try await receiveTunnel(packets: packets)

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -140,10 +140,7 @@ class JNITunnelController(
             return INVALID_TUN_FD
         }
 
-        // IMPORTANT: this is a requirement for VirtualTunnelInterface.
-        // By default, establish() returns a non-blocking descriptor.
-        builder.setBlocking(true)
-
+        // IMPORTANT: By default, establish() returns a non-blocking descriptor.
         tunDescriptor = try {
             builder.establish()
         } catch (e: RuntimeException) {


### PR DESCRIPTION
In JNITunnelController, tun I/O was set to blocking with `builder.setBlocking(true)`, because Android defaults to non-blocking. This was an old limitation of VirtualTunnelInterface due to the inability to handle non-blocking I/O, but that's easy to fix with a check on `errno != EGAIN`.

In fact, the blocking read loop in VirtualTunnelInterface was delaying the tun shutdown up to 5-15s. The typical Android key icon associated with the VPN was directly affected by the same delay.

A concern remains about CPU% and performance, as non-blocking I/O in VirtualTunnelInterface should yield a little bit on EAGAIN. Default to 20ms to start with.

Rename .linkFailure error code to the more generic .ioFailure