### PR TITLE
Core: Defer tun lifecycle to VirtualTunnelInterface

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -152,12 +152,8 @@ public final class NativeTunnelController: TunnelController, Sendable {
 //        tun.deviceName
         await tunnel.shutdown()
 
-        // Release tun implementation if necessary
-        let controllerRef = ref
-        Task.detached { [tunnel] in
-            await tunnel.waitUntilIdle()
-            pp_tun_ctrl_clear_tunnel(controllerRef, tunnel.tun)
-        }
+        // Wrap up clear in native layer
+        pp_tun_ctrl_clear_tunnel(ref, withKillSwitch)
     }
 
     public func setReasserting(_ reasserting: Bool) {

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -150,6 +150,9 @@ public final class NativeTunnelController: TunnelController, Sendable {
         }
         // FIXME: #188, revert settings (record)
 //        tun.deviceName
+
+        // Make sure to issue the tunnel shutdown and wait for it to
+        // finish to prevent races on VirtualTunnelInterface.deinit
         await tunnel.shutdown()
 
         // Wrap up clear in native layer

--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -46,7 +46,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 
     private let activeLock: SemaphoreMutex
 
-    // WARNING: tun is NOT owned
+    // WARNING: tun ownership is transferred
     init(
         _ ctx: PartoutLoggerContext,
         tun: pp_tun,
@@ -75,6 +75,9 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
 
     deinit {
         pp_log(ctx, .core, .debug, "Deinit VirtualTunnelInterface")
+
+        // WARNING: Must wait for shutdown() before deinit
+        pp_tun_free(tun)
     }
 
     nonisolated var fileDescriptor: UInt64? {
@@ -212,9 +215,8 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         guard shouldShutdown else { return }
         pp_log(ctx, .core, .info, "Shut down TUN")
         pp_tun_shutdown(tun)
-    }
 
-    func waitUntilIdle() async {
+        // Wait for shutdown
         await readQueue.waitUntilIdle()
         await writeQueue.waitUntilIdle()
     }

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -19,6 +19,7 @@ typedef struct __pp_tun_struct *pp_tun;
 int pp_tun_read(const pp_tun _Nonnull tun, uint8_t *_Nonnull dst, size_t dst_len);
 int pp_tun_write(const pp_tun _Nonnull tun, const uint8_t *_Nonnull src, size_t src_len);
 void pp_tun_shutdown(const pp_tun _Nonnull tun);
+void pp_tun_free(pp_tun _Nonnull tun);
 
 /* Return the file descriptor or -1 if none. */
 int pp_tun_fd(const pp_tun _Nonnull tun);
@@ -45,7 +46,6 @@ bool pp_tun_ctrl_configure_sockets(void *_Nullable ref,
                                    const size_t fds_len);
 void pp_tun_ctrl_report_snapshot(void *_Nullable ref,
                                  const char *_Nonnull snapshot_json);
-void pp_tun_ctrl_clear_tunnel(void *_Nullable ref,
-                              pp_tun _Nullable tun_impl);
+void pp_tun_ctrl_clear_tunnel(void *_Nullable ref, bool kill_switch);
 void pp_tun_ctrl_cancel_tunnel(void *_Nullable ref,
                                const char *_Nullable error_message);

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -21,6 +21,12 @@ struct __pp_tun_struct {
     int fd;
 };
 
+void pp_tun_free(pp_tun tun) {
+    if (!tun) return;
+    pp_tun_shutdown(tun);
+    free(tun);
+}
+
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
     if (!tun || tun->fd < 0) return -1;
     return read(tun->fd, dst, dst_len);
@@ -72,7 +78,7 @@ static const kotlin_sig sig_ctrl_onSnapshot = {
 };
 static const kotlin_sig sig_ctrl_clearTunnel = {
     "clearTunnel",
-    "()V"
+    "(Z)V"
 };
 static const kotlin_sig sig_ctrl_cancelTunnel = {
     "cancelTunnel",
@@ -273,11 +279,8 @@ cleanup:
 }
 
 // Balance with pp_tun_ctrl_set_tunnel
-void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
+void pp_tun_ctrl_clear_tunnel(void *jni_ref, bool kill_switch) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_clear_tunnel(%p)", jni_ref);
-    if (!tun_impl) return;
-    pp_tun_shutdown(tun_impl);
-    free(tun_impl);
 
     PP_JNI_ATTACH_OR_RETURN_VOID(env);
 
@@ -294,7 +297,7 @@ void pp_tun_ctrl_clear_tunnel(void *jni_ref, pp_tun tun_impl) {
         pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_android: ctrl_clear_tunnel(), NULL method");
         goto cleanup;
     }
-    (*env)->CallVoidMethod(env, jni_ref, method);
+    (*env)->CallVoidMethod(env, jni_ref, method, kill_switch);
     if ((*env)->ExceptionCheck(env)) {
         (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -76,7 +76,6 @@ failure:
     return NULL;
 }
 
-static
 void pp_tun_free(pp_tun tun) {
     if (!tun) return;
     pp_tun_shutdown(tun);
@@ -179,9 +178,9 @@ void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_darwin: ctrl_report_snapshot(%p)", ref);
 }
 
-void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
+void pp_tun_ctrl_clear_tunnel(void *ref, bool kill_switch) {
     (void)ref;
-    (void)tun_impl;
+    (void)kill_switch;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_darwin: ctrl_clear_tunnel(%p)", ref);
 }
 

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -8,6 +8,11 @@
 #include "portable/tun.h"
 
 #if !PARTOUT_HAS_TUN
+void pp_tun_free(pp_tun tun) {
+    (void)tun;
+    pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: free()");
+}
+
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
     (void)tun;
     (void)dst;
@@ -71,9 +76,9 @@ void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_report_snapshot(%p)", ref);
 }
 
-void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
+void pp_tun_ctrl_clear_tunnel(void *ref, bool kill_switch) {
     (void)ref;
-    (void)tun_impl;
+    (void)kill_switch;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_dummy: ctrl_clear_tunnel(%p)", ref);
 }
 

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -60,7 +60,6 @@ failure:
     return NULL;
 }
 
-static
 void pp_tun_free(pp_tun tun) {
     if (!tun) return;
     pp_tun_shutdown(tun);
@@ -123,9 +122,9 @@ void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: ctrl_report_snapshot(%p)", ref);
 }
 
-void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
+void pp_tun_ctrl_clear_tunnel(void *ref, bool kill_switch) {
     (void)ref;
-    (void)tun_impl;
+    (void)kill_switch;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: ctrl_clear_tunnel(%p)", ref);
 }
 

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -131,7 +131,6 @@ failure:
     return NULL;
 }
 
