### PR TITLE
Core: Use consistent fn/ctx order in C functions

### DIFF
--- a/Sources/PartoutCore_C/include/tls/tls.h
+++ b/Sources/PartoutCore_C/include/tls/tls.h
@@ -49,8 +49,8 @@ pp_tls_options *pp_tls_options_create(int sec_level,
                                       const char *_Nullable cert_pem,
                                       const char *_Nullable key_pem,
                                       const char *_Nullable hostname,
-                                      void *_Nullable ctx,
-                                      void (*on_verify_failure)(void *_Nullable ctx));
+                                      void (*on_verify_failure)(void *_Nullable ctx),
+                                      void *_Nullable ctx);
 
 void pp_tls_options_free(pp_tls_options *opt);
 

--- a/Sources/PartoutCore_C/tls_options.c
+++ b/Sources/PartoutCore_C/tls_options.c
@@ -15,8 +15,8 @@ pp_tls_options *pp_tls_options_create(int sec_level,
                                       const char *_Nullable cert_pem,
                                       const char *_Nullable key_pem,
                                       const char *_Nullable hostname,
-                                      void *ctx,
-                                      void (*on_verify_failure)(void *ctx)) {
+                                      void (*on_verify_failure)(void *ctx),
+                                      void *ctx) {
     pp_assert(ca_path && on_verify_failure);
 
     pp_tls_options *opt = pp_alloc(sizeof(pp_tls_options));

--- a/Sources/PartoutOpenVPNConnection/Internal/TLSWrapper+Native.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/TLSWrapper+Native.swift
@@ -60,14 +60,14 @@ private final class NativeTLSWrapper: TLSProtocol {
             certPEM,
             keyPEM,
             hostname,
-            Unmanaged.passUnretained(didFailVerification).toOpaque(),
             { ctx in
                 guard let ctx else { return }
                 let stream = Unmanaged<PassthroughStream<Void>>
                     .fromOpaque(ctx)
                     .takeUnretainedValue()
                 stream.send()
-            }
+            },
+            Unmanaged.passUnretained(didFailVerification).toOpaque()
         )
         var error = PPTLSErrorNone
         guard let tls = pp_tls_create(options, &error) else {

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
@@ -20,7 +20,7 @@ final class WireGuardBackend: @unchecked Sendable {
     }
 
     func setLogger(context: UnsafeMutableRawPointer?, logger_fn: LoggerCallback?) {
-        pp_wg_set_logger(context, logger_fn)
+        pp_wg_set_logger(logger_fn, context)
     }
 
 #if os(Windows)

--- a/Sources/PartoutWireGuardConnection_C/include/wireguard/wireguard.h
+++ b/Sources/PartoutWireGuardConnection_C/include/wireguard/wireguard.h
@@ -14,7 +14,7 @@ int pp_wg_init();
 typedef void (*pp_wg_logger_fn)(void *context, int level, const char *msg);
 
 const char *pp_wg_version();
-void pp_wg_set_logger(void *context, pp_wg_logger_fn logger_fn);
+void pp_wg_set_logger(pp_wg_logger_fn logger_fn, void *context);
 #if PARTOUT_WINDOWS
 int pp_wg_turn_on(const char *settings, const char *ifname);
 #else

--- a/Sources/PartoutWireGuardConnection_C/wireguard.c
+++ b/Sources/PartoutWireGuardConnection_C/wireguard.c
@@ -24,7 +24,7 @@ const char *pp_wg_version() {
     return wgVersion();
 }
 
-void pp_wg_set_logger(void *context, pp_wg_logger_fn logger_fn) {
+void pp_wg_set_logger(pp_wg_logger_fn logger_fn, void *context) {
     return wgSetLogger(context, logger_fn);
 }
 


### PR DESCRIPTION
- pp_tls_options_create
- pp_wg_set_logger