### PR TITLE
Android: Prevent leaks on reconnections

### DIFF
--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/socket.h>
 
 struct __pp_tun_struct {
     int fd;
@@ -39,8 +40,7 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
 
 void pp_tun_shutdown(const pp_tun tun) {
     if (!tun || tun->fd < 0) return;
-    close(tun->fd);
-    tun->fd = -1;
+    shutdown(tun->fd, SHUT_RDWR);
 }
 
 int pp_tun_fd(const pp_tun tun) {

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -191,6 +191,29 @@ class JNITunnelController(
 
     override fun clearTunnel(killSwitch: Boolean) = synchronized(lock) {
         if (isNativeCancelled) { return }
+
+        // Optionally replace with catch-all fake tun
+        if (killSwitch) {
+            val builder = service.Builder()
+            // FIXME: Externalize these constants
+            builder.addAddress("192.0.2.1", 32)
+            builder.addAddress("fd00::1", 128)
+            builder.addRoute("0.0.0.0", 0)
+            builder.addRoute("::", 0)
+            runCatching {
+                val oldDescriptor = tunDescriptor
+                val newDescriptor = builder.establish()
+                if (newDescriptor == null) {
+                    Log.e(logTag, "Unable to set up kill switch")
+                    return@synchronized
+                }
+                oldDescriptor?.close()
+                tunDescriptor = newDescriptor
+            }.onFailure {
+                Log.e(logTag, "Unable to set up kill switch", it)
+            }
+        }
+
         return@synchronized
     }
 

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -207,8 +207,12 @@ class JNITunnelController(
                     Log.e(logTag, "Unable to set up kill switch")
                     return@synchronized
                 }
-                oldDescriptor?.close()
                 tunDescriptor = newDescriptor
+                runCatching {
+                    oldDescriptor?.close()
+                }.onFailure {
+                    Log.e(logTag, "Unable to close former tun descriptor", it)
+                }
             }.onFailure {
                 Log.e(logTag, "Unable to set up kill switch", it)
             }

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -58,12 +58,14 @@ class JNITunnelController(
     // JNI interactions with Native (Swift)
     private var nativeDelegate: Long = 0
     private var isNativeCancelled = false
-    private var tunDescriptor: ParcelFileDescriptor? = null
 
     // Network observers
     private val reachabilityObserver = ReachabilityObserver(service)
     private var reachabilityJob: Job? = null
     private var reachableNetwork: Network? = null
+
+    // Retain tun across reconnections
+    private var tunDescriptor: ParcelFileDescriptor? = null
 
     override fun startObserving() {
         reachabilityJob = reachabilityObserver
@@ -93,11 +95,8 @@ class JNITunnelController(
     override fun setTunnel(infoJSON: String): Int = synchronized(lock) {
         if (isNativeCancelled) { return INVALID_TUN_FD }
         Log.d(logTag, "setTunnel()")
-        if (tunDescriptor != null) {
-            Log.e(logTag, "Tunnel descriptor already established")
-            return INVALID_TUN_FD
-        }
 
+        // Decode info modules
         val builder = service.Builder()
         val info: TunnelRemoteInfoWrapper = try {
             json.decodeFromString(infoJSON)
@@ -105,9 +104,10 @@ class JNITunnelController(
             Log.e(logTag, "Unable to decode tunnel info JSON", e)
             return INVALID_TUN_FD
         }
+
+        // Apply modules to VPN builder
         var appliedAddressSettings = false
         var appliedDnsSettings = false
-
         info.modules?.forEach {
             when (it) {
                 is TaggedModuleDNS -> {
@@ -135,26 +135,35 @@ class JNITunnelController(
                 else -> {}
             }
         }
-
         if (!appliedAddressSettings) {
             Log.e(logTag, "No valid interface address")
             return INVALID_TUN_FD
         }
 
         // IMPORTANT: By default, establish() returns a non-blocking descriptor.
-        tunDescriptor = try {
+        val newDescriptor = try {
             builder.establish()
         } catch (e: RuntimeException) {
             Log.e(logTag, "Unable to establish tunnel", e)
             null
         }
-        if (tunDescriptor == null) {
+        if (newDescriptor == null) {
             Log.e(logTag, "Unable to establish tunnel")
             return INVALID_TUN_FD
         }
 
-        val fd = tunDescriptor?.detachFd() ?: INVALID_TUN_FD
-        tunDescriptor = null
+        // Close old tun kept as handover kill switch
+        if (tunDescriptor != null) {
+            Log.d(logTag, "Clear old tun")
+            runCatching {
+                tunDescriptor?.close()
+            }
+            tunDescriptor = null
+        }
+
+        // Track tun then propagate fd to native layer
+        tunDescriptor = newDescriptor
+        val fd = newDescriptor.fd
         Log.i(logTag, "Established tunnel descriptor: $fd")
         return fd
     }
@@ -187,14 +196,26 @@ class JNITunnelController(
 
     override fun cancelTunnel(errorCode: String?) = synchronized(lock) {
         if (isNativeCancelled) { return }
-        isNativeCancelled = true
-        tunDescriptor = null // Do not close, fd is detached
         Log.d(logTag, "cancelTunnel()")
+
+        // Prevent further calls
+        isNativeCancelled = true
+
+        // Close former tunnel
+        runCatching {
+            tunDescriptor?.close()
+            tunDescriptor = null
+        }.onFailure {
+            Log.e(logTag, "Unable to close former tun descriptor", it)
+        }
+
         if (errorCode != null) {
             Log.e(logTag, "VPN daemon cancelled: $errorCode")
         } else {
             Log.i(logTag, "VPN daemon cancelled")
         }
+
+        // Signal disconnection to delegate (runtime)
         delegate.disconnect()
         return@synchronized
     }


### PR DESCRIPTION
Before anything, do not detach the tun fd so that its lifecycle is entirely controlled by Android. The C code must not close() the fd.

Then, provide two best-effort strategies to avoid leaks on reconnections:

- Do not close the now-owned tun fd on clearTunnel(). Instead, keep it open until the next setTunnel() succeeds. Otherwise, Android would "unlock" the network as soon as the descriptor is closed, thus causing the leaks.
- Optionally, set up a fake "kill switch" tun that catches the default IPv4/6 routes and redirects them through a bogus IP address. For this to work, #440 was necessary so that the VPN sockets properly escape the VPN.