### PR TITLE
Core: Configure sockets in BSDSocketFactory

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -110,9 +110,17 @@ public final class NativeTunnelController: TunnelController, Sendable {
     }
 
     public func configureSockets(with descriptors: [UInt64]) {
-        descriptors.map(Int32.init).withUnsafeBufferPointer {
-            pp_tun_ctrl_configure_sockets(ref, $0.baseAddress, $0.count)
-        }
+        descriptors
+            .map(Int32.init)
+            .withUnsafeBufferPointer { fds in
+                if let info = reachabilityInfo?.toCReachability {
+                    withUnsafePointer(to: info) { infoPtr in
+                        pp_tun_ctrl_configure_sockets(ref, infoPtr, fds.baseAddress, fds.count)
+                    }
+                } else {
+                    pp_tun_ctrl_configure_sockets(ref, nil, fds.baseAddress, fds.count)
+                }
+            }
     }
 
     public func reportSnapshot(_ snapshot: TunnelSnapshot) {
@@ -167,16 +175,14 @@ public final class NativeTunnelController: TunnelController, Sendable {
 // MARK: - DNS
 
 extension NativeTunnelController: DNSResolver {
+    public var reachabilityInfo: ReachabilityInfo? {
+        reachabilityHolder.get()
+    }
+
     public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
-        let fallbackReachability: ReachabilityInfo?
-#if os(Android)
-        fallbackReachability = reachabilityHolder.get()
-#else
-        fallbackReachability = reachability
-#endif
-        return try await dns.resolve(
+        try await dns.resolve(
             hostname,
-            reachability: reachability ?? fallbackReachability,
+            reachability: reachability ?? reachabilityInfo,
             timeout: timeout
         )
     }
@@ -271,6 +277,21 @@ private final class BetterPathProxy: BetterPathStreamFactory, @unchecked Sendabl
     }
 }
 
+// MARK: - SocketConfigurator
+
+extension NativeTunnelController {
+    public func socketConfigurator() -> SocketConfigurator {
+        SocketConfigurator(
+            reachability: { [weak self] in
+                self?.reachabilityInfo
+            },
+            configureSocket: { [weak self] fd in
+                self?.configureSockets(with: [fd])
+            }
+        )
+    }
+}
+
 // MARK: - Helpers
 
 private extension UnsafeMutableRawPointer {
@@ -280,6 +301,21 @@ private extension UnsafeMutableRawPointer {
 
     var toSelf: NativeTunnelController {
         Unmanaged.fromOpaque(self).takeUnretainedValue()
+    }
+}
+
+private extension ReachabilityInfo {
+    var toCReachability: pp_tun_ctrl_reachability {
+#if os(Android)
+        pp_tun_ctrl_reachability(
+            reachable: isReachable,
+            network_handle: networkHandle ?? 0
+        )
+#else
+        pp_tun_ctrl_reachability(
+            reachable: isReachable
+        )
+#endif
     }
 }
 

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -211,7 +211,7 @@ extension NativeTunnelController: ReachabilityObserver {
 }
 
 private extension NativeTunnelController {
-    func onReachability(_ reachability: UnsafePointer<pp_tun_ctrl_reachability>) {
+    func onReachability(_ reachability: UnsafePointer<pp_reachability>) {
         let isReachable = reachability.pointee.reachable
 #if os(Android)
         pp_log(ctx, .core, .info, "Network reachability changed: reachable=\(isReachable), network_handle=\(reachability.pointee.network_handle)")
@@ -229,7 +229,7 @@ private extension NativeTunnelController {
 
 private final class ReachabilityHolder: @unchecked Sendable {
     private let lock = SemaphoreMutex()
-    private var reachability: pp_tun_ctrl_reachability?
+    private var reachability: pp_reachability?
 
     nonisolated func get() -> ReachabilityInfo? {
         lock.with {
@@ -247,7 +247,7 @@ private final class ReachabilityHolder: @unchecked Sendable {
         }
     }
 
-    nonisolated func set(_ new: UnsafePointer<pp_tun_ctrl_reachability>) {
+    nonisolated func set(_ new: UnsafePointer<pp_reachability>) {
         lock.with {
             reachability = new.pointee
         }
@@ -305,14 +305,14 @@ private extension UnsafeMutableRawPointer {
 }
 
 private extension ReachabilityInfo {
-    var toCReachability: pp_tun_ctrl_reachability {
+    var toCReachability: pp_reachability {
 #if os(Android)
-        pp_tun_ctrl_reachability(
+        pp_reachability(
             reachable: isReachable,
             network_handle: networkHandle ?? 0
         )
 #else
-        pp_tun_ctrl_reachability(
+        pp_reachability(
             reachable: isReachable
         )
 #endif

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -109,8 +109,8 @@ public final class NativeTunnelController: TunnelController, Sendable {
         return VirtualTunnelInterface(ctx, tun: tun, maxReadLength: maxReadLength)
     }
 
-    public func configureSockets(with descriptors: [UInt64]) {
-        descriptors
+    public func configureSockets(with descriptors: [UInt64]) throws {
+        let result = descriptors
             .map(Int32.init)
             .withUnsafeBufferPointer { fds in
                 if let info = reachabilityInfo?.toCReachability {
@@ -121,6 +121,9 @@ public final class NativeTunnelController: TunnelController, Sendable {
                     pp_tun_ctrl_configure_sockets(ref, nil, fds.baseAddress, fds.count)
                 }
             }
+        guard result else {
+            throw PartoutError(.socketConfiguration)
+        }
     }
 
     public func reportSnapshot(_ snapshot: TunnelSnapshot) {
@@ -286,7 +289,13 @@ extension NativeTunnelController {
                 self?.reachabilityInfo
             },
             configureSocket: { [weak self] fd in
-                self?.configureSockets(with: [fd])
+                do {
+                    try self?.configureSockets(with: [fd])
+                    return true
+                } catch {
+                    pp_log(self?.ctx ?? .global, .core, .fault, "Unable to configure sockets: \(error)")
+                    return false
+                }
             }
         )
     }

--- a/Sources/PartoutCore/Connection/BSDSocket.swift
+++ b/Sources/PartoutCore/Connection/BSDSocket.swift
@@ -206,11 +206,11 @@ private extension BSDSocket {
                         Int32(timeout),
                         &cReachability,
                         { ctx, fd in
-                            guard let ctx else { return }
+                            guard let ctx else { return true }
                             let cfg = Unmanaged<SocketConfigurator>
                                 .fromOpaque(ctx)
                                 .takeUnretainedValue()
-                            cfg.configureSocket(fd)
+                            return cfg.configureSocket(fd)
                         },
                         cConfigurator
                     )

--- a/Sources/PartoutCore/Connection/BSDSocket.swift
+++ b/Sources/PartoutCore/Connection/BSDSocket.swift
@@ -24,6 +24,8 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
 
     private let betterPathStream: PassthroughStream<Void>
 
+    private let configurator: SocketConfigurator?
+
     private let socketHandle: SocketHandle
 
     private let readQueue: DispatchQueue
@@ -47,6 +49,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
         endpoint: ExtendedEndpoint,
         timeout: Int,
         betterPathFactory: BetterPathStreamFactory,
+        configurator: SocketConfigurator?,
         socketBufferLength: Int = 1 * 1024 * 1024,
         maxReadLength: Int = 128 * 1024,
         maxReadBatchPackets: Int = 256,
@@ -55,7 +58,8 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
         let sock = try await openSocket(
             endpoint: endpoint,
             timeout: timeout,
-            socketBufferLength: socketBufferLength
+            socketBufferLength: socketBufferLength,
+            configurator: configurator
         )
         let closesOnEmptyRead = endpoint.plainSocketType == .tcp
         let betterPathStream = betterPathFactory.newStream()
@@ -69,7 +73,8 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
             maxReadBatchPackets: maxReadBatchPackets,
             maxReadBatchBytes: maxReadBatchBytes,
             betterPathFactory: betterPathFactory,
-            betterPathStream: betterPathStream
+            betterPathStream: betterPathStream,
+            configurator: configurator
         )
     }
 
@@ -83,7 +88,8 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
         maxReadBatchPackets: Int,
         maxReadBatchBytes: Int,
         betterPathFactory: BetterPathStreamFactory,
-        betterPathStream: PassthroughStream<Void>
+        betterPathStream: PassthroughStream<Void>,
+        configurator: SocketConfigurator?
     ) {
         self.ctx = ctx
         self.endpoint = endpoint
@@ -94,6 +100,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
         self.maxReadBatchBytes = max(maxReadLength, maxReadBatchBytes)
         self.betterPathFactory = betterPathFactory
         self.betterPathStream = betterPathStream
+        self.configurator = configurator
         socketHandle = SocketHandle(sock: sock)
         let queueLabelContext = socketHandle.fileDescriptor?.description ?? "unknown"
         readQueue = DispatchQueue(
@@ -160,6 +167,7 @@ public final class BSDSocket: LinkInterface, SocketIOInterface, @unchecked Senda
             endpoint: endpoint,
             timeout: connectTimeout,
             betterPathFactory: betterPathFactory,
+            configurator: configurator,
             maxReadLength: maxReadLength
         )
     }
@@ -173,18 +181,38 @@ private extension BSDSocket {
     static func openSocket(
         endpoint: ExtendedEndpoint,
         timeout: Int,
-        socketBufferLength: Int
+        socketBufferLength: Int,
+        configurator: SocketConfigurator?
     ) async throws -> pp_socket {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let blocking = endpoint.plainSocketType == .tcp
+
+                let reachability = configurator?.reachability()
+                var cReachability = pp_tun_ctrl_reachability()
+                cReachability.reachable = reachability?.isReachable ?? false
+#if os(Android)
+                cReachability.network_handle = reachability?.networkHandle ?? 0
+#endif
+                let cConfigurator = configurator.map {
+                    Unmanaged.passUnretained($0).toOpaque()
+                }
                 let newSock = endpoint.address.rawValue.withCString { cAddr in
                     pp_socket_open(
                         cAddr,
                         endpoint.socketProto,
                         endpoint.proto.port,
                         blocking,
-                        Int32(timeout)
+                        Int32(timeout),
+                        &cReachability,
+                        { ctx, fd in
+                            guard let ctx else { return }
+                            let cfg = Unmanaged<SocketConfigurator>
+                                .fromOpaque(ctx)
+                                .takeUnretainedValue()
+                            cfg.configureSocket(fd)
+                        },
+                        cConfigurator
                     )
                 }
                 guard let newSock else {

--- a/Sources/PartoutCore/Connection/BSDSocket.swift
+++ b/Sources/PartoutCore/Connection/BSDSocket.swift
@@ -189,7 +189,7 @@ private extension BSDSocket {
                 let blocking = endpoint.plainSocketType == .tcp
 
                 let reachability = configurator?.reachability()
-                var cReachability = pp_tun_ctrl_reachability()
+                var cReachability = pp_reachability()
                 cReachability.reachable = reachability?.isReachable ?? false
 #if os(Android)
                 cReachability.network_handle = reachability?.networkHandle ?? 0

--- a/Sources/PartoutCore/Connection/BSDSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/BSDSocketFactory.swift
@@ -8,15 +8,24 @@ public final class BSDSocketFactory: NetworkInterfaceFactory {
 
     private let betterPathFactory: BetterPathStreamFactory
 
+    private let configurator: SocketConfigurator?
+
     public init(
         _ ctx: PartoutLoggerContext,
-        betterPathFactory: BetterPathStreamFactory
+        betterPathFactory: BetterPathStreamFactory,
+        configurator: SocketConfigurator? = nil
     ) {
         self.ctx = ctx
         self.betterPathFactory = betterPathFactory
+        self.configurator = configurator
     }
 
     public func linkObserver(to endpoint: ExtendedEndpoint) -> LinkObserver {
-        BSDSocketObserver(ctx, endpoint: endpoint, betterPathFactory: betterPathFactory)
+        BSDSocketObserver(
+            ctx,
+            endpoint: endpoint,
+            betterPathFactory: betterPathFactory,
+            configurator: configurator
+        )
     }
 }

--- a/Sources/PartoutCore/Connection/BSDSocketObserver.swift
+++ b/Sources/PartoutCore/Connection/BSDSocketObserver.swift
@@ -12,17 +12,21 @@ public final class BSDSocketObserver: LinkObserver, @unchecked Sendable {
 
     private let betterPathFactory: BetterPathStreamFactory
 
+    private let configurator: SocketConfigurator?
+
     private let maxReadLength: Int
 
     public init(
         _ ctx: PartoutLoggerContext,
         endpoint: ExtendedEndpoint,
         betterPathFactory: BetterPathStreamFactory,
+        configurator: SocketConfigurator?,
         maxReadLength: Int = 128 * 1024
     ) {
         self.ctx = ctx
         self.endpoint = endpoint
         self.betterPathFactory = betterPathFactory
+        self.configurator = configurator
         self.maxReadLength = maxReadLength
     }
 
@@ -32,6 +36,7 @@ public final class BSDSocketObserver: LinkObserver, @unchecked Sendable {
             endpoint: endpoint,
             timeout: timeout,
             betterPathFactory: betterPathFactory,
+            configurator: configurator,
             maxReadLength: maxReadLength
         )
     }

--- a/Sources/PartoutCore/Connection/SocketConfigurator.swift
+++ b/Sources/PartoutCore/Connection/SocketConfigurator.swift
@@ -5,11 +5,11 @@
 /// Provides methods to configure sockets on a native platform.
 public final class SocketConfigurator: Sendable {
     public let reachability: @Sendable () -> ReachabilityInfo?
-    public let configureSocket: @Sendable (_ fd: UInt64) -> Void
+    public let configureSocket: @Sendable (_ fd: UInt64) -> Bool
 
     public init(
         reachability: @Sendable @escaping () -> ReachabilityInfo?,
-        configureSocket: @Sendable @escaping (_: UInt64) -> Void
+        configureSocket: @Sendable @escaping (_: UInt64) -> Bool
     ) {
         self.reachability = reachability
         self.configureSocket = configureSocket

--- a/Sources/PartoutCore/Connection/SocketConfigurator.swift
+++ b/Sources/PartoutCore/Connection/SocketConfigurator.swift
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+/// Provides methods to configure sockets on a native platform.
+public final class SocketConfigurator: Sendable {
+    public let reachability: @Sendable () -> ReachabilityInfo?
+    public let configureSocket: @Sendable (_ fd: UInt64) -> Void
+
+    public init(
+        reachability: @Sendable @escaping () -> ReachabilityInfo?,
+        configureSocket: @Sendable @escaping (_: UInt64) -> Void
+    ) {
+        self.reachability = reachability
+        self.configureSocket = configureSocket
+    }
+}

--- a/Sources/PartoutCore/Connection/TunnelController.swift
+++ b/Sources/PartoutCore/Connection/TunnelController.swift
@@ -6,7 +6,7 @@
 public protocol TunnelController: AnyObject, Sendable {
     func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface
 
-    func configureSockets(with descriptors: [UInt64])
+    func configureSockets(with descriptors: [UInt64]) throws
 
     func reportSnapshot(_ snapshot: TunnelSnapshot)
 

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -36,6 +36,7 @@ Given the main app and the daemon:
 - ``DataCount``
 - ``EndpointResolver``
 - ``NetworkInterfaceFactory``
+- ``SocketConfigurator``
 
 ### DNS resolution
 

--- a/Sources/PartoutCore/Partout+Core.swift
+++ b/Sources/PartoutCore/Partout+Core.swift
@@ -105,6 +105,9 @@ extension PartoutError.Code {
     /// Network is unreachable.
     public static let networkUnreachable = Self("networkUnreachable")
 
+    /// Native sockets could not be configured.
+    public static let socketConfiguration = Self("socketConfiguration")
+
     /// TUN device is not active.
     public static let tunNotActive = Self("tunNotActive")
 

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -10,6 +10,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* Network reachability. */
+typedef struct {
+    bool reachable;
+#if PARTOUT_ANDROID
+    uint64_t network_handle;
+#endif
+} pp_tun_ctrl_reachability;
+
 /* The available protocols. */
 typedef enum {
     PPSocketProtoTCP,
@@ -34,7 +42,10 @@ pp_socket _Nullable pp_socket_open(const char *_Nonnull ip_addr,
                                    pp_socket_proto proto,
                                    uint16_t port,
                                    bool blocking,
-                                   int timeout_ms);
+                                   int timeout_ms,
+                                   const pp_tun_ctrl_reachability *_Nullable info,
+                                   void (*_Nullable configure)(void *_Nullable ctx, uint64_t fd),
+                                   void *_Nullable configure_ctx);
 
 /* I/O. Returns PP_SOCKET_WOULD_BLOCK when a non-blocking operation would block. */
 int pp_socket_read(pp_socket _Nonnull sock,

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -44,7 +44,7 @@ pp_socket _Nullable pp_socket_open(const char *_Nonnull ip_addr,
                                    bool blocking,
                                    int timeout_ms,
                                    const pp_reachability *_Nullable info,
-                                   void (*_Nullable configure)(void *_Nullable ctx, uint64_t fd),
+                                   bool (*_Nullable configure)(void *_Nullable ctx, uint64_t fd),
                                    void *_Nullable configure_ctx);
 
 /* I/O. Returns PP_SOCKET_WOULD_BLOCK when a non-blocking operation would block. */

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -16,7 +16,7 @@ typedef struct {
 #if PARTOUT_ANDROID
     uint64_t network_handle;
 #endif
-} pp_tun_ctrl_reachability;
+} pp_reachability;
 
 /* The available protocols. */
 typedef enum {
@@ -43,7 +43,7 @@ pp_socket _Nullable pp_socket_open(const char *_Nonnull ip_addr,
                                    uint16_t port,
                                    bool blocking,
                                    int timeout_ms,
-                                   const pp_tun_ctrl_reachability *_Nullable info,
+                                   const pp_reachability *_Nullable info,
                                    void (*_Nullable configure)(void *_Nullable ctx, uint64_t fd),
                                    void *_Nullable configure_ctx);
 

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -29,7 +29,7 @@ const char *_Nullable pp_tun_name(const pp_tun _Nonnull tun);
 typedef struct {
     void *_Nullable ctx;
     void (*_Nonnull on_reachability)(void *_Nonnull ctx,
-                                     const pp_tun_ctrl_reachability *_Nonnull reachability);
+                                     const pp_reachability *_Nonnull reachability);
     void (*_Nonnull on_better_path)(void *_Nonnull ctx);
     char *_Nullable (*_Nonnull environment_value)(void *_Nonnull ctx, const char *_Nonnull key);
 } pp_tun_ctrl_delegate;
@@ -39,7 +39,7 @@ pp_tun _Nullable pp_tun_ctrl_set_tunnel(void *_Nullable ref,
                                         const char *_Nonnull uuid,
                                         const char *_Nullable info_json);
 void pp_tun_ctrl_configure_sockets(void *_Nullable ref,
-                                   const pp_tun_ctrl_reachability *_Nullable info,
+                                   const pp_reachability *_Nullable info,
                                    const int *_Nullable fds,
                                    const size_t fds_len);
 void pp_tun_ctrl_report_snapshot(void *_Nullable ref,

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "portable/conditionals.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "portable/common.h"
 #include "portable/socket.h"
@@ -38,7 +39,7 @@ void pp_tun_ctrl_set_delegate(void *_Nullable ref,
 pp_tun _Nullable pp_tun_ctrl_set_tunnel(void *_Nullable ref,
                                         const char *_Nonnull uuid,
                                         const char *_Nullable info_json);
-void pp_tun_ctrl_configure_sockets(void *_Nullable ref,
+bool pp_tun_ctrl_configure_sockets(void *_Nullable ref,
                                    const pp_reachability *_Nullable info,
                                    const int *_Nullable fds,
                                    const size_t fds_len);

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include "portable/common.h"
+#include "portable/socket.h"
 
 /* Opaque tun device. */
 typedef struct __pp_tun_struct *pp_tun;
@@ -26,12 +27,6 @@ const char *_Nullable pp_tun_name(const pp_tun _Nonnull tun);
 
 /* Tunnel controller. */
 typedef struct {
-    bool reachable;
-#if PARTOUT_ANDROID
-    uint64_t network_handle;
-#endif
-} pp_tun_ctrl_reachability;
-typedef struct {
     void *_Nullable ctx;
     void (*_Nonnull on_reachability)(void *_Nonnull ctx,
                                      const pp_tun_ctrl_reachability *_Nonnull reachability);
@@ -44,6 +39,7 @@ pp_tun _Nullable pp_tun_ctrl_set_tunnel(void *_Nullable ref,
                                         const char *_Nonnull uuid,
                                         const char *_Nullable info_json);
 void pp_tun_ctrl_configure_sockets(void *_Nullable ref,
+                                   const pp_tun_ctrl_reachability *_Nullable info,
                                    const int *_Nullable fds,
                                    const size_t fds_len);
 void pp_tun_ctrl_report_snapshot(void *_Nullable ref,

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -81,7 +81,10 @@ pp_socket pp_socket_open(const char *ip_addr,
                          pp_socket_proto proto,
                          uint16_t port,
                          bool blocking,
-                         int timeout_ms) {
+                         int timeout_ms,
+                         const pp_tun_ctrl_reachability *info,
+                         void (*configure)(void *ctx, uint64_t fd),
+                         void *configure_ctx) {
     int socktype = 0;
     struct addrinfo hints, *resolved = NULL;
     char port_str[16] = { 0 };
@@ -108,6 +111,9 @@ pp_socket pp_socket_open(const char *ip_addr,
         if (local_is_invalid_fd(new_fd)) {
             local_print_error("socket()");
             goto failure;
+        }
+        if (configure) {
+            configure(configure_ctx, new_fd);
         }
         if (local_connect_with_timeout(new_fd,
                                            (const struct sockaddr *)&numeric_addr,
@@ -137,7 +143,15 @@ pp_socket pp_socket_open(const char *ip_addr,
 #endif
 
     snprintf(port_str, sizeof(port_str), "%u", port);
+#if PARTOUT_ANDROID
+    if (info || info->network_handle <= 0) {
+        local_print_error("android_getaddrinfofornetwork(): missing network handle");
+        goto failure;
+    }
+    if (android_getaddrinfofornetwork(info->network_handle, ip_addr, port_str, &hints, &resolved) != 0) {
+#else
     if (getaddrinfo(ip_addr, port_str, &hints, &resolved) != 0) {
+#endif
         local_print_error("getaddrinfo()");
         goto failure;
     }
@@ -148,6 +162,9 @@ pp_socket pp_socket_open(const char *ip_addr,
         if (local_is_invalid_fd(new_fd)) {
             local_print_error("socket()");
             continue;
+        }
+        if (configure) {
+            configure(configure_ctx, new_fd);
         }
         const int ret = local_connect_with_timeout(new_fd,
                                                        p->ai_addr,

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -82,7 +82,7 @@ pp_socket pp_socket_open(const char *ip_addr,
                          uint16_t port,
                          bool blocking,
                          int timeout_ms,
-                         const pp_tun_ctrl_reachability *info,
+                         const pp_reachability *info,
                          void (*configure)(void *ctx, uint64_t fd),
                          void *configure_ctx) {
     int socktype = 0;

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -83,7 +83,7 @@ pp_socket pp_socket_open(const char *ip_addr,
                          bool blocking,
                          int timeout_ms,
                          const pp_reachability *info,
-                         void (*configure)(void *ctx, uint64_t fd),
+                         bool (*configure)(void *ctx, uint64_t fd),
                          void *configure_ctx) {
     int socktype = 0;
     struct addrinfo hints, *resolved = NULL;
@@ -113,7 +113,10 @@ pp_socket pp_socket_open(const char *ip_addr,
             goto failure;
         }
         if (configure) {
-            configure(configure_ctx, new_fd);
+            if (!configure(configure_ctx, new_fd)) {
+                local_print_error("configure()");
+                goto failure;
+            }
         }
         if (local_connect_with_timeout(new_fd,
                                            (const struct sockaddr *)&numeric_addr,
@@ -163,8 +166,9 @@ pp_socket pp_socket_open(const char *ip_addr,
             local_print_error("socket()");
             continue;
         }
-        if (configure) {
-            configure(configure_ctx, new_fd);
+        if (!configure(configure_ctx, new_fd)) {
+            local_print_error("configure()");
+            goto failure;
         }
         const int ret = local_connect_with_timeout(new_fd,
                                                        p->ai_addr,

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -112,11 +112,9 @@ pp_socket pp_socket_open(const char *ip_addr,
             local_print_error("socket()");
             goto failure;
         }
-        if (configure) {
-            if (!configure(configure_ctx, new_fd)) {
-                local_print_error("configure()");
-                goto failure;
-            }
+        if (configure && !configure(configure_ctx, new_fd)) {
+            local_print_error("configure()");
+            goto failure;
         }
         if (local_connect_with_timeout(new_fd,
                                            (const struct sockaddr *)&numeric_addr,
@@ -166,7 +164,7 @@ pp_socket pp_socket_open(const char *ip_addr,
             local_print_error("socket()");
             continue;
         }
-        if (!configure(configure_ctx, new_fd)) {
+        if (configure && !configure(configure_ctx, new_fd)) {
             local_print_error("configure()");
             goto failure;
         }

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -144,7 +144,7 @@ pp_socket pp_socket_open(const char *ip_addr,
 
     snprintf(port_str, sizeof(port_str), "%u", port);
 #if PARTOUT_ANDROID
-    if (info || info->network_handle <= 0) {
+    if (!info || info->network_handle <= 0) {
         local_print_error("android_getaddrinfofornetwork(): missing network handle");
         goto failure;
     }

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -82,6 +82,7 @@ pp_socket pp_socket_open(const char *ip_addr,
                          uint16_t port,
                          bool blocking,
                          int timeout_ms) {
+    int socktype = 0;
     struct addrinfo hints, *resolved = NULL;
     char port_str[16] = { 0 };
     os_socket_fd new_fd = local_invalid_fd();
@@ -91,27 +92,19 @@ pp_socket pp_socket_open(const char *ip_addr,
         goto failure;
     }
 
-    pp_zero(&hints, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;   // IPv4 or IPv6
     switch (proto) {
         case PPSocketProtoTCP:
-            ipproto = IPPROTO_TCP;
-            hints.ai_socktype = SOCK_STREAM;
+            socktype = SOCK_STREAM;
             break;
         case PPSocketProtoUDP:
-            ipproto = IPPROTO_UDP;
-            hints.ai_socktype = SOCK_DGRAM;
+            socktype = SOCK_DGRAM;
             break;
     }
-    hints.ai_protocol = ipproto;
-#ifdef AI_NUMERICSERV
-    hints.ai_flags = AI_NUMERICSERV;
-#endif
 
     struct sockaddr_storage numeric_addr;
     os_socklen_t numeric_addrlen = 0;
     if (local_parse_numeric_addr(ip_addr, port, &numeric_addr, &numeric_addrlen)) {
-        new_fd = socket(numeric_addr.ss_family, hints.ai_socktype, ipproto);
+        new_fd = socket(numeric_addr.ss_family, socktype, ipproto);
         if (local_is_invalid_fd(new_fd)) {
             local_print_error("socket()");
             goto failure;
@@ -126,6 +119,22 @@ pp_socket pp_socket_open(const char *ip_addr,
         }
         return pp_socket_create(new_fd);
     }
+
+    pp_zero(&hints, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;   // IPv4 or IPv6
+    hints.ai_socktype = socktype;
+    switch (proto) {
+        case PPSocketProtoTCP:
+            ipproto = IPPROTO_TCP;
+            break;
+        case PPSocketProtoUDP:
+            ipproto = IPPROTO_UDP;
+            break;
+    }
+    hints.ai_protocol = ipproto;
+#ifdef AI_NUMERICSERV
+    hints.ai_flags = AI_NUMERICSERV;
+#endif
 
     snprintf(port_str, sizeof(port_str), "%u", port);
     if (getaddrinfo(ip_addr, port_str, &hints, &resolved) != 0) {

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -175,13 +175,15 @@ cleanup:
     return tun_impl;
 }
 
-void pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_reachability *info,
+bool pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_configure_sockets(%p)", jni_ref);
-    if (!fds || fds_len == 0) return;
+    if (!fds || fds_len == 0) return false;
 
-    PP_JNI_ATTACH_OR_RETURN_VOID(env);
+    PP_JNI_ATTACH_OR_RETURN(env, false);
+
+    bool success = false;
 
     if (info && info->network_handle > 0) {
         for (int i = 0; i < fds_len; ++i) {
@@ -220,10 +222,14 @@ void pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_reachability *info,
         goto cleanup;
     }
 
+    success = true;
+
 cleanup:
     if (j_fds != NULL) (*env)->DeleteLocalRef(env, j_fds);
     if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
     PP_JNI_DETACH(env);
+
+    return success;
 }
 
 void pp_tun_ctrl_report_snapshot(void *_Nullable ref,

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -188,7 +188,7 @@ bool pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_reachability *info,
     if (info && info->network_handle > 0) {
         for (int i = 0; i < fds_len; ++i) {
             if (android_setsocknetwork(info->network_handle, fds[i]) != 0) {
-                pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_configure_sockets(), android_setsocknetwork(%d)", i);
+                pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_configure_sockets(), android_setsocknetwork(%d)", fds[i]);
                 goto cleanup;
             }
         }

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -175,7 +175,7 @@ cleanup:
     return tun_impl;
 }
 
-void pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_tun_ctrl_reachability *info,
+void pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_configure_sockets(%p)", jni_ref);
@@ -343,7 +343,7 @@ Java_io_partout_vpn_JNITunnelController_onNativeReachabilityUpdate(JNIEnv *env,
     (void)thiz;
     pp_tun_ctrl_delegate *ctrl_delegate = (pp_tun_ctrl_delegate *)(intptr_t)delegate;
     if (!ctrl_delegate || !ctrl_delegate->ctx) return;
-    const pp_tun_ctrl_reachability reachability = {
+    const pp_reachability reachability = {
         .reachable = net_handle != -1,
         .network_handle = net_handle
     };

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -175,12 +175,22 @@ cleanup:
     return tun_impl;
 }
 
-void pp_tun_ctrl_configure_sockets(void *jni_ref, const int *fds, const size_t fds_len) {
+void pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_tun_ctrl_reachability *info,
+                                   const int *fds, const size_t fds_len) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_configure_sockets(%p)", jni_ref);
     if (!fds || fds_len == 0) return;
 
     PP_JNI_ATTACH_OR_RETURN_VOID(env);
+
+    if (info && info->network_handle > 0) {
+        for (int i = 0; i < fds_len; ++i) {
+            if (android_setsocknetwork(info->network_handle, fds[i]) != 0) {
+                pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_configure_sockets(), android_setsocknetwork(%d)", i);
+                goto cleanup;
+            }
+        }
+    }
 
     jclass cls = NULL;
     jmethodID method = NULL;

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -163,8 +163,10 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const int *fds, const size_t fds_len) {
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+                                   const int *fds, const size_t fds_len) {
     (void)ref;
+    (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_darwin: ctrl_configure_sockets(%p)", ref);

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -163,7 +163,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -163,13 +163,14 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
+bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_darwin: ctrl_configure_sockets(%p)", ref);
+    return true;
 }
 
 void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -55,13 +55,14 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
+bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_configure_sockets(%p)", ref);
+    return true;
 }
 
 void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -55,8 +55,10 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const int *fds, const size_t fds_len) {
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+                                   const int *fds, const size_t fds_len) {
     (void)ref;
+    (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_configure_sockets(%p)", ref);

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -55,7 +55,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -107,7 +107,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -107,8 +107,10 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const int *fds, const size_t fds_len) {
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+                                   const int *fds, const size_t fds_len) {
     (void)ref;
+    (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: ctrl_configure_sockets(%p)", ref);

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -107,13 +107,14 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
+bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: ctrl_configure_sockets(%p)", ref);
+    return true;
 }
 
 void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -227,8 +227,10 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const int *fds, const size_t fds_len) {
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+                                   const int *fds, const size_t fds_len) {
     (void)ref;
+    (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: ctrl_configure_sockets(%p)", ref);

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -227,13 +227,14 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
+bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;
     (void)fds;
     (void)fds_len;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: ctrl_configure_sockets(%p)", ref);
+    return true;
 }
 
 void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -227,7 +227,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     return NULL;
 }
 
-void pp_tun_ctrl_configure_sockets(void *ref, const pp_tun_ctrl_reachability *info,
+void pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
                                    const int *fds, const size_t fds_len) {
     (void)ref;
     (void)info;

--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1.swift
@@ -195,7 +195,6 @@ extension _OpenVPNConnectionV1: OpenVPNSessionDelegate {
         )
         builder.print()
         do {
-            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             let tunnelInterface = try await controller.setTunnelSettings(
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -184,7 +184,6 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
         )
         builder.print()
         do {
-            controller.configureSockets(with: remoteFd.map { [$0] } ?? [])
             let tunnelInterface = try await controller.setTunnelSettings(
                 with: TunnelRemoteInfo(
                     originalModuleId: moduleId,

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -9,7 +9,7 @@ protocol WireGuardAdapterDelegate: AnyObject, Sendable {
 
     func adapterShouldSetNetworkSettings(_ adapter: WireGuardAdapter, settings: TunnelRemoteInfo) async throws -> IOInterface
 
-    func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [UInt64])
+    func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [UInt64]) throws
 
     func adapterShouldClearNetworkSettings(_ adapter: WireGuardAdapter, tunnel: IOInterface) async
 }
@@ -185,7 +185,11 @@ actor WireGuardAdapter {
         reachabilityTask = Task { [weak self] in
             for await isReachable in stream {
                 guard !Task.isCancelled else { return }
-                await self?.didUpdateReachable(isReachable: isReachable)
+                do {
+                    try await self?.didUpdateReachable(isReachable: isReachable)
+                } catch {
+                    self?.logHandler(.error, "Unable to update reachability: \(error)")
+                }
             }
         }
     }
@@ -247,18 +251,18 @@ actor WireGuardAdapter {
 #if os(iOS)
         backend.disableSomeRoamingForBrokenMobileSemantics(handle)
 #endif
-        configureSockets(for: handle)
+        try configureSockets(for: handle)
         return handle
     }
 
     @discardableResult
-    private func configureSockets(for handle: Int32) -> [UInt64] {
+    private func configureSockets(for handle: Int32) throws -> [UInt64] {
         let descriptors = backend.socketDescriptors(handle)
             .filter { $0 >= 0 }
             .map { UInt64($0) }
         pp_log(ctx, .wireguard, .info, "Socket descriptors: \(descriptors)")
         guard !descriptors.isEmpty else { return [] }
-        delegate?.adapterShouldConfigureSockets(self, descriptors: descriptors)
+        try delegate?.adapterShouldConfigureSockets(self, descriptors: descriptors)
         return descriptors
     }
 
@@ -274,14 +278,14 @@ actor WireGuardAdapter {
         )
     }
 
-    private func didUpdateReachable(isReachable: Bool) async {
+    private func didUpdateReachable(isReachable: Bool) async throws {
 //        logHandler(.verbose, "Network change detected with \(path.status) route and interface order \(path.availableInterfaces)")
         logHandler(.verbose, "Network change detected, reachable: \(isReachable)")
 
 #if os(macOS)
         if case .started(let handle, _) = self.state {
             await backend.bumpSocketsAndWait(handle)
-            configureSockets(for: handle)
+            try configureSockets(for: handle)
         }
 #else
         switch state {
@@ -292,7 +296,7 @@ actor WireGuardAdapter {
                 backend.setConfig(handle, settings: wgConfig)
                 backend.disableSomeRoamingForBrokenMobileSemantics(handle)
                 await backend.bumpSocketsAndWait(handle)
-                configureSockets(for: handle)
+                try configureSockets(for: handle)
             } else {
                 logHandler(.verbose, "Connectivity offline, pausing backend.")
 

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -154,8 +154,8 @@ extension _WireGuardConnectionV2: WireGuardAdapterDelegate {
         }
     }
 
-    nonisolated func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [UInt64]) {
-        controller.configureSockets(with: descriptors)
+    nonisolated func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [UInt64]) throws {
+        try controller.configureSockets(with: descriptors)
     }
 
     func adapterShouldClearNetworkSettings(_ adapter: WireGuardAdapter, tunnel: IOInterface) async {

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -72,6 +72,7 @@ set(PARTOUT_SOURCES
 ./PartoutCore/Connection/SharedTunnelEnvironment.swift
 ./PartoutCore/Connection/SimpleConnectionDaemon.swift
 ./PartoutCore/Connection/SimpleDNSResolver.swift
+./PartoutCore/Connection/SocketConfigurator.swift
 ./PartoutCore/Connection/SocketHandle.swift
 ./PartoutCore/Connection/SocketIOInterface.swift
 ./PartoutCore/Connection/StaticTunnelEnvironment.swift


### PR DESCRIPTION
Decouple the VPN implementations from the responsibility of configuring the sockets, because this is a platform concern.

Steps:

- Build SocketConfigurator from NativeTunnelController, which provides reachability info and a native callback to configure a socket descriptor for the underlying platform
- Hook the configurator into the BSDSocketFactory flow, so that the sockets configuration now happens exactly between the socket() and connect() syscalls

This order is a strict requirement on Android, where the socket configuration in `pp_tun_ctrl_configure_sockets` consists of:

- android_setsocknetwork() (NDK)
- protect() (JNI)

and must happen before connect().