### PR TITLE
WireGuard: Redo DNS resolution after tunnel setup

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -47,7 +47,7 @@ public final class NativeTunnelController: TunnelController, Sendable {
 
         // Native resolver requires network handle on Android
         dns = SimpleDNSResolver {
-            POSIXDNSStrategy(hostname: $0)
+            POSIXDNSStrategy(hostname: $0, flags: $1)
         }
 
         var delegate = pp_tun_ctrl_delegate(
@@ -181,9 +181,15 @@ extension NativeTunnelController: DNSResolver {
         reachabilityHolder.get()
     }
 
-    public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
+    public func resolve(
+        _ hostname: String,
+        flags: Set<DNSResolverFlag>,
+        reachability: ReachabilityInfo?,
+        timeout: Int
+    ) async throws -> [DNSRecord] {
         try await dns.resolve(
             hostname,
+            flags: flags,
             reachability: reachability ?? reachabilityInfo,
             timeout: timeout
         )

--- a/Sources/PartoutCore/Connection/DNSResolver.swift
+++ b/Sources/PartoutCore/Connection/DNSResolver.swift
@@ -39,7 +39,7 @@ public protocol DNSResolver: AnyObject, Sendable {
 }
 
 extension DNSResolver {
-    public func resolve(_ hostname: String, flags: Set<DNSResolverFlag>, timeout: Int) async throws -> [DNSRecord] {
+    public func resolve(_ hostname: String, flags: Set<DNSResolverFlag> = [], timeout: Int) async throws -> [DNSRecord] {
         try await resolve(hostname, flags: flags, reachability: nil, timeout: timeout)
     }
 }

--- a/Sources/PartoutCore/Connection/DNSResolver.swift
+++ b/Sources/PartoutCore/Connection/DNSResolver.swift
@@ -4,7 +4,6 @@
 
 /// Result of ``DNSResolver/resolve(_:timeout:)``.
 public struct DNSRecord: Hashable, Codable, Sendable {
-
     /// Address string.
     public let address: String
 
@@ -17,9 +16,13 @@ public struct DNSRecord: Hashable, Codable, Sendable {
     }
 }
 
+/// Flags for ``DNSResolver``.
+public enum DNSResolverFlag: Sendable {
+    case allAddresses
+}
+
 /// Performs DNS resolution.
 public protocol DNSResolver: AnyObject, Sendable {
-
     /**
      Resolves a hostname asynchronously.
 
@@ -29,13 +32,14 @@ public protocol DNSResolver: AnyObject, Sendable {
      */
     func resolve(
         _ hostname: String,
+        flags: Set<DNSResolverFlag>,
         reachability: ReachabilityInfo?,
         timeout: Int
     ) async throws -> [DNSRecord]
 }
 
 extension DNSResolver {
-    public func resolve(_ hostname: String, timeout: Int) async throws -> [DNSRecord] {
-        try await resolve(hostname, reachability: nil, timeout: timeout)
+    public func resolve(_ hostname: String, flags: Set<DNSResolverFlag>, timeout: Int) async throws -> [DNSRecord] {
+        try await resolve(hostname, flags: flags, reachability: nil, timeout: timeout)
     }
 }

--- a/Sources/PartoutCore/Connection/EndpointResolver+Resolvable.swift
+++ b/Sources/PartoutCore/Connection/EndpointResolver+Resolvable.swift
@@ -43,7 +43,6 @@ extension EndpointResolver {
         func resolved(with dns: DNSResolver, timeout: Int) async throws -> Self {
             let records = try await dns.resolve(
                 originalEndpoint.address.rawValue,
-                flags: [],
                 timeout: timeout
             )
             pp_log(ctx, .core, .notice, "DNS resolved addresses: \(records.map { $0.address.asSensitiveAddress(ctx) })")

--- a/Sources/PartoutCore/Connection/EndpointResolver+Resolvable.swift
+++ b/Sources/PartoutCore/Connection/EndpointResolver+Resolvable.swift
@@ -41,7 +41,11 @@ extension EndpointResolver {
         }
 
         func resolved(with dns: DNSResolver, timeout: Int) async throws -> Self {
-            let records = try await dns.resolve(originalEndpoint.address.rawValue, timeout: timeout)
+            let records = try await dns.resolve(
+                originalEndpoint.address.rawValue,
+                flags: [],
+                timeout: timeout
+            )
             pp_log(ctx, .core, .notice, "DNS resolved addresses: \(records.map { $0.address.asSensitiveAddress(ctx) })")
             return with(newResolvedEndpoints: originalEndpoint.unrolledEndpoints(ctx, records: records))
         }

--- a/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
+++ b/Sources/PartoutCore/Connection/POSIXDNSStrategy.swift
@@ -7,10 +7,12 @@ internal import _PartoutCore_C
 /// Implementation of ``SimpleDNSStrategy`` with the POSIX C library.
 public actor POSIXDNSStrategy: SimpleDNSStrategy {
     private let hostname: String
+    private let flags: Set<DNSResolverFlag>
     private var task: Task<[DNSRecord]?, Error>?
 
-    public init(hostname: String) {
+    public init(hostname: String, flags: Set<DNSResolverFlag>) {
         self.hostname = hostname
+        self.flags = flags
     }
 
     public func startResolution() async throws {
@@ -22,9 +24,14 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
             records = try await task.value
         } else {
             let hostname = self.hostname
+            let flags = self.flags
             let reachabilityCopy = reachability
             let newTask = Task.detached { @Sendable in
-                try Self.resolveAndBlock(hostname: hostname, reachability: reachabilityCopy)
+                try Self.resolveAndBlock(
+                    hostname: hostname,
+                    flags: flags,
+                    reachability: reachabilityCopy
+                )
             }
             task = newTask
             records = try await newTask.value
@@ -42,7 +49,7 @@ public actor POSIXDNSStrategy: SimpleDNSStrategy {
 }
 
 private extension POSIXDNSStrategy {
-    static func resolveAndBlock(hostname: String, reachability: ReachabilityInfo?) throws -> [DNSRecord]? {
+    static func resolveAndBlock(hostname: String, flags: Set<DNSResolverFlag>, reachability: ReachabilityInfo?) throws -> [DNSRecord]? {
 #if os(Android)
         guard let networkHandle = reachability?.networkHandle else {
             throw PartoutError(.networkUnreachable)
@@ -51,9 +58,8 @@ private extension POSIXDNSStrategy {
 #endif
         var hints = addrinfo()
 #if canImport(Darwin)
-        // We set this to ALL so that we get v4 addresses even on DNS64 networks
-        // However, DNS breaks on Android when AI_ALL + AF_UNSPEC is set
-        hints.ai_flags = AI_ALL
+        // Beware that DNS breaks on Android when AI_ALL + AF_UNSPEC is set
+        hints.ai_flags = flags.contains(.allAddresses) ? AI_ALL : 0
 #endif
         hints.ai_family = AF_UNSPEC // IPv4/IPv6
         // XXX: Choosing either would dedup results

--- a/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
+++ b/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
@@ -13,9 +13,19 @@ public protocol SimpleDNSStrategy: Sendable {
 
 /// ``DNSResolver`` with support for timeout cancellation.
 public actor SimpleDNSResolver: DNSResolver {
+    private struct PendingKey: Hashable, Sendable {
+        let hostname: String
+        let flags: Set<DNSResolverFlag>
+
+        init(_ hostname: String, _ flags: Set<DNSResolverFlag>) {
+            self.hostname = hostname
+            self.flags = flags
+        }
+    }
+
     private let strategy: (String, Set<DNSResolverFlag>) -> SimpleDNSStrategy
 
-    private var pendingResolutions: [String: Task<[DNSRecord], Error>]
+    private var pendingResolutions: [PendingKey: Task<[DNSRecord], Error>]
 
     public init(strategy: @escaping (String, Set<DNSResolverFlag>) -> SimpleDNSStrategy) {
         self.strategy = strategy
@@ -28,7 +38,8 @@ public actor SimpleDNSResolver: DNSResolver {
         reachability: ReachabilityInfo?,
         timeout: Int
     ) async throws -> [DNSRecord] {
-        if let pendingResolutionTask = pendingResolutions[hostname] {
+        let key = PendingKey(hostname, flags)
+        if let pendingResolutionTask = pendingResolutions[key] {
             return try await pendingResolutionTask.value
         }
         let newStrategy = strategy(hostname, flags)
@@ -40,9 +51,9 @@ public actor SimpleDNSResolver: DNSResolver {
                 timeout: timeout
             )
         }
-        pendingResolutions[hostname] = resolutionTask
+        pendingResolutions[key] = resolutionTask
         defer {
-            pendingResolutions.removeValue(forKey: hostname)
+            pendingResolutions.removeValue(forKey: key)
         }
         return try await resolutionTask.value
     }

--- a/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
+++ b/Sources/PartoutCore/Connection/SimpleDNSResolver.swift
@@ -13,20 +13,25 @@ public protocol SimpleDNSStrategy: Sendable {
 
 /// ``DNSResolver`` with support for timeout cancellation.
 public actor SimpleDNSResolver: DNSResolver {
-    private let strategy: (String) -> SimpleDNSStrategy
+    private let strategy: (String, Set<DNSResolverFlag>) -> SimpleDNSStrategy
 
     private var pendingResolutions: [String: Task<[DNSRecord], Error>]
 
-    public init(strategy: @escaping (String) -> SimpleDNSStrategy) {
+    public init(strategy: @escaping (String, Set<DNSResolverFlag>) -> SimpleDNSStrategy) {
         self.strategy = strategy
         pendingResolutions = [:]
     }
 
-    public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
+    public func resolve(
+        _ hostname: String,
+        flags: Set<DNSResolverFlag>,
+        reachability: ReachabilityInfo?,
+        timeout: Int
+    ) async throws -> [DNSRecord] {
         if let pendingResolutionTask = pendingResolutions[hostname] {
             return try await pendingResolutionTask.value
         }
-        let newStrategy = strategy(hostname)
+        let newStrategy = strategy(hostname, flags)
         let resolutionTask = Task {
             try await newStrategy.startResolution()
             return try await Self.waitForResolution(

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -42,6 +42,7 @@ Given the main app and the daemon:
 
 - ``DNSRecord``
 - ``DNSResolver``
+- ``DNSResolverFlag``
 - ``POSIXDNSStrategy``
 - ``ReachabilityInfo``
 - ``SimpleDNSResolver``

--- a/Sources/PartoutCore/Testing/MockDNSResolver.swift
+++ b/Sources/PartoutCore/Testing/MockDNSResolver.swift
@@ -10,7 +10,7 @@ public final class MockDNSResolver: DNSResolver, @unchecked Sendable {
     public init() {
     }
 
-    public func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
+    public func resolve(_ hostname: String, flags: Set<DNSResolverFlag>, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
         if let error {
             throw error
         }

--- a/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/V1/_OpenVPNConnectionV1+Default.swift
@@ -18,7 +18,7 @@ extension _OpenVPNConnectionV1 {
         // Hardcode portable implementations
         let prng = PlatformPRNG()
         let dns = SimpleDNSResolver {
-            POSIXDNSStrategy(hostname: $0)
+            POSIXDNSStrategy(hostname: $0, flags: $1)
         }
         let sessionFactory = {
             try await OpenVPNSession(

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2+Default.swift
@@ -23,7 +23,7 @@ extension _OpenVPNConnectionV2 {
         // Hardcode portable implementations
         let prng = PlatformPRNG()
         let dns = parameters.controller as? DNSResolver ?? SimpleDNSResolver {
-            POSIXDNSStrategy(hostname: $0)
+            POSIXDNSStrategy(hostname: $0, flags: $1)
         }
         let sessionFactory = {
             try await OpenVPNSession(

--- a/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/Configuration+Resolve.swift
@@ -47,14 +47,16 @@ extension WireGuard.Configuration {
 
     func resolvePeers(
         dns: DNSResolver?,
+        flags: Set<DNSResolverFlag>,
         timeout: Int,
         logHandler: @escaping WireGuardAdapter.LogHandler
     ) async throws -> [Endpoint: Endpoint] {
         let resolver = dns ?? SimpleDNSResolver {
-            POSIXDNSStrategy(hostname: $0)
+            POSIXDNSStrategy(hostname: $0, flags: $1)
         }
         return try await resolvePeers(
             resolver: resolver,
+            flags: flags,
             timeout: timeout,
             logHandler: logHandler
         )
@@ -62,6 +64,7 @@ extension WireGuard.Configuration {
 
     func resolvePeers(
         resolver: DNSResolver,
+        flags: Set<DNSResolverFlag>,
         timeout: Int,
         logHandler: @escaping WireGuardAdapter.LogHandler
     ) async throws -> [Endpoint: Endpoint] {
@@ -78,6 +81,7 @@ extension WireGuard.Configuration {
                         }
                         let resolvedRecords = try await resolver.resolve(
                             endpoint.address.rawValue,
+                            flags: flags,
                             timeout: timeout
                         )
                         var currentResolved: [Endpoint] = []

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -50,7 +50,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
         let resolutionMap: [Endpoint: Endpoint]
         do {
             // We set this to zero so that we actually resolve this using DNS64
-            resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
+            resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
         } catch {
             logHandler(.error, "Unable to resolve peer endpoints: \(error.localizedDescription)")
             return wgSettings
@@ -98,7 +98,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
         }
 
         // We set this to zero so that we actually resolve this using DNS64
-        let resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
+        let resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
 
         for peer in tunnelConfiguration.peers {
             let publicKey = try peer.publicKey.rawValue.hexStringFromBase64()

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -39,7 +39,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
     }
 
     func cacheResolvedPeerEndpoints(logHandler: @escaping WireGuardAdapter.LogHandler) async throws {
-        // We set this to ALL so that we get v4 addresses even on DNS64 networks
+        // We set .allAddresses so that we get v4 addresses even on DNS64 networks
         _ = try await resolvePeers(dns: dns, flags: [.allAddresses], logHandler: logHandler)
     }
 
@@ -49,7 +49,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
 
         let resolutionMap: [Endpoint: Endpoint]
         do {
-            // We set this to zero so that we actually resolve this using DNS64
+            // We omit flags so that we actually resolve this using DNS64
             resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
         } catch {
             logHandler(.error, "Unable to resolve peer endpoints: \(error.localizedDescription)")
@@ -97,7 +97,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
             wgSettings.append("replace_peers=true\n")
         }
 
-        // We set this to zero so that we actually resolve this using DNS64
+        // We omit flags so that we actually resolve this using DNS64
         let resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
 
         for peer in tunnelConfiguration.peers {

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -50,7 +50,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
         let resolutionMap: [Endpoint: Endpoint]
         do {
             // We set this to zero so that we actually resolve this using DNS64
-            resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
+            resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
         } catch {
             logHandler(.error, "Unable to resolve peer endpoints: \(error.localizedDescription)")
             return wgSettings
@@ -98,7 +98,7 @@ final class TunnelRemoteInfoGenerator: Sendable {
         }
 
         // We set this to zero so that we actually resolve this using DNS64
-        let resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
+        let resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
 
         for peer in tunnelConfiguration.peers {
             let publicKey = try peer.publicKey.rawValue.hexStringFromBase64()

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -38,6 +38,11 @@ final class TunnelRemoteInfoGenerator: Sendable {
         await resolvedEndpoints.reset()
     }
 
+    @discardableResult
+    func resolvePeerEndpoints(logHandler: @escaping WireGuardAdapter.LogHandler) async throws -> [Endpoint: Endpoint] {
+        try await resolvePeers(dns: dns, logHandler: logHandler)
+    }
+
     // Only updates peer endpoints
     func endpointUapiConfiguration(logHandler: @escaping WireGuardAdapter.LogHandler) async -> String {
         var wgSettings = ""

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -38,10 +38,9 @@ final class TunnelRemoteInfoGenerator: Sendable {
         await resolvedEndpoints.reset()
     }
 
-    @discardableResult
-    func resolvePeerEndpoints(logHandler: @escaping WireGuardAdapter.LogHandler) async throws -> [Endpoint: Endpoint] {
+    func cacheResolvedPeerEndpoints(logHandler: @escaping WireGuardAdapter.LogHandler) async throws {
         // We set this to ALL so that we get v4 addresses even on DNS64 networks
-        try await resolvePeers(dns: dns, flags: [.allAddresses], logHandler: logHandler)
+        _ = try await resolvePeers(dns: dns, flags: [.allAddresses], logHandler: logHandler)
     }
 
     // Only updates peer endpoints

--- a/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/TunnelRemoteInfoGenerator.swift
@@ -40,7 +40,8 @@ final class TunnelRemoteInfoGenerator: Sendable {
 
     @discardableResult
     func resolvePeerEndpoints(logHandler: @escaping WireGuardAdapter.LogHandler) async throws -> [Endpoint: Endpoint] {
-        try await resolvePeers(dns: dns, logHandler: logHandler)
+        // We set this to ALL so that we get v4 addresses even on DNS64 networks
+        try await resolvePeers(dns: dns, flags: [.allAddresses], logHandler: logHandler)
     }
 
     // Only updates peer endpoints
@@ -49,7 +50,8 @@ final class TunnelRemoteInfoGenerator: Sendable {
 
         let resolutionMap: [Endpoint: Endpoint]
         do {
-            resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
+            // We set this to zero so that we actually resolve this using DNS64
+            resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
         } catch {
             logHandler(.error, "Unable to resolve peer endpoints: \(error.localizedDescription)")
             return wgSettings
@@ -96,7 +98,8 @@ final class TunnelRemoteInfoGenerator: Sendable {
             wgSettings.append("replace_peers=true\n")
         }
 
-        let resolutionMap = try await resolvePeers(dns: dns, logHandler: logHandler)
+        // We set this to zero so that we actually resolve this using DNS64
+        let resolutionMap = try await resolvePeers(dns: dns, flags: [], logHandler: logHandler)
 
         for peer in tunnelConfiguration.peers {
             let publicKey = try peer.publicKey.rawValue.hexStringFromBase64()
@@ -189,12 +192,17 @@ final class TunnelRemoteInfoGenerator: Sendable {
 }
 
 private extension TunnelRemoteInfoGenerator {
-    func resolvePeers(dns: DNSResolver?, logHandler: @escaping WireGuardAdapter.LogHandler) async throws -> [Endpoint: Endpoint] {
+    func resolvePeers(
+        dns: DNSResolver?,
+        flags: Set<DNSResolverFlag>,
+        logHandler: @escaping WireGuardAdapter.LogHandler
+    ) async throws -> [Endpoint: Endpoint] {
         if let resolutionMap = await resolvedEndpoints.value {
             return resolutionMap
         }
         let resolutionMap = try await tunnelConfiguration.resolvePeers(
             dns: dns,
+            flags: flags,
             timeout: dnsTimeout,
             logHandler: logHandler
         )

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -145,10 +145,12 @@ actor WireGuardAdapter {
         }
         do {
             let settingsGenerator = makeSettingsGenerator(with: tunnelConfiguration)
-            let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
+            // Keep first DNS before tunnel settings, but DNS64 re-resolution after.
+            try await settingsGenerator.resolvePeerEndpoints(logHandler: logHandler)
             try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
                 moduleId: moduleId
             ))
+            let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
             let handle = try startWireGuardBackend(wgConfig: wgConfig)
             state = .started(handle, settingsGenerator)
         } catch {
@@ -342,13 +344,22 @@ actor WireGuardAdapter {
         logHandler(.verbose, "Connectivity online, resuming backend.")
         do {
             await settingsGenerator.resetResolvedEndpoints()
-            let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
+            // Keep first DNS before tunnel settings, but DNS64 re-resolution after.
+            try await settingsGenerator.resolvePeerEndpoints(logHandler: logHandler)
             guard isTemporarilyShutdown(with: settingsGenerator) else {
                 return
             }
             try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
                 moduleId: moduleId
             ))
+            guard isTemporarilyShutdown(with: settingsGenerator) else {
+                if let tunnel {
+                    await delegate?.adapterShouldClearNetworkSettings(self, tunnel: tunnel)
+                    self.tunnel = nil
+                }
+                return
+            }
+            let wgConfig = try await settingsGenerator.uapiConfiguration(logHandler: logHandler)
             guard isTemporarilyShutdown(with: settingsGenerator) else {
                 if let tunnel {
                     await delegate?.adapterShouldClearNetworkSettings(self, tunnel: tunnel)

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -145,7 +145,6 @@ actor WireGuardAdapter {
         }
         do {
             let settingsGenerator = makeSettingsGenerator(with: tunnelConfiguration)
-            // Keep first DNS before tunnel settings, but DNS64 re-resolution after.
             try await settingsGenerator.resolvePeerEndpoints(logHandler: logHandler)
             try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
                 moduleId: moduleId
@@ -344,7 +343,6 @@ actor WireGuardAdapter {
         logHandler(.verbose, "Connectivity online, resuming backend.")
         do {
             await settingsGenerator.resetResolvedEndpoints()
-            // Keep first DNS before tunnel settings, but DNS64 re-resolution after.
             try await settingsGenerator.resolvePeerEndpoints(logHandler: logHandler)
             guard isTemporarilyShutdown(with: settingsGenerator) else {
                 return

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -145,7 +145,7 @@ actor WireGuardAdapter {
         }
         do {
             let settingsGenerator = makeSettingsGenerator(with: tunnelConfiguration)
-            try await settingsGenerator.resolvePeerEndpoints(logHandler: logHandler)
+            try await settingsGenerator.cacheResolvedPeerEndpoints(logHandler: logHandler)
             try await setNetworkSettings(settingsGenerator.generateRemoteInfo(
                 moduleId: moduleId
             ))
@@ -343,7 +343,7 @@ actor WireGuardAdapter {
         logHandler(.verbose, "Connectivity online, resuming backend.")
         do {
             await settingsGenerator.resetResolvedEndpoints()
-            try await settingsGenerator.resolvePeerEndpoints(logHandler: logHandler)
+            try await settingsGenerator.cacheResolvedPeerEndpoints(logHandler: logHandler)
             guard isTemporarilyShutdown(with: settingsGenerator) else {
                 return
             }

--- a/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
+++ b/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
@@ -9,7 +9,7 @@ struct SimpleDNSResolverTests {
     @Test
     func givenResolver_whenResolveBeforeTimeout_thenReturnsResolvedRecords() async throws {
         let records = [DNSRecord(address: "1.2.3.4", isIPv6: false)]
-        let sut = SimpleDNSResolver { _ in
+        let sut = SimpleDNSResolver { _, _ in
             MockStrategy(records: records, delay: 100)
         }
         let result = try await sut.resolve("foobar.com", timeout: 500)
@@ -19,7 +19,7 @@ struct SimpleDNSResolverTests {
     @Test
     func givenResolver_whenResolveAfterTimeout_thenFailsWithTimeout() async throws {
         let records = [DNSRecord(address: "1.2.3.4", isIPv6: false)]
-        let sut = SimpleDNSResolver { _ in
+        let sut = SimpleDNSResolver { _, _ in
             MockStrategy(records: records, delay: 500)
         }
         do {

--- a/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
+++ b/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
@@ -34,7 +34,7 @@ struct SimpleDNSResolverTests {
 
     @Test
     func givenResolverIgnoringCancellation_whenTimeout_thenStillReturns() async throws {
-        let sut = SimpleDNSResolver { _ in
+        let sut = SimpleDNSResolver { _, _ in
             CancellationIgnoringStrategy()
         }
         do {

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -114,8 +114,48 @@ struct TunnelRemoteInfoGeneratorTests {
         let requestedHostnamesAfterUAPI = await dns.requestedHostnames
 
         #expect(requestedHostnamesAfterResolve == [sourceEndpoint.address.rawValue])
+        #expect(await dns.requestedFlags == [[.allAddresses]])
         #expect(requestedHostnamesAfterUAPI == requestedHostnamesAfterResolve)
         #expect(uapiConfiguration.contains("endpoint=\(ipv4Endpoint.wgRepresentation)"))
+    }
+
+    @Test
+    func givenUncachedEndpoint_whenGeneratingUAPIConfigurations_thenResolveWithoutAllAddresses() async throws {
+        let sourceEndpoint = try Endpoint("foobar.com", 51830)
+        let ipv4Endpoint = try Endpoint("77.160.28.16", sourceEndpoint.port)
+        let configuration = try makeConfiguration(endpoint: sourceEndpoint.rawValue)
+        let fullConfigurationDNS = RecordingDNSResolver()
+        await fullConfigurationDNS.setResolvedRecords([
+            DNSRecord(address: ipv4Endpoint.address.rawValue, isIPv6: false)
+        ], for: sourceEndpoint.address.rawValue)
+        let endpointUpdateDNS = RecordingDNSResolver()
+        await endpointUpdateDNS.setResolvedRecords([
+            DNSRecord(address: ipv4Endpoint.address.rawValue, isIPv6: false)
+        ], for: sourceEndpoint.address.rawValue)
+
+        let fullConfigurationGenerator = TunnelRemoteInfoGenerator(
+            .global,
+            tunnelConfiguration: configuration,
+            dns: fullConfigurationDNS,
+            dnsTimeout: 1000
+        )
+        let endpointUpdateGenerator = TunnelRemoteInfoGenerator(
+            .global,
+            tunnelConfiguration: configuration,
+            dns: endpointUpdateDNS,
+            dnsTimeout: 1000
+        )
+
+        let uapiConfiguration = try await fullConfigurationGenerator.uapiConfiguration(logHandler: { _, _ in })
+        let endpointUapiConfiguration = await endpointUpdateGenerator.endpointUapiConfiguration(logHandler: { _, _ in })
+
+        #expect(await fullConfigurationDNS.requestedHostnames == [sourceEndpoint.address.rawValue])
+        #expect(await fullConfigurationDNS.requestedFlags == [[]])
+        #expect(uapiConfiguration.contains("endpoint=\(ipv4Endpoint.wgRepresentation)"))
+
+        #expect(await endpointUpdateDNS.requestedHostnames == [sourceEndpoint.address.rawValue])
+        #expect(await endpointUpdateDNS.requestedFlags == [[]])
+        #expect(endpointUapiConfiguration.contains("endpoint=\(ipv4Endpoint.wgRepresentation)"))
     }
 
     @Test
@@ -230,17 +270,24 @@ private actor RecordingDNSResolver: DNSResolver {
 
     private var hostnames: [String] = []
 
+    private var flags: [Set<DNSResolverFlag>] = []
+
     func setResolvedRecords(_ records: [DNSRecord], for hostname: String) {
         resolvedRecords[hostname] = records
     }
 
     func resolve(_ hostname: String, flags: Set<DNSResolverFlag>, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
         hostnames.append(hostname)
+        self.flags.append(flags)
         return resolvedRecords[hostname] ?? []
     }
 
     var requestedHostnames: [String] {
         hostnames
+    }
+
+    var requestedFlags: [Set<DNSResolverFlag>] {
+        flags
     }
 }
 

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -89,6 +89,34 @@ struct TunnelRemoteInfoGeneratorTests {
     }
 
     @Test
+    func givenPreResolvedEndpoint_whenGeneratingUAPIConfiguration_thenUsesCachedDNS() async throws {
+        let sourceEndpoint = try Endpoint("foobar.com", 51830)
+        let ipv4Endpoint = try Endpoint("77.160.28.16", sourceEndpoint.port)
+        let configuration = try makeConfiguration(endpoint: sourceEndpoint.rawValue)
+        let dns = RecordingDNSResolver()
+        await dns.setResolvedRecords([
+            DNSRecord(address: ipv4Endpoint.address.rawValue, isIPv6: false)
+        ], for: sourceEndpoint.address.rawValue)
+
+        let sut = TunnelRemoteInfoGenerator(
+            .global,
+            tunnelConfiguration: configuration,
+            dns: dns,
+            dnsTimeout: 1000
+        )
+
+        _ = try await sut.resolvePeerEndpoints(logHandler: { _, _ in })
+        let requestedHostnamesAfterResolve = await dns.requestedHostnames
+
+        let uapiConfiguration = try await sut.uapiConfiguration(logHandler: { _, _ in })
+        let requestedHostnamesAfterUAPI = await dns.requestedHostnames
+
+        #expect(requestedHostnamesAfterResolve == [sourceEndpoint.address.rawValue])
+        #expect(requestedHostnamesAfterUAPI == requestedHostnamesAfterResolve)
+        #expect(uapiConfiguration.contains("endpoint=\(ipv4Endpoint.wgRepresentation)"))
+    }
+
+    @Test
     func givenCachedResolution_whenGeneratingEndpointUpdate_thenDoesNotResolveAgainUntilReset() async throws {
         let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
         let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="

--- a/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
+++ b/Tests/PartoutWireGuardTests/TunnelRemoteInfoGeneratorTests.swift
@@ -57,6 +57,7 @@ struct TunnelRemoteInfoGeneratorTests {
 
         let map = try await configuration.resolvePeers(
             resolver: dns,
+            flags: [],
             timeout: 1000,
             logHandler: { _, _ in }
         )
@@ -79,6 +80,7 @@ struct TunnelRemoteInfoGeneratorTests {
 
         let map = try await configuration.resolvePeers(
             resolver: dns,
+            flags: [],
             timeout: 1000,
             logHandler: { _, _ in }
         )
@@ -105,7 +107,7 @@ struct TunnelRemoteInfoGeneratorTests {
             dnsTimeout: 1000
         )
 
-        _ = try await sut.resolvePeerEndpoints(logHandler: { _, _ in })
+        _ = try await sut.cacheResolvedPeerEndpoints(logHandler: { _, _ in })
         let requestedHostnamesAfterResolve = await dns.requestedHostnames
 
         let uapiConfiguration = try await sut.uapiConfiguration(logHandler: { _, _ in })
@@ -232,7 +234,7 @@ private actor RecordingDNSResolver: DNSResolver {
         resolvedRecords[hostname] = records
     }
 
-    func resolve(_ hostname: String, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
+    func resolve(_ hostname: String, flags: Set<DNSResolverFlag>, reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
         hostnames.append(hostname)
         return resolvedRecords[hostname] ?? []
     }


### PR DESCRIPTION
Match v1 behavior. Perform the first resolution with AI_ALL, then discover more endpoints by redoing the resolution inside the tunnel without hints.

WARNING: POSIXDNSStrategy goes back to `ai_hints = 0` by default. Regression in #391.