### PR TITLE
NE: Move WireGuard fd trick to NETunnelInterface

### DIFF
--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -13,6 +13,23 @@
 #include "portable/common.h"
 #include "portable/socket.h"
 
+/* Redefine these manually because the <sys/kern_control.h>
+ * header is not exposed to iOS/tvOS */
+#if PARTOUT_APPLE && !PARTOUT_MACOS
+struct ctl_info {
+    u_int32_t   ctl_id;
+    char        ctl_name[96];
+};
+struct sockaddr_ctl {
+    u_char      sc_len;
+    u_char      sc_family;
+    u_int16_t   ss_sysaddr;
+    u_int32_t   sc_id;
+    u_int32_t   sc_unit;
+    u_int32_t   sc_reserved[5];
+};
+#endif
+
 #pragma clang assume_nonnull begin
 
 /* Opaque tun device. */

--- a/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
@@ -19,7 +19,35 @@ public final class NETunnelInterface: IOInterface {
     // MARK: TunnelInterface
 
     public var fileDescriptor: UInt64? {
-        nil
+        var ctlInfo = ctl_info()
+        withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
+            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
+                _ = strcpy($0, "com.apple.net.utun_control")
+            }
+        }
+        for fd: Int32 in 0...1024 {
+            var addr = sockaddr_ctl()
+            var len = socklen_t(MemoryLayout.size(ofValue: addr))
+            let ret = withUnsafeMutablePointer(to: &addr) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    getpeername(fd, $0, &len)
+                }
+            }
+            guard ret == 0 && addr.sc_family == AF_SYSTEM else {
+                continue
+            }
+            if ctlInfo.ctl_id == 0 {
+                let ret = ioctl(fd, CTLIOCGINFO, &ctlInfo)
+                guard ret == 0 else {
+                    continue
+                }
+            }
+            guard addr.sc_id == ctlInfo.ctl_id else {
+                continue
+            }
+            return UInt64(fd)
+        }
+        return nil
     }
 
     public func readPackets() async throws -> [Data] {
@@ -36,3 +64,5 @@ public final class NETunnelInterface: IOInterface {
         impl?.writePackets(packets, withProtocols: protocols as [NSNumber])
     }
 }
+
+private let CTLIOCGINFO: UInt = 0xc0644e03

--- a/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+internal import _PartoutCore_C
 import NetworkExtension
 
 /// A tunnel interface based on `NEPacketTunnelFlow`.
@@ -19,6 +20,28 @@ public final class NETunnelInterface: IOInterface {
     // MARK: TunnelInterface
 
     public var fileDescriptor: UInt64? {
+        Self.existingFileDescriptor.map(UInt64.init)
+    }
+
+    public func readPackets() async throws -> [Data] {
+        guard let impl else {
+            pp_log(ctx, .os, .error, "NEPacketTunnelFlow released prematurely")
+            throw PartoutError(.unhandled)
+        }
+        let pair = await impl.readPackets()
+        return pair.0
+    }
+
+    public func writePackets(_ packets: [Data]) {
+        let protocols = packets.map(IPHeader.protocolNumber(inPacket:))
+        impl?.writePackets(packets, withProtocols: protocols as [NSNumber])
+    }
+}
+
+extension NETunnelInterface {
+    private static let CTLIOCGINFO: UInt = 0xc0644e03
+
+    public static var existingFileDescriptor: Int32? {
         var ctlInfo = ctl_info()
         withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
             $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
@@ -37,7 +60,7 @@ public final class NETunnelInterface: IOInterface {
                 continue
             }
             if ctlInfo.ctl_id == 0 {
-                let ret = ioctl(fd, CTLIOCGINFO, &ctlInfo)
+                let ret = ioctl(fd, Self.CTLIOCGINFO, &ctlInfo)
                 guard ret == 0 else {
                     continue
                 }
@@ -45,24 +68,8 @@ public final class NETunnelInterface: IOInterface {
             guard addr.sc_id == ctlInfo.ctl_id else {
                 continue
             }
-            return UInt64(fd)
+            return fd
         }
         return nil
     }
-
-    public func readPackets() async throws -> [Data] {
-        guard let impl else {
-            pp_log(ctx, .os, .error, "NEPacketTunnelFlow released prematurely")
-            throw PartoutError(.unhandled)
-        }
-        let pair = await impl.readPackets()
-        return pair.0
-    }
-
-    public func writePackets(_ packets: [Data]) {
-        let protocols = packets.map(IPHeader.protocolNumber(inPacket:))
-        impl?.writePackets(packets, withProtocols: protocols as [NSNumber])
-    }
 }
-
-private let CTLIOCGINFO: UInt = 0xc0644e03

--- a/Sources/PartoutWireGuardConnection/V1/Internal/LegacyWireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V1/Internal/LegacyWireGuardAdapter.swift
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
+internal import _PartoutCore_C
 internal import _PartoutWireGuard_C
 import NetworkExtension
+import PartoutOS
 
 protocol LegacyWireGuardAdapterDelegate: AnyObject {
     func adapterShouldReassert(_ adapter: LegacyWireGuardAdapter, reasserting: Bool)
@@ -45,35 +47,7 @@ class LegacyWireGuardAdapter: @unchecked Sendable {
 
     /// Tunnel device file descriptor.
     private var tunnelFileDescriptor: Int32? {
-        var ctlInfo = ctl_info()
-        withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
-            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
-                _ = strcpy($0, "com.apple.net.utun_control")
-            }
-        }
-        for fd: Int32 in 0...1024 {
-            var addr = sockaddr_ctl()
-            var ret: Int32 = -1
-            var len = socklen_t(MemoryLayout.size(ofValue: addr))
-            withUnsafeMutablePointer(to: &addr) {
-                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                    ret = getpeername(fd, $0, &len)
-                }
-            }
-            if ret != 0 || addr.sc_family != AF_SYSTEM {
-                continue
-            }
-            if ctlInfo.ctl_id == 0 {
-                ret = ioctl(fd, CTLIOCGINFO, &ctlInfo)
-                if ret != 0 {
-                    continue
-                }
-            }
-            if addr.sc_id == ctlInfo.ctl_id {
-                return fd
-            }
-        }
-        return nil
+        NETunnelInterface.existingFileDescriptor
     }
 
     /// Returns a WireGuard version.

