### PR TITLE
Core: Implement fd muxing with kqueue/epoll

### DIFF
--- a/Examples/Sources/test-posix-socket/main.swift
+++ b/Examples/Sources/test-posix-socket/main.swift
@@ -30,7 +30,8 @@ func tryTCPConnection() async throws {
     let observer = BSDSocketObserver(
         .global,
         endpoint: endpoint,
-        betterPathFactory: DummyFactory()
+        betterPathFactory: DummyFactory(),
+        configurator: nil
     )
     let sut = try await observer.waitForActivity(timeout: 5000)
 

--- a/Examples/Sources/test-wintun/main.c
+++ b/Examples/Sources/test-wintun/main.c
@@ -10,7 +10,7 @@
 
 int main() {
     puts("Hello");
-    pp_tun tun = pp_tun_create("00000000-00000000-00000000-00000000", NULL);
+    pp_tun tun = pp_tun_open("00000000-00000000-00000000-00000000");
     Sleep(1000 * 1000); // 1000 seconds
     return 0;
 }

--- a/Sources/PartoutCore_C/include/module.modulemap
+++ b/Sources/PartoutCore_C/include/module.modulemap
@@ -1,6 +1,7 @@
 module _PartoutCore_C {
     header "portable/common.h"
     header "portable/endian.h"
+    header "portable/mux.h"
     header "portable/network.h"
     header "portable/prng.h"
     header "portable/socket.h"

--- a/Sources/PartoutCore_C/include/portable/mux.h
+++ b/Sources/PartoutCore_C/include/portable/mux.h
@@ -23,6 +23,5 @@ void pp_mux_set_on_readable(pp_mux mux, void (*callback)(void *ctx, int fd), voi
 void pp_mux_set_on_writable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx);
 int pp_mux_wait(pp_mux mux);
 bool pp_mux_wake(pp_mux mux);
-void pp_mux_stop(pp_mux mux);
 
 #pragma clang assume_nonnull end

--- a/Sources/PartoutCore_C/include/portable/mux.h
+++ b/Sources/PartoutCore_C/include/portable/mux.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#pragma once
+#include "portable/conditionals.h"
+
+#include <stdbool.h>
+#include "portable/common.h"
+
+#pragma clang assume_nonnull begin
+
+typedef struct __pp_mux *pp_mux;
+
+pp_mux _Nullable pp_mux_create(int num);
+void pp_mux_free(pp_mux mux);
+
+bool pp_mux_add(pp_mux mux, int fd);
+bool pp_mux_set_write(pp_mux mux, int fd, bool enable);
+void pp_mux_set_on_readable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx);
+void pp_mux_set_on_writable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx);
+int pp_mux_wait(pp_mux mux);
+bool pp_mux_wake(pp_mux mux);
+void pp_mux_stop(pp_mux mux);
+
+#pragma clang assume_nonnull end

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -18,11 +18,28 @@
 /* Opaque tun device. */
 typedef struct __pp_tun_struct *pp_tun;
 
+extern const int PP_TUN_WOULD_BLOCK;
+
+#if !PARTOUT_WINDOWS
+/* With manual file descriptor. */
+pp_tun pp_tun_create(int fd);
+static inline bool pp_tun_would_block() {
+    return (errno == EAGAIN || errno == EWOULDBLOCK);
+}
+#endif
+
 /* Platform-specific implementations. */
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len);
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len);
 void pp_tun_shutdown(const pp_tun tun);
-void pp_tun_free(pp_tun tun);
+void pp_tun_free_and_close(pp_tun tun, bool and_close);
+
+static inline void pp_tun_release(pp_tun tun) {
+    pp_tun_free_and_close(tun, false);
+}
+static inline void pp_tun_free(pp_tun tun) {
+    pp_tun_free_and_close(tun, true);
+}
 
 /* Return the file descriptor or -1 if none. */
 int pp_tun_fd(const pp_tun tun);

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -29,6 +29,7 @@ static inline bool pp_tun_would_block() {
 #endif
 
 /* Platform-specific implementations. */
+pp_tun _Nullable pp_tun_open(const char *uuid);
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len);
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len);
 void pp_tun_shutdown(const pp_tun tun);

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -7,13 +7,13 @@
 #include "portable/mux.h"
 #include <errno.h>
 
