### PR TITLE
Android: Wire clearTunnel() to JNITunnelController lifecycle

### DIFF
--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -46,7 +46,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 
     private let activeLock: SemaphoreMutex
 
-    // WARNING: tun ownership is transferred
+    // WARNING: tun is NOT owned
     init(
         _ ctx: PartoutLoggerContext,
         tun: pp_tun,

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -69,7 +69,9 @@ private extension POSIXDNSStrategy {
         guard result == 0 else {
             switch result {
             case EAI_BADFLAGS:
-                pp_log_g(.core, .fault, "getaddrinfo() failed with bad flags")
+                pp_log_g(.core, .fault, "getaddrinfo() failed with EAI_BADFLAGS")
+            case EAI_NODATA:
+                pp_log_g(.core, .fault, "getaddrinfo() failed with EAI_NODATA")
             default:
                 pp_log_g(.core, .fault, "getaddrinfo() failed with result \(result)")
             }

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -117,6 +117,7 @@ cleanup:
     PP_JNI_DETACH(env);
 }
 
+// Balance with pp_tun_ctrl_clear_tunnel
 pp_tun pp_tun_ctrl_set_tunnel(void *jni_ref, const char *uuid, const char *info_json) {
     (void)uuid;
     assert(jni_ref);
@@ -251,6 +252,15 @@ cleanup:
     PP_JNI_DETACH(env);
 }
 
+// Balance with pp_tun_ctrl_set_tunnel
+void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
+    (void)jni_ref;
+    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_clear_tunnel(%p)", jni_ref);
+    if (!tun_impl) return;
+    pp_tun_shutdown(tun_impl);
+    free(tun_impl);
+}
+
 void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_cancel_tunnel(%p)", jni_ref);
@@ -284,14 +294,6 @@ cleanup:
     if (j_error_message != NULL) (*env)->DeleteLocalRef(env, j_error_message);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
     PP_JNI_DETACH(env);
-}
-
-void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
-    (void)jni_ref;
-    pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_clear_tunnel(%p)", jni_ref);
-    if (!tun_impl) return;
-    pp_tun_shutdown(tun_impl);
-    free(tun_impl);
 }
 
 JNIEXPORT void JNICALL

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -258,7 +258,6 @@ cleanup:
 
 // Balance with pp_tun_ctrl_set_tunnel
 void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
-    (void)jni_ref;
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_clear_tunnel(%p)", jni_ref);
     if (!tun_impl) return;
     pp_tun_shutdown(tun_impl);
@@ -268,7 +267,6 @@ void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
 
     jclass cls = NULL;
     jmethodID method = NULL;
-    jintArray j_fds = NULL;
 
     cls = (*env)->GetObjectClass(env, jni_ref);
     if (cls == NULL) {

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -261,7 +261,7 @@ void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
     free(tun_impl);
 }
 
-void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
+void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_code) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_cancel_tunnel(%p)", jni_ref);
 
@@ -269,7 +269,7 @@ void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
 
     jclass cls = NULL;
     jmethodID method = NULL;
-    jstring j_error_message = NULL;
+    jstring j_error_code = NULL;
 
     cls = (*env)->GetObjectClass(env, jni_ref);
     if (cls == NULL) {
@@ -281,8 +281,8 @@ void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
         pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_cancel_tunnel(), NULL method");
         goto cleanup;
     }
-    j_error_message = error_message ? (*env)->NewStringUTF(env, error_message) : NULL;
-    (*env)->CallVoidMethod(env, jni_ref, method, j_error_message);
+    j_error_code = error_code ? (*env)->NewStringUTF(env, error_code) : NULL;
+    (*env)->CallVoidMethod(env, jni_ref, method, j_error_code);
     if ((*env)->ExceptionCheck(env)) {
         (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);
@@ -291,7 +291,7 @@ void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_message) {
     }
 
 cleanup:
-    if (j_error_message != NULL) (*env)->DeleteLocalRef(env, j_error_message);
+    if (j_error_code != NULL) (*env)->DeleteLocalRef(env, j_error_code);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
     PP_JNI_DETACH(env);
 }

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -70,6 +70,10 @@ static const kotlin_sig sig_ctrl_onSnapshot = {
     "onSnapshot",
     "(Ljava/lang/String;)V"
 };