--- a/Sources/PartoutWireGuardConnection/V1/Internal/LegacyWireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V1/Internal/LegacyWireGuardAdapter.swift
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
-internal import _PartoutCore_C
 internal import _PartoutWireGuard_C
 import NetworkExtension
 import PartoutOS

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -234,7 +234,7 @@ actor WireGuardAdapter {
         guard let delegate else { return }
         tunnel = try await delegate.adapterShouldSetNetworkSettings(self, settings: networkSettings)
 #if !os(Windows)
-        guard let tunFd = tunnel?.fileDescriptor.map(Int32.init) ?? fallbackFileDescriptor else {
+        guard let tunFd = tunnel?.fileDescriptor.map(Int32.init) else {
             throw WireGuardAdapterError.cannotLocateTunnelFileDescriptor
         }
         tunnelFileDescriptor = tunFd
@@ -409,42 +409,6 @@ actor WireGuardAdapter {
             return false
         }
         return currentSettingsGenerator === settingsGenerator
-    }
-
-    private nonisolated var fallbackFileDescriptor: Int32? {
-#if canImport(Darwin)
-        var ctlInfo = ctl_info()
-        withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
-            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
-                _ = strcpy($0, "com.apple.net.utun_control")
-            }
-        }
-        for fd: Int32 in 0...1024 {
-            var addr = sockaddr_ctl()
-            var ret: Int32 = -1
-            var len = socklen_t(MemoryLayout.size(ofValue: addr))
-            withUnsafeMutablePointer(to: &addr) {
-                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                    ret = getpeername(fd, $0, &len)
-                }
-            }
-            if ret != 0 || addr.sc_family != AF_SYSTEM {
-                continue
-            }
-            if ctlInfo.ctl_id == 0 {
-                ret = ioctl(fd, CTLIOCGINFO, &ctlInfo)
-                if ret != 0 {
-                    continue
-                }
-            }
-            if addr.sc_id == ctlInfo.ctl_id {
-                return fd
-            }
-        }
-        return nil
-#else
-        return nil
-#endif
     }
 }
 

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
-internal import _PartoutCore_C
 internal import _PartoutWireGuard_C
 
 protocol WireGuardAdapterDelegate: AnyObject, Sendable {

--- a/Sources/PartoutWireGuard_C/include/wireguard/sys.h
+++ b/Sources/PartoutWireGuard_C/include/wireguard/sys.h
@@ -12,22 +12,4 @@
 #include "wireguard/key.h"
 #include "wireguard/x25519.h"
 
-/* Redefine these manually because the <sys/kern_control.h>
- * header is not exposed to iOS */
-#if PARTOUT_APPLE
-#define CTLIOCGINFO 0xc0644e03UL
-struct ctl_info {
-    u_int32_t   ctl_id;
-    char        ctl_name[96];
-};
-struct sockaddr_ctl {
-    u_char      sc_len;
-    u_char      sc_family;
-    u_int16_t   ss_sysaddr;
-    u_int32_t   sc_id;
-    u_int32_t   sc_unit;
-    u_int32_t   sc_reserved[5];
-};
-#endif
-
 #endif


### PR DESCRIPTION
The code is not bound to WireGuard, but rather to Apple platforms. Dedup logic in WireGuard v1/v2.