-#define PP_MUX_WAKE_ID 1
-
 #if PARTOUT_APPLE
 #include <sys/types.h>
 #include <sys/event.h>
 #include <sys/time.h>
 #include <unistd.h>
+
+#define PP_MUX_WAKE_ID 1
 
 struct __pp_mux {
     int handle;

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include "portable/mux.h"
+#include <errno.h>
+
+#define PP_MUX_WAKE_ID 1
+
+#if PARTOUT_APPLE
+#include <sys/types.h>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+struct __pp_mux {
+    int handle;
+    struct kevent *events;
+    int events_len;
+    void (*on_readable)(void *ctx, int fd);
+    void (*on_writable)(void *ctx, int fd);
+    void *read_ctx;
+    void *write_ctx;
+};
+
+pp_mux pp_mux_create(int num) {
+    int handle = kqueue();
+    if (handle < 0) return NULL;
+    pp_mux mux = pp_alloc(sizeof(*mux));
+    mux->handle = handle;
+    const int max_events = 1 + 2 * num;
+    mux->events = pp_alloc(max_events * sizeof(struct kevent));
+    mux->events_len = max_events;
+
+    /* EV_CLEAR resets the fd after wake delivery. */
+    struct kevent ev;
+    EV_SET(&ev, PP_MUX_WAKE_ID, EVFILT_USER, EV_ADD | EV_CLEAR, 0, 0, NULL);
+    if (kevent(mux->handle, &ev, 1, NULL, 0, NULL) != 0) {
+        pp_mux_free(mux);
+        return NULL;
+    }
+
+    return mux;
+}
+
+void pp_mux_free(pp_mux mux) {
+    if (!mux) return;
+    close(mux->handle);
+    pp_free(mux->events);
+    pp_free(mux);
+}
+
+bool pp_mux_add(pp_mux mux, int fd) {
+    if (!mux) return false;
+    struct kevent ev;
+    EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0, 0);
+    return kevent(mux->handle, &ev, 1, NULL, 0, NULL) == 0;
+}
+
+bool pp_mux_set_write(pp_mux mux, int fd, bool enable) {
+    if (!mux) return false;
+    struct kevent ev;
+    EV_SET(&ev, fd, EVFILT_WRITE, enable ? EV_ADD : EV_DELETE, 0, 0, 0);
+    const int ret = kevent(mux->handle, &ev, 1, NULL, 0, NULL);
+    if (ret < 0) {
+        /* Ignore failed deletion. */
+        if (!enable && errno == ENOENT) return true;
+        return false;
+    }
+    return true;
+}
+
+void pp_mux_set_on_readable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx) {
+    if (!mux) return;
+    mux->on_readable = callback;
+    mux->read_ctx = ctx;
+}
+
+void pp_mux_set_on_writable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx) {
+    if (!mux) return;
+    mux->on_writable = callback;
+    mux->write_ctx = ctx;
+}
+
+int pp_mux_wait(pp_mux mux) {
+    if (!mux) return -1;
+    const int num = kevent(mux->handle, NULL, 0, mux->events, mux->events_len, NULL);
+    for (int i = 0; i < num; ++i) {
+        const struct kevent *ev = mux->events + i;
+        const int fd = (int)ev->ident;
+        if (ev->filter == EVFILT_READ) {
+            if (ev->flags & EV_EOF) {
+                struct kevent changes[2];
+                EV_SET(&changes[0], fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+                EV_SET(&changes[1], fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
+                kevent(mux->handle, changes, 2, NULL, 0, NULL);
+                // FIXME: ###, Report EOF
+                continue;
+            }
+            if (mux->on_readable) {
+                mux->on_readable(mux->read_ctx, fd);
+            }
+        } else if (ev->filter == EVFILT_WRITE) {
+            if (mux->on_writable) {
+                mux->on_writable(mux->write_ctx, fd);
+            }
+        } else if (ev->filter == EVFILT_USER && ev->ident == PP_MUX_WAKE_ID) {
+            continue;
+        }
+    }
+    return num;
+}
+
+bool pp_mux_wake(pp_mux mux) {
+    if (!mux) return false;
+    struct kevent ev;
+    EV_SET(&ev, PP_MUX_WAKE_ID, EVFILT_USER, 0, NOTE_TRIGGER, 0, NULL);
+    return kevent(mux->handle, &ev, 1, NULL, 0, NULL) == 0;
+}
+
+void pp_mux_stop(pp_mux mux) {
+    if (!mux) return;
+//    eventf
+}
+
+#elif PARTOUT_LINUX
+#include <sys/epoll.h>
+#include <unistd.h>
+
+struct __pp_mux {
+    int handle;
+    struct epoll_event *events;
+    int events_len;
+};
+
+pp_mux pp_mux_create(int num) {
+    int handle = epoll_create(1); /* Size is ignored */
+    if (handle < 0) return NULL;
+    pp_mux mux = pp_alloc(sizeof(*mux));
+    mux->handle = handle;
+    mux->events = pp_alloc((1 + num) * sizeof(struct epoll_event));
+    mux->events_len = 1 + num;
+    return mux;
+}
+
+void pp_mux_free(pp_mux mux) {
+    if (!mux) return;
+    close(mux->handle);
+    pp_free(mux->events);
+    pp_free(mux);
+}
+
+bool pp_mux_add(pp_mux mux, int pos, int fd) {
+    if (!mux) return false;
+    struct epoll_event *event = &mux->events[pos];
+    event->events = EPOLLIN;
+    event->data.fd = fd;
+    return epoll_ctl(mux->handle, EPOLL_CTL_ADD, fd, event) == 0;
+}
+
+bool pp_mux_set_write(pp_mux mux, int pos, int fd, bool enable) {
+    if (!mux) return false;
+    struct epoll_event *event = &mux->events[pos];
+    event->events = enable ? (EPOLLIN | EPOLLOUT) : EPOLLIN;
+    event->data.fd = fd;
+    return epoll_ctl(mux->handle, EPOLL_CTL_MOD, fd, event) == 0;
+}
+
+int pp_mux_wait(pp_mux mux) {
+    if (!mux) return -1;
+    return epoll_wait(mux->handle, mux->events, mux->events_len, -1);
+}
+#endif

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -125,7 +125,7 @@ void pp_mux_stop(pp_mux mux) {
 //    eventf
 }
 
-#elif PARTOUT_LINUX
+#elif PARTOUT_LINUX || PARTOUT_ANDROID
 #include <sys/epoll.h>
 #include <unistd.h>
 

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -112,11 +112,6 @@ bool pp_mux_wake(pp_mux mux) {
     return kevent(mux->handle, &ev, 1, NULL, 0, NULL) == 0;
 }
 
-void pp_mux_stop(pp_mux mux) {
-    if (!mux) return;
-//    eventf
-}
-
 #elif PARTOUT_LINUX || PARTOUT_ANDROID
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
@@ -257,9 +252,5 @@ bool pp_mux_wake(pp_mux mux) {
     if (!mux) return false;
     if (eventfd_write(mux->wake_fd, 1) == 0) return true;
     return errno == EAGAIN;
-}
-
-void pp_mux_stop(pp_mux mux) {
-    if (!mux) return;
 }
 #endif

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -91,14 +91,6 @@ int pp_mux_wait(pp_mux mux) {
         const struct kevent *ev = mux->events + i;
         const int fd = (int)ev->ident;
         if (ev->filter == EVFILT_READ) {
-            if (ev->flags & EV_EOF) {
-                struct kevent changes[2];
-                EV_SET(&changes[0], fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
-                EV_SET(&changes[1], fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
-                kevent(mux->handle, changes, 2, NULL, 0, NULL);
-                // FIXME: ###, Report EOF
-                continue;
-            }
             if (mux->on_readable) {
                 mux->on_readable(mux->read_ctx, fd);
             }
@@ -246,15 +238,15 @@ int pp_mux_wait(pp_mux mux) {
             }
             continue;
         }
-        if (ev->events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP)) {
-            epoll_ctl(mux->handle, EPOLL_CTL_DEL, fd, NULL);
-            // FIXME: ###, Report EOF
-            continue;
-        }
-        if ((ev->events & EPOLLIN) && mux->on_readable) {
+        const bool failed = ev->events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP);
+        const bool readable = (ev->events & EPOLLIN) || failed;
+        const bool writable = ev->events & EPOLLOUT;
+        bool did_notify_readable = false;
+        if (readable && mux->on_readable) {
             mux->on_readable(mux->read_ctx, fd);
+            did_notify_readable = true;
         }
-        if ((ev->events & EPOLLOUT) && mux->on_writable) {
+        if ((writable || (!did_notify_readable && failed)) && mux->on_writable) {
             mux->on_writable(mux->write_ctx, fd);
         }
     }

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -127,49 +127,147 @@ void pp_mux_stop(pp_mux mux) {
 
 #elif PARTOUT_LINUX || PARTOUT_ANDROID
 #include <sys/epoll.h>
+#include <sys/eventfd.h>
 #include <unistd.h>
+
+#ifndef EPOLLRDHUP
+#define EPOLLRDHUP 0
+#endif
 
 struct __pp_mux {
     int handle;
+    int wake_fd;
     struct epoll_event *events;
     int events_len;
+    void (*on_readable)(void *ctx, int fd);
+    void (*on_writable)(void *ctx, int fd);
+    void *read_ctx;
+    void *write_ctx;
 };
 
 pp_mux pp_mux_create(int num) {
     int handle = epoll_create(1); /* Size is ignored */
     if (handle < 0) return NULL;
+    int wake_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (wake_fd < 0) {
+        close(handle);
+        return NULL;
+    }
+
     pp_mux mux = pp_alloc(sizeof(*mux));
     mux->handle = handle;
+    mux->wake_fd = wake_fd;
     mux->events = pp_alloc((1 + num) * sizeof(struct epoll_event));
     mux->events_len = 1 + num;
+
+    struct epoll_event ev;
+    pp_zero(&ev, sizeof(ev));
+    ev.events = EPOLLIN;
+    ev.data.fd = mux->wake_fd;
+    if (epoll_ctl(mux->handle, EPOLL_CTL_ADD, mux->wake_fd, &ev) != 0) {
+        pp_mux_free(mux);
+        return NULL;
+    }
+
     return mux;
 }
 
 void pp_mux_free(pp_mux mux) {
     if (!mux) return;
     close(mux->handle);
+    close(mux->wake_fd);
     pp_free(mux->events);
     pp_free(mux);
 }
 
-bool pp_mux_add(pp_mux mux, int pos, int fd) {
+bool pp_mux_add(pp_mux mux, int fd) {
     if (!mux) return false;
-    struct epoll_event *event = &mux->events[pos];
-    event->events = EPOLLIN;
-    event->data.fd = fd;
-    return epoll_ctl(mux->handle, EPOLL_CTL_ADD, fd, event) == 0;
+    struct epoll_event ev;
+    pp_zero(&ev, sizeof(ev));
+    ev.events = EPOLLIN | EPOLLERR | EPOLLHUP | EPOLLRDHUP;
+    ev.data.fd = fd;
+    const int ret = epoll_ctl(mux->handle, EPOLL_CTL_ADD, fd, &ev);
+    if (ret < 0) {
+        if (errno == EEXIST) return true;
+        return false;
+    }
+    return true;
 }
 
-bool pp_mux_set_write(pp_mux mux, int pos, int fd, bool enable) {
+bool pp_mux_set_write(pp_mux mux, int fd, bool enable) {
     if (!mux) return false;
-    struct epoll_event *event = &mux->events[pos];
-    event->events = enable ? (EPOLLIN | EPOLLOUT) : EPOLLIN;
-    event->data.fd = fd;
-    return epoll_ctl(mux->handle, EPOLL_CTL_MOD, fd, event) == 0;
+    struct epoll_event ev;
+    pp_zero(&ev, sizeof(ev));
+    ev.events = EPOLLIN | EPOLLERR | EPOLLHUP | EPOLLRDHUP;
+    if (enable) {
+        ev.events |= EPOLLOUT;
+    }
+    ev.data.fd = fd;
+    const int ret = epoll_ctl(mux->handle, EPOLL_CTL_MOD, fd, &ev);
+    if (ret < 0) {
+        if (enable && errno == ENOENT) {
+            return epoll_ctl(mux->handle, EPOLL_CTL_ADD, fd, &ev) == 0;
+        }
+        /* Ignore failed deletion. */
+        if (!enable && errno == ENOENT) return true;
+        return false;
+    }
+    return true;
+}
+
+void pp_mux_set_on_readable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx) {
+    if (!mux) return;
+    mux->on_readable = callback;
+    mux->read_ctx = ctx;
+}
+
+void pp_mux_set_on_writable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx) {
+    if (!mux) return;
+    mux->on_writable = callback;
+    mux->write_ctx = ctx;
 }
 
 int pp_mux_wait(pp_mux mux) {
     if (!mux) return -1;
-    return epoll_wait(mux->handle, mux->events, mux->events_len, -1);
+    const int num = epoll_wait(mux->handle, mux->events, mux->events_len, -1);
+    for (int i = 0; i < num; ++i) {
+        const struct epoll_event *ev = mux->events + i;
+        const int fd = ev->data.fd;
+        if (fd == mux->wake_fd) {
+            eventfd_t value;
+            while (true) {
+                if (eventfd_read(mux->wake_fd, &value) == 0) {
+                    continue;
+                }
+                if (errno == EINTR) {
+                    continue;
+                }
+                break;
+            }
+            continue;
+        }
+        if (ev->events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP)) {
+            epoll_ctl(mux->handle, EPOLL_CTL_DEL, fd, NULL);
+            // FIXME: ###, Report EOF
+            continue;
+        }
+        if ((ev->events & EPOLLIN) && mux->on_readable) {
+            mux->on_readable(mux->read_ctx, fd);
+        }
+        if ((ev->events & EPOLLOUT) && mux->on_writable) {
+            mux->on_writable(mux->write_ctx, fd);
+        }
+    }
+    return num;
+}
+
+bool pp_mux_wake(pp_mux mux) {
+    if (!mux) return false;
+    if (eventfd_write(mux->wake_fd, 1) == 0) return true;
+    return errno == EAGAIN;
+}
+
+void pp_mux_stop(pp_mux mux) {
+    if (!mux) return;
 }
 #endif

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -21,20 +21,36 @@ struct __pp_tun_struct {
     int fd;
 };
 
-void pp_tun_free(pp_tun tun) {
+pp_tun pp_tun_create(int fd) {
+    pp_tun tun = pp_alloc(sizeof(*tun));
+    tun->fd = fd;
+    return tun;
+}
+
+void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
-    pp_tun_shutdown(tun);
+    if (and_close) {
+        pp_tun_shutdown(tun);
+    }
     pp_free(tun);
 }
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
     if (!tun || tun->fd < 0) return -1;
-    return read(tun->fd, dst, dst_len);
+    const int ret = read(tun->fd, dst, dst_len);
+    if (ret < 0 && pp_tun_would_block()) {
+        return PP_TUN_WOULD_BLOCK;
+    }
+    return ret;
 }
 
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     if (!tun || tun->fd < 0) return -1;
-    return write(tun->fd, src, src_len);
+    const int ret = write(tun->fd, src, src_len);
+    if (ret < 0 && pp_tun_would_block()) {
+        return PP_TUN_WOULD_BLOCK;
+    }
+    return ret;
 }
 
 void pp_tun_shutdown(const pp_tun tun) {

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -148,7 +148,7 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
         }
         return -1;
     }
-    if (written_len != (int)(pi_len + src_len)) return -2;
+    if (written_len != (int)(pi_len + src_len)) return -3;
     return written_len;
 }
 

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -27,8 +27,14 @@ struct __pp_tun_struct {
     const char *dev_name;
 };
 
