### PR TITLE
Android: Fix disconnection on profile switch

### DIFF
--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -38,7 +38,6 @@ class PartoutVpnServiceRuntime(
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
     private var isRunning = false
-    @Volatile private var isStoppingTunnel = false
 
     // C/JNI controller
     private var controller: JNITunnelController? = null
@@ -136,9 +135,9 @@ class PartoutVpnServiceRuntime(
         engine.onSnapshot(snapshot)
     }
 
-    override fun disconnect() {
-        if (isStoppingTunnel) { return }
+    override fun disconnect(controller: JNITunnelController) {
         launchCommand {
+            if (controller != this.controller) { return@launchCommand }
             stopTunnel()
             stopService()
         }
@@ -175,16 +174,16 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to stop VPN daemon", e)
         } finally {
             controller?.stopObserving()
-            isStoppingTunnel = true
-            try {
-                controller?.cancelTunnel(null)
-            } finally {
-                isStoppingTunnel = false
-            }
+            controller?.cancelTunnel(null)
             controller = null
         }
         isRunning = false
         snapshotEmitter.emitFinal()
+    }
+
+    private fun disconnect() = launchCommand {
+        stopTunnel()
+        stopService()
     }
 
     private fun stopService() {

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -38,6 +38,7 @@ class PartoutVpnServiceRuntime(
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
     private var isRunning = false
+    @Volatile private var isStoppingTunnel = false
 
     // C/JNI controller
     private var controller: JNITunnelController? = null
@@ -135,9 +136,12 @@ class PartoutVpnServiceRuntime(
         engine.onSnapshot(snapshot)
     }
 
-    override fun disconnect() = launchCommand {
-        stopTunnel()
-        stopService()
+    override fun disconnect() {
+        if (isStoppingTunnel) { return }
+        launchCommand {
+            stopTunnel()
+            stopService()
+        }
     }
     //endregion
 
@@ -171,7 +175,12 @@ class PartoutVpnServiceRuntime(
             Log.e(logTag, "Unable to stop VPN daemon", e)
         } finally {
             controller?.stopObserving()
-            controller?.cancelTunnel(null)
+            isStoppingTunnel = true
+            try {
+                controller?.cancelTunnel(null)
+            } finally {
+                isStoppingTunnel = false
+            }
             controller = null
         }
         isRunning = false

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -135,12 +135,10 @@ class PartoutVpnServiceRuntime(
         engine.onSnapshot(snapshot)
     }
 
-    override fun disconnect(controller: JNITunnelController) {
-        launchCommand {
-            if (controller != this.controller) { return@launchCommand }
-            stopTunnel()
-            stopService()
-        }
+    override fun disconnect(controller: JNITunnelController) = launchCommand {
+        if (controller != this.controller) { return@launchCommand }
+        stopTunnel()
+        stopService()
     }
     //endregion
 

--- a/cross/android/io/partout/vpn/JNITunnelController.kt
+++ b/cross/android/io/partout/vpn/JNITunnelController.kt
@@ -44,7 +44,7 @@ interface TunnelController {
 
 interface TunnelControllerDelegate {
     fun sendSnapshot(snapshot: TunnelSnapshot)
-    fun disconnect()
+    fun disconnect(controller: JNITunnelController)
 }
 
 class JNITunnelController(
@@ -259,7 +259,7 @@ class JNITunnelController(
         }
 
         // Signal disconnection to delegate (runtime)
-        delegate.disconnect()
+        delegate.disconnect(this)
         return@synchronized
     }
 


### PR DESCRIPTION
Connecting to profile B while profile A is connected is still interpreted as "stop service", because the runtime is unable to tell what profile we're disconnecting from.

Rather than calling the raw disconnect(), which we must restrict to the manual stop intent, let JNITunnelController delegate disconnect(this) to the runtime, so that we only shut down the service if the call comes from the active controller.