+static const kotlin_sig sig_ctrl_clearTunnel = {
+    "clearTunnel",
+    "()V"
+};
 static const kotlin_sig sig_ctrl_cancelTunnel = {
     "cancelTunnel",
     "(Ljava/lang/String;)V"
@@ -259,6 +263,33 @@ void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
     if (!tun_impl) return;
     pp_tun_shutdown(tun_impl);
     free(tun_impl);
+
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
+
+    jclass cls = NULL;
+    jmethodID method = NULL;
+    jintArray j_fds = NULL;
+
+    cls = (*env)->GetObjectClass(env, jni_ref);
+    if (cls == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_clear_tunnel(), NULL cls");
+        goto cleanup;
+    }
+    method = (*env)->GetMethodID(env, cls, sig_ctrl_clearTunnel.name, sig_ctrl_clearTunnel.signature);
+    if (method == NULL) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_clear_tunnel(), NULL method");
+        goto cleanup;
+    }
+    (*env)->CallVoidMethod(env, jni_ref, method);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_clear_tunnel(), Kotlin exception");
+        goto cleanup;
+    }
+
+cleanup:
+    PP_JNI_DETACH(env);
 }
 
 void pp_tun_ctrl_cancel_tunnel(void *jni_ref, const char *error_code) {

--- a/Tests/PartoutCoreTests/PartoutErrorTests.swift
+++ b/Tests/PartoutCoreTests/PartoutErrorTests.swift
@@ -29,7 +29,7 @@ struct PartoutErrorTests {
     @Test(arguments: [
         (PartoutError(.authentication), "{PartoutError.authentication}"),
         (PartoutError(.authentication, "userInfo"), "{PartoutError.authentication, userInfo=userInfo}"),
-        (PartoutError(.authentication, "userInfo", SomeDescriptiveError()), "{PartoutError.authentication, userInfo=userInfo, reason=SomeDescriptiveError()}")
+        (PartoutError(.authentication, "userInfo", SomeDescriptiveError()), "{PartoutError.authentication, userInfo=userInfo, reason=SomeDescriptiveError() (errorDescription)}")
     ])
     func givenError_whenDescribe_thenReturnsDescription(error: PartoutError, expectedDescription: String) {
         #expect(error.debugDescription == expectedDescription)

--- a/Tests/PartoutCoreTests/PartoutErrorTests.swift
+++ b/Tests/PartoutCoreTests/PartoutErrorTests.swift
@@ -27,9 +27,9 @@ struct PartoutErrorTests {
     }
 
     @Test(arguments: [
-        (PartoutError(.authentication), "[PartoutError.authentication]"),
-        (PartoutError(.authentication, "userInfo"), "[PartoutError.authentication, userInfo]"),
-        (PartoutError(.authentication, "userInfo", SomeDescriptiveError()), "[PartoutError.authentication, userInfo, errorDescription]")
+        (PartoutError(.authentication), "{PartoutError.authentication}"),
+        (PartoutError(.authentication, "userInfo"), "{PartoutError.authentication, userInfo=userInfo}"),
+        (PartoutError(.authentication, "userInfo", SomeDescriptiveError()), "{PartoutError.authentication, userInfo=userInfo, reason=SomeDescriptiveError()}")
     ])
     func givenError_whenDescribe_thenReturnsDescription(error: PartoutError, expectedDescription: String) {
         #expect(error.debugDescription == expectedDescription)

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -171,6 +171,7 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to stop VPN daemon", e)
         } finally {
             controller?.stopObserving()
+            controller?.cancelTunnel(null)
             controller = null
         }
         isRunning = false

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -32,6 +32,7 @@ interface TunnelController {
     fun setTunnel(infoJSON: String): Int
     fun configureSockets(fds: IntArray)
     fun onSnapshot(snapshotJSON: String)
+    fun clearTunnel()
     fun cancelTunnel(errorCode: String?)
 
     // Kotlin -> JNI
@@ -179,9 +180,15 @@ class JNITunnelController(
         return@synchronized
     }
 
+    override fun clearTunnel() = synchronized(lock) {
+        if (isNativeCancelled) { return }
+        return@synchronized
+    }
+
     override fun cancelTunnel(errorCode: String?) = synchronized(lock) {
         if (isNativeCancelled) { return }
         isNativeCancelled = true
+        tunDescriptor = null // Do not close, fd is detached
         Log.d(logTag, "cancelTunnel()")
         if (errorCode != null) {
             Log.e(logTag, "VPN daemon cancelled: $errorCode")


### PR DESCRIPTION
It does nothing, but it sits in the right place. Remember to cancelTunnel() at the very end of the service lifecycle.