-static
 void pp_tun_free(pp_tun tun) {
     if (!tun) return;
     pp_tun_shutdown(tun);
@@ -243,9 +242,9 @@ void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: ctrl_report_snapshot(%p)", ref);
 }
 
-void pp_tun_ctrl_clear_tunnel(void *ref, pp_tun tun_impl) {
+void pp_tun_ctrl_clear_tunnel(void *ref, bool kill_switch) {
     (void)ref;
-    (void)tun_impl;
+    (void)kill_switch;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: ctrl_clear_tunnel(%p)", ref);
 }
 

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -32,7 +32,7 @@ interface TunnelController {
     fun setTunnel(infoJSON: String): Int
     fun configureSockets(fds: IntArray)
     fun onSnapshot(snapshotJSON: String)
-    fun clearTunnel()
+    fun clearTunnel(killSwitch: Boolean)
     fun cancelTunnel(errorCode: String?)
 
     // Kotlin -> JNI
@@ -180,7 +180,7 @@ class JNITunnelController(
         return@synchronized
     }
 
-    override fun clearTunnel() = synchronized(lock) {
+    override fun clearTunnel(killSwitch: Boolean) = synchronized(lock) {
         if (isNativeCancelled) { return }
         return@synchronized
     }


### PR DESCRIPTION
Be more robust about pp_tun lifecycle because it's spread over too many places:

- Transfer pp_tun ownership to VirtualTunnelInterface, do the native pp_tun_free() on deinit
- Just make sure that NativeTunnelController shuts down VirtualTunnelInterface before deinit

At the native layer:

- Stop passing now irrelevant pp_tun to ctrl_clear_tunnel()
- Propagate kill switch flag instead, let the native layer decide what to do with it