+pp_tun pp_tun_create(int fd) {
+    pp_tun tun = pp_alloc(sizeof(*tun));
+    tun->fd = fd;
+    return tun;
+}
+
 static
-pp_tun pp_tun_create(const char *uuid) {
+pp_tun pp_tun_request(const char *uuid) {
     (void)uuid;
     struct sockaddr_ctl sc = { 0 };
     struct ctl_info ctl_info = { 0 };
@@ -76,9 +82,11 @@ failure:
     return NULL;
 }
 
-void pp_tun_free(pp_tun tun) {
+void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
-    pp_tun_shutdown(tun);
+    if (and_close) {
+        pp_tun_shutdown(tun);
+    }
     if (tun->dev_name) {
         pp_free((void *)tun->dev_name);
     }
@@ -111,6 +119,9 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
 
     const int read_len = (int)readv(tun->fd, iov, sizeof(iov) / sizeof(struct iovec));
     if (read_len < 0) {
+        if (pp_tun_would_block()) {
+            return PP_TUN_WOULD_BLOCK;
+        }
         return -1;
     }
     if (read_len < (int)sizeof(pi)) {
@@ -133,6 +144,9 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
 
     const int written_len = (int)writev(tun->fd, iov, sizeof(iov) / sizeof(struct iovec));
     if (written_len < 0) {
+        if (pp_tun_would_block()) {
+            return PP_TUN_WOULD_BLOCK;
+        }
         return -1;
     }
     if (written_len != (int)(pi_len + src_len)) return -2;

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -34,7 +34,7 @@ pp_tun pp_tun_create(int fd) {
 }
 
 static
-pp_tun pp_tun_request(const char *uuid) {
+pp_tun pp_tun_open(const char *uuid) {
     (void)uuid;
     struct sockaddr_ctl sc = { 0 };
     struct ctl_info ctl_info = { 0 };

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -33,7 +33,6 @@ pp_tun pp_tun_create(int fd) {
     return tun;
 }
 
-static
 pp_tun pp_tun_open(const char *uuid) {
     (void)uuid;
     struct sockaddr_ctl sc = { 0 };

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -10,10 +10,15 @@
 const int PP_TUN_WOULD_BLOCK = -2;
 
 #if !PARTOUT_HAS_TUN
+struct __pp_tun_struct {
+    int fd;
+};
+
 pp_tun pp_tun_create(int fd) {
-    (void)fd;
     pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: create()");
-    return NULL;
+    pp_tun tun = pp_alloc(sizeof(*tun));
+    tun->fd = fd;
+    return tun;
 }
 
 pp_tun pp_tun_open(const char *uuid) {
@@ -24,7 +29,9 @@ pp_tun pp_tun_open(const char *uuid) {
 
 void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     (void)tun;
+    (void)and_close;
     pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: free_and_close()");
+    pp_free(tun);
 }
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -10,9 +10,9 @@
 const int PP_TUN_WOULD_BLOCK = -2;
 
 #if !PARTOUT_HAS_TUN
-void pp_tun_free(pp_tun tun) {
+void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     (void)tun;
-    pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: free()");
+    pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: free_and_close()");
 }
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -7,6 +7,8 @@
 #include "portable/common.h"
 #include "portable/tun.h"
 
+const int PP_TUN_WOULD_BLOCK = -2;
+
 #if !PARTOUT_HAS_TUN
 void pp_tun_free(pp_tun tun) {
     (void)tun;

--- a/Sources/PartoutCore_C/tun_dummy.c
+++ b/Sources/PartoutCore_C/tun_dummy.c
@@ -10,6 +10,18 @@
 const int PP_TUN_WOULD_BLOCK = -2;
 
 #if !PARTOUT_HAS_TUN
+pp_tun pp_tun_create(int fd) {
+    (void)fd;
+    pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: create()");
+    return NULL;
+}
+
+pp_tun pp_tun_open(const char *uuid) {
+    (void)uuid;
+    pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: open()");
+    return NULL;
+}
+
 void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     (void)tun;
     pp_clog(PPLogCategoryCore, PPLogLevelDebug, "tun_dummy: free_and_close()");

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -32,7 +32,7 @@ pp_tun pp_tun_create(int fd) {
 }
 
 static
-pp_tun pp_tun_request(const char *uuid) {
+pp_tun pp_tun_open(const char *uuid) {
     (void)uuid;
     const char *dev_path = "/dev/net/tun";
     int fd = -1;

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -31,7 +31,6 @@ pp_tun pp_tun_create(int fd) {
     return tun;
 }
 
-static
 pp_tun pp_tun_open(const char *uuid) {
     (void)uuid;
     const char *dev_path = "/dev/net/tun";

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -25,8 +25,14 @@ struct __pp_tun_struct {
     const char *dev_name;
 };
 
+pp_tun pp_tun_create(int fd) {
+    pp_tun tun = pp_alloc(sizeof(*tun));
+    tun->fd = fd;
+    return tun;
+}
+
 static
-pp_tun pp_tun_create(const char *uuid) {
+pp_tun pp_tun_request(const char *uuid) {
     (void)uuid;
     const char *dev_path = "/dev/net/tun";
     int fd = -1;
@@ -60,9 +66,11 @@ failure:
     return NULL;
 }
 
-void pp_tun_free(pp_tun tun) {
+void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
-    pp_tun_shutdown(tun);
+    if (and_close) {
+        pp_tun_shutdown(tun);
+    }
     if (tun->dev_name) {
         pp_free((void *)tun->dev_name);
     }
@@ -71,12 +79,20 @@ void pp_tun_free(pp_tun tun) {
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
     if (!tun || tun->fd < 0) return -1;
-    return read(tun->fd, dst, dst_len);
+    const int ret = read(tun->fd, dst, dst_len);
+    if (ret < 0 && pp_tun_would_block()) {
+        return PP_TUN_WOULD_BLOCK;
+    }
+    return ret;
 }
 
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     if (!tun || tun->fd < 0) return -1;
-    return write(tun->fd, src, src_len);
+    const int ret = write(tun->fd, src, src_len);
+    if (ret < 0 && pp_tun_would_block()) {
+        return PP_TUN_WOULD_BLOCK;
+    }
+    return ret;
 }
 
 void pp_tun_shutdown(const pp_tun tun) {

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -64,7 +64,7 @@ GUID guid_from_wstring(const wchar_t *wstr) {
 }
 
 static
-pp_tun pp_tun_create(const char *uuid) {
+pp_tun pp_tun_request(const char *uuid) {
     if (!uuid) return NULL;
     WINTUN_ADAPTER_HANDLE adapter = NULL;
     WINTUN_SESSION_HANDLE session = NULL;
@@ -132,11 +132,13 @@ failure:
     return NULL;
 }
 
-void pp_tun_free(pp_tun tun) {
+void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
-    pp_tun_shutdown(tun);
-    if (tun->adapter) {
-        WintunCloseAdapter(tun->adapter);
+    if (and_close) {
+        pp_tun_shutdown(tun);
+        if (tun->adapter) {
+            WintunCloseAdapter(tun->adapter);
+        }
     }
     pp_free(tun->name);
     pp_free(tun);

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -64,7 +64,7 @@ GUID guid_from_wstring(const wchar_t *wstr) {
 }
 
 static
-pp_tun pp_tun_request(const char *uuid) {
+pp_tun pp_tun_open(const char *uuid) {
     if (!uuid) return NULL;
     WINTUN_ADAPTER_HANDLE adapter = NULL;
     WINTUN_SESSION_HANDLE session = NULL;

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -63,7 +63,6 @@ GUID guid_from_wstring(const wchar_t *wstr) {
     return guid;
 }
 
-static
 pp_tun pp_tun_open(const char *uuid) {
     if (!uuid) return NULL;
     WINTUN_ADAPTER_HANDLE adapter = NULL;

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -333,6 +333,7 @@ set(PARTOUT_C_SOURCES
 ./MiniFoundation_C/std.c
 ./PartoutCore_C/common.c
 ./PartoutCore_C/lib.c
+./PartoutCore_C/mux.c
 ./PartoutCore_C/network.c
 ./PartoutCore_C/prng.c
 ./PartoutCore_C/socket.c


### PR DESCRIPTION
Multiplex link and tun descriptors into a single blocking call. Use kqueue on Darwin/BSD and epoll on Linux.

Must change tun.h a little bit to:

- Allocate and release manually with a fd (pp_tun_create/release)
- Rename former pp_tun_create to pp_tun_open and expose it
- Handle "would block" sentinel