### PR TITLE
Core: Interact with FdLooper

### DIFF
--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -332,7 +332,7 @@ private extension FdLooper {
         // Write link
         if fdSet.writable.contains(link.fd) {
             var watchWrites = false
-            while let pending = lock.with(block: { link.dequeueWrite() }) {
+            while let pending = link.dequeueWrite(lock: lock) {
                 do {
                     let didComplete = try link.performWrite(pending, lock: lock)
                     watchWrites = !didComplete
@@ -353,7 +353,7 @@ private extension FdLooper {
         // Write tun
         if let tun, fdSet.writable.contains(tun.fd) {
             var watchWrites = false
-            while let pending = lock.with(block: { tun.dequeueWrite() }) {
+            while let pending = tun.dequeueWrite(lock: lock) {
                 do {
                     let didComplete = try tun.performWrite(pending, lock: lock)
                     watchWrites = !didComplete
@@ -529,8 +529,10 @@ private extension FdLooper {
             return didComplete
         }
 
-        func dequeueWrite() -> PendingWrite? {
-            writeQueue.first
+        func dequeueWrite(lock: SemaphoreMutex) -> PendingWrite? {
+            lock.with {
+                writeQueue.first
+            }
         }
 
         func enqueueWrite(_ pendingWrite: PendingWrite) {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -444,12 +444,9 @@ private extension FdLooper {
 
     func finish(throwing error: Error? = nil) {
         lock.lock()
-        guard terminalError == nil else {
-            lock.unlock()
-            return
-        }
-        terminalError = error
+        precondition(state != .stopped)
         state = .stopped
+        terminalError = error
         lock.unlock()
 
         delegate.onFinish(error)

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -35,8 +35,8 @@ public final class FdLooper: @unchecked Sendable {
     // Consumer:
     // - Writes to linkQueue/tunQueue .outbound
     // - Reads from linkQueue/tunQueue .inbound
-    private var linkQueue: BidirectionalState<[[UInt8]]>
-    private var tunQueue: BidirectionalState<[[UInt8]]>
+    private var linkQueue: BidirectionalState<[Data]>
+    private var tunQueue: BidirectionalState<[Data]>
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -262,7 +262,10 @@ private extension FdLooper {
         if fdSet.writable.contains(linkFd) {
             var watchWrites = false
             while let packet = linkQueue.outbound.first {
-                let count = pp_socket_write(link, packet, packet.count)
+                let packetCount = packet.count
+                let count = packet.withUnsafeBytes {
+                    pp_socket_write(link, $0, packetCount)
+                }
                 guard count != PP_SOCKET_WOULD_BLOCK else {
                     watchWrites = true
                     break
@@ -273,7 +276,7 @@ private extension FdLooper {
                 // Dequeue, but reinsert remainder on partial write
                 linkQueue.outbound.removeFirst()
                 if count < packet.count {
-                    let partialPacket = [UInt8](packet[Int(count)...])
+                    let partialPacket = Data(packet[Int(count)...])
                     linkQueue.outbound.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
@@ -289,7 +292,10 @@ private extension FdLooper {
         if let tunFd, let tun, fdSet.writable.contains(tunFd) {
             var watchWrites = false
             while let packet = tunQueue.outbound.first {
-                let count = pp_tun_write(tun, packet, packet.count)
+                let packetCount = packet.count
+                let count = packet.withUnsafeBytes {
+                    pp_tun_write(tun, $0, packetCount)
+                }
                 guard count != PP_TUN_WOULD_BLOCK else {
                     watchWrites = true
                     break
@@ -300,7 +306,7 @@ private extension FdLooper {
                 // Dequeue, but reinsert remainder on partial write
                 tunQueue.outbound.removeFirst()
                 if count < packet.count {
-                    let partialPacket = [UInt8](packet[Int(count)...])
+                    let partialPacket = Data(packet[Int(count)...])
                     tunQueue.outbound.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
@@ -325,7 +331,7 @@ private extension FdLooper {
                     throw PartoutError(.ioFailure)
                 }
                 if count > 0 {
-                    let packet = [UInt8](tunBuf[0..<Int(count)])
+                    let packet = Data(tunBuf[0..<Int(count)])
                     tunQueue.inbound.append(packet)
                 }
                 // Keep going
@@ -347,7 +353,7 @@ private extension FdLooper {
                     throw PartoutError(.ioFailure)
                 }
                 if count > 0 {
-                    let packet = [UInt8](linkBuf[0..<Int(count)])
+                    let packet = Data(linkBuf[0..<Int(count)])
                     linkQueue.inbound.append(packet)
                 }
                 // Keep going

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -50,20 +50,25 @@ public final class FdLooper: @unchecked Sendable {
         let linkFd = linkInterface.fileDescriptor.map(Int32.init)
         let tunFd = tunInterface?.fileDescriptor.map(Int32.init)
         guard let linkFd else {
+            pp_log(ctx, .core, .fault, "Missing link descriptor")
             throw PartoutError(.fdUnavailable)
         }
         guard tunInterface == nil || tunFd != nil else {
+            pp_log(ctx, .core, .fault, "Missing tun descriptor")
             throw PartoutError(.fdUnavailable)
         }
         guard let newMux = pp_mux_create(Int32(Self.numberOfDescriptors)) else {
+            pp_log(ctx, .core, .fault, "Unable to create mux")
             throw PartoutError(.muxFailure)
         }
         guard pp_mux_add(newMux, linkFd) else {
+            pp_log(ctx, .core, .fault, "Unable to add linkFd")
             pp_mux_free(newMux)
             throw PartoutError(.muxFailure, linkFd)
         }
         if let tunFd {
             guard pp_mux_add(newMux, tunFd) else {
+                pp_log(ctx, .core, .fault, "Unable to add tunFd")
                 pp_mux_free(newMux)
                 throw PartoutError(.muxFailure, tunFd)
             }
@@ -233,6 +238,7 @@ private extension FdLooper {
                     break
                 }
                 guard pp_mux_add(mux, fd) else {
+                    pp_log(ctx, .core, .fault, "Unable to attach tun")
                     results.append(.attachTun(continuation, .failure(PartoutError(.muxFailure, fd))))
                     break
                 }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -319,7 +319,7 @@ private extension FdLooper {
             while let pending = lock.with(block: { linkQueue.first }) {
                 let packetCount = pending.data.count
                 let count = pending.data.withUnsafeBytes {
-                    pp_socket_write(link, $0.bytePointer, packetCount)
+                    pp_socket_write(link, $0.bytePointer + pending.offset, packetCount)
                 }
                 guard count != PP_SOCKET_WOULD_BLOCK else {
                     watchWrites = true
@@ -351,7 +351,7 @@ private extension FdLooper {
             while let pending = lock.with(block: { tunQueue.first }) {
                 let packetCount = pending.data.count
                 let count = pending.data.withUnsafeBytes {
-                    pp_tun_write(tun, $0.bytePointer, packetCount)
+                    pp_tun_write(tun, $0.bytePointer + pending.offset, packetCount)
                 }
                 guard count != PP_TUN_WOULD_BLOCK else {
                     watchWrites = true

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -498,9 +498,9 @@ private extension FdLooper {
             fd: Int32,
             originalInterface: IOInterface,
             readBufSize: Int,
-            read: @escaping @Sendable (inout [UInt8]) throws -> Data?,
-            write: @escaping @Sendable (PendingWrite) throws -> Int,
-            cleanup: @escaping @Sendable () -> Void
+            read: @escaping (inout [UInt8]) throws -> Data?,
+            write: @escaping (PendingWrite) throws -> Int,
+            cleanup: @escaping () -> Void
         ) {
             self.fd = fd
             self.originalInterface = originalInterface

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -268,7 +268,7 @@ public final class FdLooper: @unchecked Sendable {
             }
             commands.append(.enableWrite(.link))
         case .tun:
-            guard let tunFd else {
+            guard tunFd != nil else {
                 pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
                 return
             }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+// FIXME: ###, Beware of the Int32/UInt64 mismatch (UNIX fd is Int32, Windows SOCKET is UInt64)
+
 #if !os(Windows)
 internal import _PartoutCore_C
 
@@ -48,33 +50,16 @@ public final class FdLooper: @unchecked Sendable {
         case stop
     }
 
-    private struct PendingWrite {
-        let data: Data
-        let offset: Int
-        init(_ data: Data, offset: Int = 0) {
-            self.data = data
-            self.offset = offset
-        }
-        init(_ pending: PendingWrite, newOffset: Int) {
-            data = pending.data
-            offset = pending.offset + newOffset
-        }
-        var count: Int {
-            data.count - offset
-        }
-    }
-
     private static let numberOfDescriptors = 2
 
     private let ctx: PartoutLoggerContext
-    private let originalLink: IOInterface
-    private var originalTun: IOInterface?
     private let mux: pp_mux
-    private let linkFd: Int32
-    private var tunFd: Int32?
-    private let link: pp_socket
-    private var tun: pp_tun?
+    private var link: SideIO
+    private var tun: SideIO?
+    private let linkHandle: pp_socket
+    private var tunHandle: pp_tun?
     private let delegate: FdLooperDelegate
+    private let tunBufSize: Int
     private let maxReadSize: Int
     private let maxReadCount: Int
 
@@ -84,19 +69,10 @@ public final class FdLooper: @unchecked Sendable {
     private var state: State
     private var stopContinuation: CheckedContinuation<Void, Error>?
     private var terminalError: Error?
-    private var linkBuf: [UInt8]
-    private var tunBuf: [UInt8]
-
-    // Consumer:
-    // - Writes to linkQueue/tunQueue .outbound
-    // - Reads from linkQueue/tunQueue .inbound
-    private var linkQueue: RingQueue<PendingWrite>
-    private var tunQueue: RingQueue<PendingWrite>
 
     public init(
         _ ctx: PartoutLoggerContext,
         link linkInterface: IOInterface,
-        tun tunInterface: IOInterface?,
         delegate: FdLooperDelegate,
         linkBufSize: Int = 64 * 1024,
         tunBufSize: Int = 16 * 1024,
@@ -104,13 +80,8 @@ public final class FdLooper: @unchecked Sendable {
         maxReadCount: Int = 128
     ) throws {
         let linkFd = linkInterface.fileDescriptor.map(Int32.init)
-        let tunFd = tunInterface?.fileDescriptor.map(Int32.init)
         guard let linkFd else {
             pp_log(ctx, .core, .fault, "Missing link descriptor")
-            throw PartoutError(.fdUnavailable)
-        }
-        guard tunInterface == nil || tunFd != nil else {
-            pp_log(ctx, .core, .fault, "Missing tun descriptor")
             throw PartoutError(.fdUnavailable)
         }
         guard let newMux = pp_mux_create(Int32(Self.numberOfDescriptors)) else {
@@ -122,21 +93,11 @@ public final class FdLooper: @unchecked Sendable {
             pp_mux_free(newMux)
             throw PartoutError(.muxFailure, linkFd)
         }
-        if let tunFd {
-            guard pp_mux_add(newMux, tunFd) else {
-                pp_log(ctx, .core, .fault, "Unable to add tunFd")
-                pp_mux_free(newMux)
-                throw PartoutError(.muxFailure, tunFd)
-            }
-        }
 
         self.ctx = ctx
         mux = newMux
-        originalLink = linkInterface
-        originalTun = tunInterface
-        self.linkFd = linkFd
-        self.tunFd = tunFd
         self.delegate = delegate
+        self.tunBufSize = tunBufSize
         self.maxReadSize = max(maxReadSize, linkBufSize, tunBufSize)
         self.maxReadCount = maxReadCount
 
@@ -144,12 +105,13 @@ public final class FdLooper: @unchecked Sendable {
         lock = SemaphoreMutex()
         commands = []
         state = .idle
-        link = pp_socket_create(UInt64(linkFd))
-        tun = tunFd.map(pp_tun_create)
-        linkBuf = Array(repeating: 0, count: linkBufSize)
-        tunBuf = Array(repeating: 0, count: tunBufSize)
-        linkQueue = RingQueue()
-        tunQueue = RingQueue()
+        linkHandle = pp_socket_create(UInt64(linkFd))
+        link = SideIO(
+            linkFd: linkFd,
+            handle: linkHandle,
+            originalInterface: linkInterface,
+            readBufSize: linkBufSize
+        )
     }
 
     deinit {
@@ -161,8 +123,8 @@ public final class FdLooper: @unchecked Sendable {
         )
 
         pp_log(ctx, .core, .debug, "Deinit InterfaceLooper")
-        pp_socket_release(link)
-        tun.map(pp_tun_release)
+        tun?.cleanup()
+        link.cleanup()
         pp_mux_free(mux)
     }
 
@@ -264,16 +226,16 @@ public final class FdLooper: @unchecked Sendable {
         switch side {
         case .link:
             packets.forEach {
-                linkQueue.append(PendingWrite($0))
+                link.enqueueWrite(PendingWrite($0))
             }
             commands.append(.enableWrite(.link))
         case .tun:
-            guard tunFd != nil else {
+            guard let tun else {
                 pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
                 return
             }
             packets.forEach {
-                tunQueue.append(PendingWrite($0))
+                tun.enqueueWrite(PendingWrite($0))
             }
             commands.append(.enableWrite(.tun))
         }
@@ -306,7 +268,7 @@ private extension FdLooper {
                     break
                 }
                 // Can only attach once
-                guard tunFd == nil else {
+                guard tun == nil else {
                     results.append(.attachTun(continuation, .failure(PartoutError(.operationCancelled))))
                     break
                 }
@@ -316,17 +278,25 @@ private extension FdLooper {
                     break
                 }
                 pp_log(ctx, .core, .info, "Attach tun (fd=\(fd))")
-                originalTun = tunInterface
-                tunFd = fd
-                tun = pp_tun_create(fd)
+
+                // Create new side
+                let tunHandle = pp_tun_create(fd)
+                self.tunHandle = tunHandle
+                tun = SideIO(
+                    tunFd: fd,
+                    handle: tunHandle,
+                    originalInterface: tunInterface,
+                    readBufSize: tunBufSize
+                )
+
                 results.append(.attachTun(continuation, .success(())))
             case .enableRead(let side):
                 switch side {
                 case .link:
-                    pp_mux_set_read(mux, linkFd, true)
+                    pp_mux_set_read(mux, link.fd, true)
                 case .tun:
-                    if let tunFd {
-                        pp_mux_set_read(mux, tunFd, true)
+                    if let tun {
+                        pp_mux_set_read(mux, tun.fd, true)
                     } else {
                         pp_log(ctx, .core, .error, "Ignoring tun enableRead(), not attached")
                     }
@@ -334,10 +304,10 @@ private extension FdLooper {
             case .enableWrite(let side):
                 switch side {
                 case .link:
-                    pp_mux_set_write(mux, linkFd, true)
+                    pp_mux_set_write(mux, link.fd, true)
                 case .tun:
-                    if let tunFd {
-                        pp_mux_set_write(mux, tunFd, true)
+                    if let tun {
+                        pp_mux_set_write(mux, tun.fd, true)
                     } else {
                         pp_log(ctx, .core, .error, "Ignoring tun enableWrite(), not attached")
                     }
@@ -360,131 +330,95 @@ private extension FdLooper {
 
     func process(mux: pp_mux, fdSet: FdSet) throws {
         // Write link
-        if fdSet.writable.contains(linkFd) {
+        if fdSet.writable.contains(link.fd) {
             var watchWrites = false
-            while let pending = lock.with(block: { linkQueue.first }) {
-                let packetCount = pending.data.count
-                let count = pending.data.withUnsafeBytes {
-                    pp_socket_write(
-                        link,
-                        $0.bytePointer + pending.offset,
-                        packetCount - pending.offset
-                    )
-                }
-                guard count != PP_SOCKET_WOULD_BLOCK else {
+            while let pending = lock.with(block: { link.dequeuePendingWrite() }) {
+                do {
+                    let didComplete = try link.performWrite(pending, lock: lock)
+                    watchWrites = !didComplete
+                } catch IOError.wouldBlock {
                     watchWrites = true
                     break
-                }
-                guard count >= 0 else {
+                } catch {
                     throw PartoutError(.ioFailure)
                 }
-                lock.lock()
-                if count < pending.count {
-                    let partialPacket = PendingWrite(pending, newOffset: Int(count))
-                    linkQueue.replaceFirst(with: partialPacket)
-                    watchWrites = true
-                } else {
-                    linkQueue.removeFirst()
-                }
-                lock.unlock()
             }
             // Stop watching if no blocks
-            pp_mux_set_write(mux, linkFd, watchWrites)
+            pp_mux_set_write(mux, link.fd, watchWrites)
             if !watchWrites {
-                fdSet.writable.remove(linkFd)
+                fdSet.writable.remove(link.fd)
             }
         }
 
         // Write tun
-        if let tunFd, let tun, fdSet.writable.contains(tunFd) {
+        if let tun, fdSet.writable.contains(tun.fd) {
             var watchWrites = false
-            while let pending = lock.with(block: { tunQueue.first }) {
-                let packetCount = pending.data.count
-                let count = pending.data.withUnsafeBytes {
-                    pp_tun_write(
-                        tun,
-                        $0.bytePointer + pending.offset,
-                        packetCount - pending.offset
-                    )
-                }
-                guard count != PP_TUN_WOULD_BLOCK else {
+            while let pending = lock.with(block: { tun.dequeuePendingWrite() }) {
+                do {
+                    let didComplete = try tun.performWrite(pending, lock: lock)
+                    watchWrites = !didComplete
+                } catch IOError.wouldBlock {
                     watchWrites = true
                     break
-                }
-                guard count >= 0 else {
+                } catch {
                     throw PartoutError(.ioFailure)
                 }
-                lock.lock()
-                if count < pending.count {
-                    let partialPacket = PendingWrite(pending, newOffset: Int(count))
-                    tunQueue.replaceFirst(with: partialPacket)
-                    watchWrites = true
-                } else {
-                    tunQueue.removeFirst()
-                }
-                lock.unlock()
             }
             // Stop watching if no blocks
-            pp_mux_set_write(mux, tunFd, watchWrites)
+            pp_mux_set_write(mux, tun.fd, watchWrites)
             if !watchWrites {
-                fdSet.writable.remove(tunFd)
+                fdSet.writable.remove(tun.fd)
             }
         }
 
         // Read tun
-        if let tunFd, let tun, fdSet.readable.contains(tunFd) {
+        if let tun, fdSet.readable.contains(tun.fd) {
             var inbox: [Data] = []
             var readCount = 0
-            var readSize: Int32 = 0
+            var readSize = 0
             while readCount < maxReadCount, readSize < maxReadSize {
-                let count = pp_tun_read(tun, &tunBuf, tunBuf.count)
-                guard count != PP_TUN_WOULD_BLOCK else {
+                do {
+                    if let packet = try tun.dequeueRead() {
+                        inbox.append(packet)
+                        readSize += packet.count
+                    }
+                    readCount += 1
+                } catch IOError.wouldBlock {
                     break
-                }
-                guard count >= 0 else {
+                } catch {
                     throw PartoutError(.ioFailure)
                 }
-                if count > 0 {
-                    let packet = Data(tunBuf[0..<Int(count)])
-                    inbox.append(packet)
-                }
-                // Keep going
-                readCount += 1
-                readSize += count
             }
             if !inbox.isEmpty {
                 let action = delegate.onRead(inbox, .tun)
                 if action == .pause {
-                    pp_mux_set_read(mux, tunFd, false)
+                    pp_mux_set_read(mux, tun.fd, false)
                 }
             }
         }
 
         // Read link
-        if fdSet.readable.contains(linkFd) {
+        if fdSet.readable.contains(link.fd) {
             var inbox: [Data] = []
             var readCount = 0
-            var readSize: Int32 = 0
+            var readSize = 0
             while readCount < maxReadCount, readSize < maxReadSize {
-                let count = pp_socket_read(link, &linkBuf, linkBuf.count)
-                guard count != PP_SOCKET_WOULD_BLOCK else {
+                do {
+                    if let packet = try link.dequeueRead() {
+                        inbox.append(packet)
+                        readSize += packet.count
+                    }
+                    readCount += 1
+                } catch IOError.wouldBlock {
                     break
-                }
-                guard count >= 0 else {
+                } catch {
                     throw PartoutError(.ioFailure)
                 }
-                if count > 0 {
-                    let packet = Data(linkBuf[0..<Int(count)])
-                    inbox.append(packet)
-                }
-                // Keep going
-                readCount += 1
-                readSize += count
             }
             if !inbox.isEmpty {
                 let action = delegate.onRead(inbox, .link)
                 if action == .pause {
-                    pp_mux_set_read(mux, linkFd, false)
+                    pp_mux_set_read(mux, link.fd, false)
                 }
             }
         }
@@ -524,6 +458,180 @@ private final class FdSet {
 
     func resetReadable() {
         readable.removeAll(keepingCapacity: true)
+    }
+}
+
+// MARK: - SideIO
+
+private extension FdLooper {
+    enum IOError: Error {
+        case wouldBlock
+        case failed
+    }
+
+    struct PendingWrite {
+        let data: Data
+        let offset: Int
+        init(_ data: Data, offset: Int = 0) {
+            self.data = data
+            self.offset = offset
+        }
+        init(_ pending: PendingWrite, newOffset: Int) {
+            data = pending.data
+            offset = pending.offset + newOffset
+        }
+        var count: Int {
+            data.count - offset
+        }
+    }
+
+    final class SideIO {
+        let fd: Int32
+        let originalInterface: IOInterface
+        private let read: (inout [UInt8]) throws -> Data?
+        private let write: (PendingWrite) throws -> Int
+        let cleanup: () -> Void
+        private var readBuf: [UInt8]
+        private var writeQueue: RingQueue<PendingWrite>
+
+        init(
+            fd: Int32,
+            originalInterface: IOInterface,
+            readBufSize: Int,
+            read: @escaping @Sendable (inout [UInt8]) throws -> Data?,
+            write: @escaping @Sendable (PendingWrite) throws -> Int,
+            cleanup: @escaping @Sendable () -> Void
+        ) {
+            self.fd = fd
+            self.originalInterface = originalInterface
+            self.read = read
+            self.write = write
+            self.cleanup = cleanup
+            readBuf = Array(repeating: 0, count: readBufSize)
+            writeQueue = RingQueue()
+        }
+
+        func dequeueRead() throws -> Data? {
+            try read(&readBuf)
+        }
+
+        func performWrite(_ pending: PendingWrite, lock: SemaphoreMutex) throws -> Bool {
+            let count = try write(pending)
+            let didComplete = count == pending.count
+            lock.lock()
+            if didComplete {
+                writeQueue.removeFirst()
+            } else {
+                let partialPacket = PendingWrite(pending, newOffset: Int(count))
+                writeQueue.replaceFirst(with: partialPacket)
+            }
+            lock.unlock()
+            return didComplete
+        }
+
+        func dequeuePendingWrite() -> PendingWrite? {
+            writeQueue.first
+        }
+
+        func enqueueWrite(_ pendingWrite: PendingWrite) {
+            writeQueue.append(pendingWrite)
+        }
+    }
+}
+
+// MARK: - Link/Tun initializers
+
+private extension FdLooper.SideIO {
+    convenience init(
+        linkFd: Int32,
+        handle: pp_socket,
+        originalInterface: IOInterface,
+        readBufSize: Int
+    ) {
+        nonisolated(unsafe) let linkHandle = handle
+        self.init(
+            fd: linkFd,
+            originalInterface: originalInterface,
+            readBufSize: readBufSize,
+            read: { buf in
+                let count = pp_socket_read(linkHandle, &buf, buf.count)
+                guard count != PP_SOCKET_WOULD_BLOCK else {
+                    throw FdLooper.IOError.wouldBlock
+                }
+                guard count >= 0 else {
+                    throw FdLooper.IOError.failed
+                }
+                guard count > 0 else {
+                    return nil
+                }
+                return Data(buf[0..<Int(count)])
+            },
+            write: { pending in
+                let count = pending.data.withUnsafeBytes {
+                    pp_socket_write(
+                        linkHandle,
+                        $0.bytePointer + pending.offset,
+                        pending.count
+                    )
+                }
+                guard count != PP_SOCKET_WOULD_BLOCK else {
+                    throw FdLooper.IOError.wouldBlock
+                }
+                guard count >= 0 else {
+                    throw FdLooper.IOError.failed
+                }
+                return Int(count)
+            },
+            cleanup: {
+                pp_socket_release(linkHandle)
+            }
+        )
+    }
+
+    convenience init(
+        tunFd: Int32,
+        handle: pp_tun,
+        originalInterface: IOInterface,
+        readBufSize: Int
+    ) {
+        nonisolated(unsafe) let tunHandle = handle
+        self.init(
+            fd: tunFd,
+            originalInterface: originalInterface,
+            readBufSize: readBufSize,
+            read: { buf in
+                let count = pp_tun_read(tunHandle, &buf, buf.count)
+                guard count != PP_TUN_WOULD_BLOCK else {
+                    throw FdLooper.IOError.wouldBlock
+                }
+                guard count >= 0 else {
+                    throw FdLooper.IOError.failed
+                }
+                guard count > 0 else {
+                    return nil
+                }
+                return Data(buf[0..<Int(count)])
+            },
+            write: { pending in
+                let count = pending.data.withUnsafeBytes {
+                    pp_tun_write(
+                        tunHandle,
+                        $0.bytePointer + pending.offset,
+                        pending.count
+                    )
+                }
+                guard count != PP_TUN_WOULD_BLOCK else {
+                    throw FdLooper.IOError.wouldBlock
+                }
+                guard count >= 0 else {
+                    throw FdLooper.IOError.failed
+                }
+                return Int(count)
+            },
+            cleanup: {
+                pp_tun_release(tunHandle)
+            }
+        )
     }
 }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -399,7 +399,9 @@ private extension FdLooper {
                 readCount += 1
                 readSize += count
             }
-            delegate.onRead(inbox, .tun)
+            if !inbox.isEmpty {
+                delegate.onRead(inbox, .tun)
+            }
         }
 
         // Read link
@@ -423,7 +425,9 @@ private extension FdLooper {
                 readCount += 1
                 readSize += count
             }
-            delegate.onRead(inbox, .link)
+            if !inbox.isEmpty {
+                delegate.onRead(inbox, .link)
+            }
         }
     }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -40,6 +40,18 @@ public final class FdLooper: @unchecked Sendable {
         case stop
     }
 
+    private struct PendingWrite {
+        let data: Data
+        let offset: Int
+        init(_ data: Data, offset: Int = 0) {
+            self.data = data
+            self.offset = offset
+        }
+        var count: Int {
+            data.count - offset
+        }
+    }
+
     private static let numberOfDescriptors = 2
 
     private let ctx: PartoutLoggerContext
@@ -65,8 +77,8 @@ public final class FdLooper: @unchecked Sendable {
     // Consumer:
     // - Writes to linkQueue/tunQueue .outbound
     // - Reads from linkQueue/tunQueue .inbound
-    private var linkQueue: [Data]
-    private var tunQueue: [Data]
+    private var linkQueue: [PendingWrite]
+    private var tunQueue: [PendingWrite]
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -229,7 +241,7 @@ public final class FdLooper: @unchecked Sendable {
         switch side {
         case .link:
             packets.forEach {
-                linkQueue.append($0)
+                linkQueue.append(PendingWrite($0))
             }
             pp_mux_set_write(mux, linkFd, true)
         case .tun:
@@ -238,7 +250,7 @@ public final class FdLooper: @unchecked Sendable {
                 return
             }
             packets.forEach {
-                tunQueue.append($0)
+                tunQueue.append(PendingWrite($0))
             }
             pp_mux_set_write(mux, tunFd, true)
         }
@@ -304,9 +316,9 @@ private extension FdLooper {
         // Write link
         if fdSet.writable.contains(linkFd) {
             var watchWrites = false
-            while let packet = lock.with(block: { linkQueue.first }) {
-                let packetCount = packet.count
-                let count = packet.withUnsafeBytes {
+            while let pending = lock.with(block: { linkQueue.first }) {
+                let packetCount = pending.data.count
+                let count = pending.data.withUnsafeBytes {
                     pp_socket_write(link, $0.bytePointer, packetCount)
                 }
                 guard count != PP_SOCKET_WOULD_BLOCK else {
@@ -319,8 +331,8 @@ private extension FdLooper {
                 // Dequeue, but reinsert remainder on partial write
                 lock.lock()
                 linkQueue.removeFirst()
-                if count < packet.count {
-                    let partialPacket = Data(packet[Int(count)...])
+                if count < pending.count {
+                    let partialPacket = PendingWrite(pending.data, offset: Int(count))
                     linkQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
@@ -336,9 +348,9 @@ private extension FdLooper {
         // Write tun
         if let tunFd, let tun, fdSet.writable.contains(tunFd) {
             var watchWrites = false
-            while let packet = lock.with(block: { tunQueue.first }) {
-                let packetCount = packet.count
-                let count = packet.withUnsafeBytes {
+            while let pending = lock.with(block: { tunQueue.first }) {
+                let packetCount = pending.data.count
+                let count = pending.data.withUnsafeBytes {
                     pp_tun_write(tun, $0.bytePointer, packetCount)
                 }
                 guard count != PP_TUN_WOULD_BLOCK else {
@@ -351,8 +363,8 @@ private extension FdLooper {
                 // Dequeue, but reinsert remainder on partial write
                 lock.lock()
                 tunQueue.removeFirst()
-                if count < packet.count {
-                    let partialPacket = Data(packet[Int(count)...])
+                if count < pending.count {
+                    let partialPacket = PendingWrite(pending.data, offset: Int(count))
                     tunQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -43,6 +43,7 @@ public final class FdLooper: @unchecked Sendable {
 
     fileprivate enum Command {
         case attachTun(tunInterface: IOInterface, CheckedContinuation<Void, Error>)
+        case setRead(Side, isEnabled: Bool)
         case stop
     }
 
@@ -251,17 +252,8 @@ public final class FdLooper: @unchecked Sendable {
 
     public func resumeReading(from side: Side) {
         lock.lock()
-        defer { lock.unlock() }
-        switch side {
-        case .link:
-            pp_mux_set_read(mux, linkFd, true)
-        case .tun:
-            guard let tunFd else {
-                pp_log(ctx, .core, .error, "Ignoring tun resume, not attached")
-                return
-            }
-            pp_mux_set_read(mux, tunFd, true)
-        }
+        commands.append(.setRead(side, isEnabled: true))
+        lock.unlock()
     }
 
     public func write(_ packets: [Data], to side: Side) {
@@ -325,6 +317,17 @@ private extension FdLooper {
                 tunFd = fd
                 tun = pp_tun_create(fd)
                 results.append(.attachTun(continuation, .success(())))
+            case .setRead(let side, let isEnabled):
+                switch side {
+                case .link:
+                    pp_mux_set_read(mux, linkFd, isEnabled)
+                case .tun:
+                    guard let tunFd else {
+                        pp_log(ctx, .core, .error, "Ignoring tun setRead(), not attached")
+                        return true
+                    }
+                    pp_mux_set_read(mux, tunFd, isEnabled)
+                }
             case .stop:
                 pp_log(ctx, .core, .info, "Stop looper")
                 shouldStop = true

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -165,9 +165,10 @@ public final class FdLooper: @unchecked Sendable {
         // Event loop
         state = .started
         loopQueue.async { [weak self] in
+            var lastError: Error?
             defer {
                 pp_log(self?.ctx ?? .global, .core, .info, "Finish looper")
-                self?.finish()
+                self?.finish(throwing: lastError)
             }
 
             // Hold mux weakly
@@ -213,7 +214,7 @@ public final class FdLooper: @unchecked Sendable {
                     try process(mux: mux, fdSet: fdSet)
                 } catch {
                     pp_log(ctx, .core, .error, "Unable to process: \(error)")
-                    finish(throwing: error)
+                    lastError = error
                     break
                 }
             }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -5,8 +5,9 @@
 #if !os(Windows)
 internal import _PartoutCore_C
 
+/// Delegates ``FdLooper`` events.
 public struct FdLooperDelegate: Sendable {
-    public typealias OnRead = @Sendable (_ packets: [Data], _ side: FdLooper.Side) -> Void
+    public typealias OnRead = @Sendable (_ packets: [Data], _ side: FdLooper.Side) -> FdLooper.ReadAction
     public typealias OnFinish = @Sendable (_ error: Error?) -> Void
 
     public let onRead: OnRead
@@ -26,6 +27,11 @@ public final class FdLooper: @unchecked Sendable {
     public enum Side: Sendable {
         case link
         case tun
+    }
+
+    public enum ReadAction: Sendable {
+        case keep
+        case pause
     }
 
     private enum State: Sendable {
@@ -415,7 +421,10 @@ private extension FdLooper {
                 readSize += count
             }
             if !inbox.isEmpty {
-                delegate.onRead(inbox, .tun)
+                let action = delegate.onRead(inbox, .tun)
+                if action == .pause {
+                    pp_mux_set_read(mux, tunFd, false)
+                }
             }
         }
 
@@ -441,7 +450,10 @@ private extension FdLooper {
                 readSize += count
             }
             if !inbox.isEmpty {
-                delegate.onRead(inbox, .link)
+                let action = delegate.onRead(inbox, .link)
+                if action == .pause {
+                    pp_mux_set_read(mux, linkFd, false)
+                }
             }
         }
     }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -223,10 +223,7 @@ public final class FdLooper: @unchecked Sendable {
 
     public func stop() async throws {
         lock.lock()
-        guard state == .started else {
-            lock.unlock()
-            return
-        }
+        precondition(state == .started, "Cannot stop() twice")
         state = .stopping
         try await withCheckedThrowingContinuation { continuation in
             stopContinuation = continuation

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -433,6 +433,7 @@ private extension FdLooper {
         guard terminalError == nil else { return }
         terminalError = error
         state = .stopped
+        delegate.onFinish(error)
     }
 }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -47,6 +47,10 @@ public final class FdLooper: @unchecked Sendable {
             self.data = data
             self.offset = offset
         }
+        init(_ pending: PendingWrite, newOffset: Int) {
+            data = pending.data
+            offset = pending.offset + newOffset
+        }
         var count: Int {
             data.count - offset
         }
@@ -336,7 +340,7 @@ private extension FdLooper {
                 lock.lock()
                 linkQueue.removeFirst()
                 if count < pending.count {
-                    let partialPacket = PendingWrite(pending.data, offset: Int(count))
+                    let partialPacket = PendingWrite(pending, newOffset: Int(count))
                     linkQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
@@ -372,7 +376,7 @@ private extension FdLooper {
                 lock.lock()
                 tunQueue.removeFirst()
                 if count < pending.count {
-                    let partialPacket = PendingWrite(pending.data, offset: Int(count))
+                    let partialPacket = PendingWrite(pending, newOffset: Int(count))
                     tunQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -137,20 +137,6 @@ public final class FdLooper: @unchecked Sendable {
         pp_mux_free(mux)
     }
 
-    public func attachTun(_ tunInterface: IOInterface) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            lock.with {
-                // Ignore command if not started or stopping
-                guard [.idle, .stopping].contains(state) else {
-                    continuation.resume(throwing: CancellationError())
-                    return
-                }
-                commands.append(.attachTun(tunInterface: tunInterface, continuation))
-                pp_mux_wake(mux)
-            }
-        }
-    }
-
     public func start() throws {
         lock.lock()
         defer { lock.unlock() }
@@ -220,6 +206,20 @@ public final class FdLooper: @unchecked Sendable {
         state = .stopping
         commands.append(.stop)
         pp_mux_wake(mux)
+    }
+
+    public func attachTun(_ tunInterface: IOInterface) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            lock.with {
+                // Ignore command if not started or stopping
+                guard [.idle, .stopping].contains(state) else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                commands.append(.attachTun(tunInterface: tunInterface, continuation))
+                pp_mux_wake(mux)
+            }
+        }
     }
 }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -5,9 +5,29 @@
 #if !os(Windows)
 internal import _PartoutCore_C
 
+public struct FdLooperDelegate: Sendable {
+    public enum Side: Sendable {
+        case link
+        case tun
+    }
+    public typealias OnRead = @Sendable (_ packets: [Data], _ side: Side) -> Void
+    public typealias OnFinish = @Sendable (_ error: Error?) -> Void
+
+    public let onRead: OnRead
+    public let onFinish: OnFinish
+
+    public init(
+        onRead: @escaping OnRead,
+        onFinish: @escaping OnFinish
+    ) {
+        self.onRead = onRead
+        self.onFinish = onFinish
+    }
+}
+
 /// Loops through a set of file descriptors.
 public final class FdLooper: @unchecked Sendable {
-    private enum State {
+    private enum State: Sendable {
         case idle
         case started
         case stopping
@@ -29,6 +49,7 @@ public final class FdLooper: @unchecked Sendable {
     private var tunFd: Int32?
     private let link: pp_socket
     private var tun: pp_tun?
+    private let delegate: FdLooperDelegate
     private let maxReadSize: Int
     private let maxReadCount: Int
 
@@ -43,13 +64,14 @@ public final class FdLooper: @unchecked Sendable {
     // Consumer:
     // - Writes to linkQueue/tunQueue .outbound
     // - Reads from linkQueue/tunQueue .inbound
-    private var linkQueue: BidirectionalState<[Data]>
-    private var tunQueue: BidirectionalState<[Data]>
+    private var linkQueue: [Data]
+    private var tunQueue: [Data]
 
     public init(
         _ ctx: PartoutLoggerContext,
         link linkInterface: IOInterface,
         tun tunInterface: IOInterface?,
+        delegate: FdLooperDelegate,
         linkBufSize: Int = 64 * 1024,
         tunBufSize: Int = 16 * 1024,
         maxReadSize: Int = 256 * 1024,
@@ -88,6 +110,7 @@ public final class FdLooper: @unchecked Sendable {
         originalTun = tunInterface
         self.linkFd = linkFd
         self.tunFd = tunFd
+        self.delegate = delegate
         self.maxReadSize = max(maxReadSize, linkBufSize, tunBufSize)
         self.maxReadCount = maxReadCount
 
@@ -99,8 +122,8 @@ public final class FdLooper: @unchecked Sendable {
         tun = tunFd.map(pp_tun_create)
         linkBuf = Array(repeating: 0, count: linkBufSize)
         tunBuf = Array(repeating: 0, count: tunBufSize)
-        linkQueue = BidirectionalState(withResetValue: [])
-        tunQueue = BidirectionalState(withResetValue: [])
+        linkQueue = []
+        tunQueue = []
     }
 
     deinit {
@@ -259,7 +282,7 @@ private extension FdLooper {
         // Write link
         if fdSet.writable.contains(linkFd) {
             var watchWrites = false
-            while let packet = linkQueue.outbound.first {
+            while let packet = linkQueue.first {
                 let packetCount = packet.count
                 let count = packet.withUnsafeBytes {
                     pp_socket_write(link, $0.bytePointer, packetCount)
@@ -272,10 +295,10 @@ private extension FdLooper {
                     throw PartoutError(.ioFailure)
                 }
                 // Dequeue, but reinsert remainder on partial write
-                linkQueue.outbound.removeFirst()
+                linkQueue.removeFirst()
                 if count < packet.count {
                     let partialPacket = Data(packet[Int(count)...])
-                    linkQueue.outbound.insert(partialPacket, at: 0)
+                    linkQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
             }
@@ -289,7 +312,7 @@ private extension FdLooper {
         // Write tun
         if let tunFd, let tun, fdSet.writable.contains(tunFd) {
             var watchWrites = false
-            while let packet = tunQueue.outbound.first {
+            while let packet = tunQueue.first {
                 let packetCount = packet.count
                 let count = packet.withUnsafeBytes {
                     pp_tun_write(tun, $0.bytePointer, packetCount)
@@ -302,10 +325,10 @@ private extension FdLooper {
                     throw PartoutError(.ioFailure)
                 }
                 // Dequeue, but reinsert remainder on partial write
-                tunQueue.outbound.removeFirst()
+                tunQueue.removeFirst()
                 if count < packet.count {
                     let partialPacket = Data(packet[Int(count)...])
-                    tunQueue.outbound.insert(partialPacket, at: 0)
+                    tunQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
             }
@@ -318,6 +341,7 @@ private extension FdLooper {
 
         // Read tun
         if let tunFd, let tun, fdSet.readable.contains(tunFd) {
+            var inbox: [Data] = []
             var readCount = 0
             var readSize: Int32 = 0
             while readCount < maxReadCount, readSize < maxReadSize {
@@ -330,16 +354,18 @@ private extension FdLooper {
                 }
                 if count > 0 {
                     let packet = Data(tunBuf[0..<Int(count)])
-                    tunQueue.inbound.append(packet)
+                    inbox.append(packet)
                 }
                 // Keep going
                 readCount += 1
                 readSize += count
             }
+            delegate.onRead(inbox, .tun)
         }
 
         // Read link
         if fdSet.readable.contains(linkFd) {
+            var inbox: [Data] = []
             var readCount = 0
             var readSize: Int32 = 0
             while readCount < maxReadCount, readSize < maxReadSize {
@@ -352,12 +378,13 @@ private extension FdLooper {
                 }
                 if count > 0 {
                     let packet = Data(linkBuf[0..<Int(count)])
-                    linkQueue.inbound.append(packet)
+                    inbox.append(packet)
                 }
                 // Keep going
                 readCount += 1
                 readSize += count
             }
+            delegate.onRead(inbox, .link)
         }
     }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -253,9 +253,9 @@ public final class FdLooper: @unchecked Sendable {
 
     public func resumeReading(from side: Side) {
         lock.lock()
+        defer { lock.unlock() }
         commands.append(.enableRead(side))
         pp_mux_wake(mux)
-        lock.unlock()
     }
 
     public func write(_ packets: [Data], to side: Side) {
@@ -277,6 +277,7 @@ public final class FdLooper: @unchecked Sendable {
             }
             commands.append(.enableWrite(.tun))
         }
+        pp_mux_wake(mux)
     }
 }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -7,6 +7,13 @@ internal import _PartoutCore_C
 
 /// Loops through a set of file descriptors.
 public final class FdLooper: @unchecked Sendable {
+    private enum State {
+        case idle
+        case started
+        case stopping
+        case stopped
+    }
+
     fileprivate enum Command {
         case attachTun(tunInterface: IOInterface, CheckedContinuation<Void, Error>)
         case stop
@@ -25,10 +32,11 @@ public final class FdLooper: @unchecked Sendable {
     private let maxReadSize: Int
     private let maxReadCount: Int
 
+    private let loopQueue: DispatchQueue
     private let lock: SemaphoreMutex
-    private var loopTask: Task<Void, Never>?
     private var commands: [Command]
-    private var isStopping: Bool
+    private var state: State
+    private var terminalError: Error?
     private var linkBuf: [UInt8]
     private var tunBuf: [UInt8]
 
@@ -83,9 +91,10 @@ public final class FdLooper: @unchecked Sendable {
         self.maxReadSize = max(maxReadSize, linkBufSize, tunBufSize)
         self.maxReadCount = maxReadCount
 
+        loopQueue = DispatchQueue(label: "FdLooper")
         lock = SemaphoreMutex()
         commands = []
-        isStopping = false
+        state = .idle
         link = pp_socket_create(UInt64(linkFd))
         tun = tunFd.map(pp_tun_create)
         linkBuf = Array(repeating: 0, count: linkBufSize)
@@ -97,7 +106,7 @@ public final class FdLooper: @unchecked Sendable {
     deinit {
         lock.lock()
         defer { lock.unlock() }
-        precondition(loopTask == nil, "Call await stop() before releasing InterfaceLooper")
+        precondition(state == .started, "Call await stop() before releasing InterfaceLooper")
 
         pp_log(ctx, .core, .debug, "Deinit InterfaceLooper")
         pp_socket_release(link)
@@ -109,7 +118,7 @@ public final class FdLooper: @unchecked Sendable {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             lock.with {
                 // Ignore command if not started or stopping
-                guard loopTask != nil, !isStopping else {
+                guard [.idle, .stopping].contains(state) else {
                     continuation.resume(throwing: CancellationError())
                     return
                 }
@@ -122,17 +131,21 @@ public final class FdLooper: @unchecked Sendable {
     public func start() throws {
         lock.lock()
         defer { lock.unlock() }
-        precondition(loopTask == nil, "Looper already started")
+        precondition(state == .idle, "Looper already started")
 
         // Event loop
-        loopTask = Task { [weak self] in
+        loopQueue.async { [weak self] in
             defer {
                 pp_log(self?.ctx ?? .global, .core, .info, "Finish looper")
+                self?.finish()
             }
+
+            // Hold mux weakly
             guard let weakMux = self?.mux else { return }
             nonisolated(unsafe) let mux = weakMux
 
-            // Bind I/O callbacks to fd set
+            // Bind I/O callbacks to fd set. Fd set is never mutated
+            // concurrently, no locks are needed.
             let fdSet = FdSet(capacity: Self.numberOfDescriptors)
             let fdSetCtx = Unmanaged.passRetained(fdSet).toOpaque()
             pp_mux_set_on_readable(mux, { ctx, fd in
@@ -144,31 +157,19 @@ public final class FdLooper: @unchecked Sendable {
                 fdSet.writable.insert(fd)
             }, fdSetCtx)
 
-            // Fd sets are mutated here and in the waitQueue, but
-            // never concurrently, so no locks are needed
-            let waitQueue = DispatchQueue(label: "InterfaceLooper.Waiter")
-            pp_log(self?.ctx ?? .global, .core, .info, "Start looper")
-
-            // Remember to clean up on task end
+            // Remember to clean up on finish
             defer {
                 Unmanaged<FdSet>.fromOpaque(fdSetCtx).release()
             }
 
             // Start loop
+            pp_log(self?.ctx ?? .global, .core, .info, "Start looper")
             while true {
                 // Reset readable fds before the wait
                 fdSet.resetReadable()
 
                 // Perform the blocking call
-                let result = await withCheckedContinuation { continuation in
-                    waitQueue.async {
-                        let num = pp_mux_wait(mux)
-                        continuation.resume(returning: num)
-                    }
-                }
-                guard result >= 0 else {
-                    break
-                }
+                guard pp_mux_wait(mux) >= 0 else { break }
 
                 // Unwrap AFTER blocking call
                 guard let self else { break }
@@ -182,29 +183,20 @@ public final class FdLooper: @unchecked Sendable {
                     try process(mux: mux, fdSet: fdSet)
                 } catch {
                     pp_log(ctx, .core, .error, "Unable to process: \(error)")
+                    finish(throwing: error)
+                    break
                 }
             }
         }
     }
 
-    public func stop() async {
-        let task: Task<Void, Never>?
-
-        // Submit .stop command
+    public func stop() {
         lock.lock()
-        task = loopTask
-        if task != nil, !isStopping {
-            isStopping = true
-            commands.append(.stop)
-            pp_mux_wake(mux)
-        }
-        lock.unlock()
-
-        // Wait for task to exit
-        await task?.value
-        lock.with {
-            loopTask = nil
-        }
+        defer { lock.unlock() }
+        guard state == .started else { return }
+        state = .stopping
+        commands.append(.stop)
+        pp_mux_wake(mux)
     }
 }
 
@@ -228,7 +220,7 @@ private extension FdLooper {
                     break
                 }
                 // Cancel attach if stopping
-                guard !isStopping else {
+                guard state != .stopping else {
                     results.append(.attachTun(continuation, .failure(CancellationError())))
                     break
                 }
@@ -367,6 +359,14 @@ private extension FdLooper {
                 readSize += count
             }
         }
+    }
+
+    func finish(throwing error: Error? = nil) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard terminalError == nil else { return }
+        terminalError = error
+        state = .stopped
     }
 }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -332,7 +332,7 @@ private extension FdLooper {
         // Write link
         if fdSet.writable.contains(link.fd) {
             var watchWrites = false
-            while let pending = lock.with(block: { link.dequeuePendingWrite() }) {
+            while let pending = lock.with(block: { link.dequeueWrite() }) {
                 do {
                     let didComplete = try link.performWrite(pending, lock: lock)
                     watchWrites = !didComplete
@@ -353,7 +353,7 @@ private extension FdLooper {
         // Write tun
         if let tun, fdSet.writable.contains(tun.fd) {
             var watchWrites = false
-            while let pending = lock.with(block: { tun.dequeuePendingWrite() }) {
+            while let pending = lock.with(block: { tun.dequeueWrite() }) {
                 do {
                     let didComplete = try tun.performWrite(pending, lock: lock)
                     watchWrites = !didComplete
@@ -529,7 +529,7 @@ private extension FdLooper {
             return didComplete
         }
 
-        func dequeuePendingWrite() -> PendingWrite? {
+        func dequeueWrite() -> PendingWrite? {
             writeQueue.first
         }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -323,7 +323,11 @@ private extension FdLooper {
             while let pending = lock.with(block: { linkQueue.first }) {
                 let packetCount = pending.data.count
                 let count = pending.data.withUnsafeBytes {
-                    pp_socket_write(link, $0.bytePointer + pending.offset, packetCount)
+                    pp_socket_write(
+                        link,
+                        $0.bytePointer + pending.offset,
+                        packetCount - pending.offset
+                    )
                 }
                 guard count != PP_SOCKET_WOULD_BLOCK else {
                     watchWrites = true
@@ -355,7 +359,11 @@ private extension FdLooper {
             while let pending = lock.with(block: { tunQueue.first }) {
                 let packetCount = pending.data.count
                 let count = pending.data.withUnsafeBytes {
-                    pp_tun_write(tun, $0.bytePointer + pending.offset, packetCount)
+                    pp_tun_write(
+                        tun,
+                        $0.bytePointer + pending.offset,
+                        packetCount - pending.offset
+                    )
                 }
                 guard count != PP_TUN_WOULD_BLOCK else {
                     watchWrites = true

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -43,7 +43,8 @@ public final class FdLooper: @unchecked Sendable {
 
     fileprivate enum Command {
         case attachTun(tunInterface: IOInterface, CheckedContinuation<Void, Error>)
-        case setRead(Side, isEnabled: Bool)
+        case enableRead(Side)
+        case enableWrite(Side)
         case stop
     }
 
@@ -252,7 +253,8 @@ public final class FdLooper: @unchecked Sendable {
 
     public func resumeReading(from side: Side) {
         lock.lock()
-        commands.append(.setRead(side, isEnabled: true))
+        commands.append(.enableRead(side))
+        pp_mux_wake(mux)
         lock.unlock()
     }
 
@@ -264,7 +266,7 @@ public final class FdLooper: @unchecked Sendable {
             packets.forEach {
                 linkQueue.append(PendingWrite($0))
             }
-            pp_mux_set_write(mux, linkFd, true)
+            commands.append(.enableWrite(.link))
         case .tun:
             guard let tunFd else {
                 pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
@@ -273,7 +275,7 @@ public final class FdLooper: @unchecked Sendable {
             packets.forEach {
                 tunQueue.append(PendingWrite($0))
             }
-            pp_mux_set_write(mux, tunFd, true)
+            commands.append(.enableWrite(.tun))
         }
     }
 }
@@ -317,16 +319,27 @@ private extension FdLooper {
                 tunFd = fd
                 tun = pp_tun_create(fd)
                 results.append(.attachTun(continuation, .success(())))
-            case .setRead(let side, let isEnabled):
+            case .enableRead(let side):
                 switch side {
                 case .link:
-                    pp_mux_set_read(mux, linkFd, isEnabled)
+                    pp_mux_set_read(mux, linkFd, true)
                 case .tun:
-                    guard let tunFd else {
-                        pp_log(ctx, .core, .error, "Ignoring tun setRead(), not attached")
-                        return true
+                    if let tunFd {
+                        pp_mux_set_read(mux, tunFd, true)
+                    } else {
+                        pp_log(ctx, .core, .error, "Ignoring tun enableRead(), not attached")
                     }
-                    pp_mux_set_read(mux, tunFd, isEnabled)
+                }
+            case .enableWrite(let side):
+                switch side {
+                case .link:
+                    pp_mux_set_write(mux, linkFd, true)
+                case .tun:
+                    if let tunFd {
+                        pp_mux_set_write(mux, tunFd, true)
+                    } else {
+                        pp_log(ctx, .core, .error, "Ignoring tun enableWrite(), not attached")
+                    }
                 }
             case .stop:
                 pp_log(ctx, .core, .info, "Stop looper")

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -228,11 +228,7 @@ public final class FdLooper: @unchecked Sendable {
     public func attachTun(_ tunInterface: IOInterface) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             lock.with {
-                // Ignore command if not started or stopping
-                guard [.idle, .stopping].contains(state) else {
-                    continuation.resume(throwing: CancellationError())
-                    return
-                }
+                precondition(state == .started, "Attach tun after start()")
                 commands.append(.attachTun(tunInterface: tunInterface, continuation))
                 pp_mux_wake(mux)
             }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -249,6 +249,21 @@ public final class FdLooper: @unchecked Sendable {
         }
     }
 
+    public func resumeReading(from side: Side) {
+        lock.lock()
+        defer { lock.unlock() }
+        switch side {
+        case .link:
+            pp_mux_set_read(mux, linkFd, true)
+        case .tun:
+            guard let tunFd else {
+                pp_log(ctx, .core, .error, "Ignoring tun resume, not attached")
+                return
+            }
+            pp_mux_set_read(mux, tunFd, true)
+        }
+    }
+
     public func write(_ packets: [Data], to side: Side) {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -156,6 +156,7 @@ public final class FdLooper: @unchecked Sendable {
         precondition(state == .idle, "Looper already started")
 
         // Event loop
+        state = .started
         loopQueue.async { [weak self] in
             defer {
                 pp_log(self?.ctx ?? .global, .core, .info, "Finish looper")

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -226,7 +226,7 @@ public final class FdLooper: @unchecked Sendable {
         switch side {
         case .link:
             packets.forEach {
-                link.unsafeEnqueueWrite(PendingWrite($0))
+                link.unsafeEnqueueWrite($0)
             }
             commands.append(.enableWrite(.link))
         case .tun:
@@ -235,7 +235,7 @@ public final class FdLooper: @unchecked Sendable {
                 return
             }
             packets.forEach {
-                tun.unsafeEnqueueWrite(PendingWrite($0))
+                tun.unsafeEnqueueWrite($0)
             }
             commands.append(.enableWrite(.tun))
         }
@@ -476,10 +476,6 @@ private extension FdLooper {
             self.data = data
             self.offset = offset
         }
-        init(_ pending: PendingWrite, newOffset: Int) {
-            data = pending.data
-            offset = pending.offset + newOffset
-        }
         var count: Int {
             data.count - offset
         }
@@ -492,7 +488,8 @@ private extension FdLooper {
         private let write: (PendingWrite) throws -> Int
         let cleanup: () -> Void
         private var readBuf: [UInt8]
-        private var writeQueue: RingQueue<PendingWrite>
+        private var writeQueue: RingQueue<Data>
+        private var writeOffset: Int
 
         init(
             fd: Int32,
@@ -509,6 +506,7 @@ private extension FdLooper {
             self.cleanup = cleanup
             readBuf = Array(repeating: 0, count: readBufSize)
             writeQueue = RingQueue()
+            writeOffset = 0
         }
 
         func dequeueRead() throws -> Data? {
@@ -521,9 +519,9 @@ private extension FdLooper {
             lock.lock()
             if didComplete {
                 writeQueue.removeFirst()
+                writeOffset = 0
             } else {
-                let partialPacket = PendingWrite(pending, newOffset: Int(count))
-                writeQueue.replaceFirst(with: partialPacket)
+                writeOffset += count
             }
             lock.unlock()
             return didComplete
@@ -531,12 +529,14 @@ private extension FdLooper {
 
         func dequeueWrite(lock: SemaphoreMutex) -> PendingWrite? {
             lock.with {
-                writeQueue.first
+                writeQueue.first.map {
+                    PendingWrite($0, offset: writeOffset)
+                }
             }
         }
 
-        func unsafeEnqueueWrite(_ pendingWrite: PendingWrite) {
-            writeQueue.append(pendingWrite)
+        func unsafeEnqueueWrite(_ packet: Data) {
+            writeQueue.append(packet)
         }
     }
 }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -264,7 +264,7 @@ private extension FdLooper {
             while let packet = linkQueue.outbound.first {
                 let packetCount = packet.count
                 let count = packet.withUnsafeBytes {
-                    pp_socket_write(link, $0, packetCount)
+                    pp_socket_write(link, $0.bytePointer, packetCount)
                 }
                 guard count != PP_SOCKET_WOULD_BLOCK else {
                     watchWrites = true
@@ -294,7 +294,7 @@ private extension FdLooper {
             while let packet = tunQueue.outbound.first {
                 let packetCount = packet.count
                 let count = packet.withUnsafeBytes {
-                    pp_tun_write(tun, $0, packetCount)
+                    pp_tun_write(tun, $0.bytePointer, packetCount)
                 }
                 guard count != PP_TUN_WOULD_BLOCK else {
                     watchWrites = true

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -222,6 +222,27 @@ public final class FdLooper: @unchecked Sendable {
             }
         }
     }
+
+    public func write(_ packets: [Data], to side: Side) {
+        lock.lock()
+        defer { lock.unlock() }
+        switch side {
+        case .link:
+            packets.forEach {
+                linkQueue.append($0)
+            }
+            pp_mux_set_write(mux, linkFd, true)
+        case .tun:
+            guard let tunFd else {
+                pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
+                return
+            }
+            packets.forEach {
+                tunQueue.append($0)
+            }
+            pp_mux_set_write(mux, tunFd, true)
+        }
+    }
 }
 
 private extension FdLooper {
@@ -283,7 +304,7 @@ private extension FdLooper {
         // Write link
         if fdSet.writable.contains(linkFd) {
             var watchWrites = false
-            while let packet = linkQueue.first {
+            while let packet = lock.with(block: { linkQueue.first }) {
                 let packetCount = packet.count
                 let count = packet.withUnsafeBytes {
                     pp_socket_write(link, $0.bytePointer, packetCount)
@@ -296,12 +317,14 @@ private extension FdLooper {
                     throw PartoutError(.ioFailure)
                 }
                 // Dequeue, but reinsert remainder on partial write
+                lock.lock()
                 linkQueue.removeFirst()
                 if count < packet.count {
                     let partialPacket = Data(packet[Int(count)...])
                     linkQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
+                lock.unlock()
             }
             // Stop watching if no blocks
             pp_mux_set_write(mux, linkFd, watchWrites)
@@ -313,7 +336,7 @@ private extension FdLooper {
         // Write tun
         if let tunFd, let tun, fdSet.writable.contains(tunFd) {
             var watchWrites = false
-            while let packet = tunQueue.first {
+            while let packet = lock.with(block: { tunQueue.first }) {
                 let packetCount = packet.count
                 let count = packet.withUnsafeBytes {
                     pp_tun_write(tun, $0.bytePointer, packetCount)
@@ -326,12 +349,14 @@ private extension FdLooper {
                     throw PartoutError(.ioFailure)
                 }
                 // Dequeue, but reinsert remainder on partial write
+                lock.lock()
                 tunQueue.removeFirst()
                 if count < packet.count {
                     let partialPacket = Data(packet[Int(count)...])
                     tunQueue.insert(partialPacket, at: 0)
                     watchWrites = true
                 }
+                lock.unlock()
             }
             // Stop watching if no blocks
             pp_mux_set_write(mux, tunFd, watchWrites)

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -167,7 +167,12 @@ public final class FdLooper: @unchecked Sendable {
         loopQueue.async { [weak self] in
             var lastError: Error?
             defer {
-                pp_log(self?.ctx ?? .global, .core, .info, "Finish looper")
+                let logCtx = self?.ctx ?? .global
+                if let lastError {
+                    pp_log(logCtx, .core, .error, "Finish looper with error: \(lastError)")
+                } else {
+                    pp_log(logCtx, .core, .info, "Finish looper")
+                }
                 self?.finish(throwing: lastError)
             }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -226,7 +226,7 @@ public final class FdLooper: @unchecked Sendable {
         switch side {
         case .link:
             packets.forEach {
-                link.enqueueWrite(PendingWrite($0))
+                link.unsafeEnqueueWrite(PendingWrite($0))
             }
             commands.append(.enableWrite(.link))
         case .tun:
@@ -235,7 +235,7 @@ public final class FdLooper: @unchecked Sendable {
                 return
             }
             packets.forEach {
-                tun.enqueueWrite(PendingWrite($0))
+                tun.unsafeEnqueueWrite(PendingWrite($0))
             }
             commands.append(.enableWrite(.tun))
         }
@@ -535,7 +535,7 @@ private extension FdLooper {
             }
         }
 
-        func enqueueWrite(_ pendingWrite: PendingWrite) {
+        func unsafeEnqueueWrite(_ pendingWrite: PendingWrite) {
             writeQueue.append(pendingWrite)
         }
     }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -223,13 +223,16 @@ public final class FdLooper: @unchecked Sendable {
 
     public func stop() async throws {
         lock.lock()
-        defer { lock.unlock() }
-        guard state == .started else { return }
+        guard state == .started else {
+            lock.unlock()
+            return
+        }
         state = .stopping
         try await withCheckedThrowingContinuation { continuation in
             stopContinuation = continuation
             commands.append(.stop)
             pp_mux_wake(mux)
+            lock.unlock()
         }
     }
 

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -6,11 +6,7 @@
 internal import _PartoutCore_C
 
 public struct FdLooperDelegate: Sendable {
-    public enum Side: Sendable {
-        case link
-        case tun
-    }
-    public typealias OnRead = @Sendable (_ packets: [Data], _ side: Side) -> Void
+    public typealias OnRead = @Sendable (_ packets: [Data], _ side: FdLooper.Side) -> Void
     public typealias OnFinish = @Sendable (_ error: Error?) -> Void
 
     public let onRead: OnRead
@@ -27,6 +23,11 @@ public struct FdLooperDelegate: Sendable {
 
 /// Loops through a set of file descriptors.
 public final class FdLooper: @unchecked Sendable {
+    public enum Side: Sendable {
+        case link
+        case tun
+    }
+
     private enum State: Sendable {
         case idle
         case started

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -167,12 +167,6 @@ public final class FdLooper: @unchecked Sendable {
         loopQueue.async { [weak self] in
             var lastError: Error?
             defer {
-                let logCtx = self?.ctx ?? .global
-                if let lastError {
-                    pp_log(logCtx, .core, .error, "Finish looper with error: \(lastError)")
-                } else {
-                    pp_log(logCtx, .core, .info, "Finish looper")
-                }
                 self?.finish(throwing: lastError)
             }
 
@@ -449,6 +443,12 @@ private extension FdLooper {
     }
 
     func finish(throwing error: Error? = nil) {
+        if let error {
+            pp_log(ctx, .core, .error, "Finish looper with error: \(error)")
+        } else {
+            pp_log(ctx, .core, .info, "Finish looper")
+        }
+
         lock.lock()
         precondition(state != .stopped)
         state = .stopped

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -90,8 +90,8 @@ public final class FdLooper: @unchecked Sendable {
     // Consumer:
     // - Writes to linkQueue/tunQueue .outbound
     // - Reads from linkQueue/tunQueue .inbound
-    private var linkQueue: [PendingWrite]
-    private var tunQueue: [PendingWrite]
+    private var linkQueue: RingQueue<PendingWrite>
+    private var tunQueue: RingQueue<PendingWrite>
 
     public init(
         _ ctx: PartoutLoggerContext,
@@ -148,8 +148,8 @@ public final class FdLooper: @unchecked Sendable {
         tun = tunFd.map(pp_tun_create)
         linkBuf = Array(repeating: 0, count: linkBufSize)
         tunBuf = Array(repeating: 0, count: tunBufSize)
-        linkQueue = []
-        tunQueue = []
+        linkQueue = RingQueue()
+        tunQueue = RingQueue()
     }
 
     deinit {
@@ -378,13 +378,13 @@ private extension FdLooper {
                 guard count >= 0 else {
                     throw PartoutError(.ioFailure)
                 }
-                // Dequeue, but reinsert remainder on partial write
                 lock.lock()
-                linkQueue.removeFirst()
                 if count < pending.count {
                     let partialPacket = PendingWrite(pending, newOffset: Int(count))
-                    linkQueue.insert(partialPacket, at: 0)
+                    linkQueue.replaceFirst(with: partialPacket)
                     watchWrites = true
+                } else {
+                    linkQueue.removeFirst()
                 }
                 lock.unlock()
             }
@@ -414,13 +414,13 @@ private extension FdLooper {
                 guard count >= 0 else {
                     throw PartoutError(.ioFailure)
                 }
-                // Dequeue, but reinsert remainder on partial write
                 lock.lock()
-                tunQueue.removeFirst()
                 if count < pending.count {
                     let partialPacket = PendingWrite(pending, newOffset: Int(count))
-                    tunQueue.insert(partialPacket, at: 0)
+                    tunQueue.replaceFirst(with: partialPacket)
                     watchWrites = true
+                } else {
+                    tunQueue.removeFirst()
                 }
                 lock.unlock()
             }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -440,10 +440,14 @@ private extension FdLooper {
 
     func finish(throwing error: Error? = nil) {
         lock.lock()
-        defer { lock.unlock() }
-        guard terminalError == nil else { return }
+        guard terminalError == nil else {
+            lock.unlock()
+            return
+        }
         terminalError = error
         state = .stopped
+        lock.unlock()
+
         delegate.onFinish(error)
     }
 }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -142,7 +142,10 @@ public final class FdLooper: @unchecked Sendable {
     deinit {
         lock.lock()
         defer { lock.unlock() }
-        precondition(state == .started, "Call await stop() before releasing InterfaceLooper")
+        precondition(
+            [.idle, .stopped].contains(state),
+            "Called start() without stop() before releasing FdLooper"
+        )
 
         pp_log(ctx, .core, .debug, "Deinit InterfaceLooper")
         pp_socket_release(link)

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -74,6 +74,7 @@ public final class FdLooper: @unchecked Sendable {
     private let lock: SemaphoreMutex
     private var commands: [Command]
     private var state: State
+    private var stopContinuation: CheckedContinuation<Void, Error>?
     private var terminalError: Error?
     private var linkBuf: [UInt8]
     private var tunBuf: [UInt8]
@@ -220,13 +221,16 @@ public final class FdLooper: @unchecked Sendable {
         }
     }
 
-    public func stop() {
+    public func stop() async throws {
         lock.lock()
         defer { lock.unlock() }
         guard state == .started else { return }
         state = .stopping
-        commands.append(.stop)
-        pp_mux_wake(mux)
+        try await withCheckedThrowingContinuation { continuation in
+            stopContinuation = continuation
+            commands.append(.stop)
+            pp_mux_wake(mux)
+        }
     }
 
     public func attachTun(_ tunInterface: IOInterface) async throws {
@@ -455,6 +459,12 @@ private extension FdLooper {
         terminalError = error
         lock.unlock()
 
+        if let error {
+            stopContinuation?.resume(throwing: error)
+        } else {
+            stopContinuation?.resume()
+        }
+        stopContinuation = nil
         delegate.onFinish(error)
     }
 }

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -36,6 +36,7 @@ Given the main app and the daemon:
 - ``DataCount``
 - ``EndpointResolver``
 - ``FdLooper``
+- ``FdLooperDelegate``
 - ``NetworkInterfaceFactory``
 - ``SocketConfigurator``
 

--- a/Sources/PartoutCore/Misc/RingQueue.swift
+++ b/Sources/PartoutCore/Misc/RingQueue.swift
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+struct RingQueue<Element> {
+    private enum Slot {
+        case empty
+        case element(Element)
+    }
+
+    private var storage: [Slot]
+
+    private var head: Int
+
+    private(set) var count: Int
+
+    init(minimumCapacity: Int = 0) {
+        precondition(minimumCapacity >= 0, "minimumCapacity must be non-negative")
+        storage = Array(repeating: .empty, count: minimumCapacity)
+        head = 0
+        count = 0
+    }
+
+    var isEmpty: Bool {
+        count == 0
+    }
+
+    var first: Element? {
+        guard !isEmpty else {
+            return nil
+        }
+        switch storage[head] {
+        case .empty:
+            return nil
+        case .element(let element):
+            return element
+        }
+    }
+
+    mutating func append(_ element: Element) {
+        reserveCapacity(count + 1)
+        storage[index(offsetBy: count)] = .element(element)
+        count += 1
+    }
+
+    @discardableResult
+    mutating func removeFirst() -> Element? {
+        guard !isEmpty else {
+            return nil
+        }
+        let element = first
+        storage[head] = .empty
+        count -= 1
+        if isEmpty {
+            head = 0
+        } else {
+            head = index(offsetBy: 1)
+        }
+        return element
+    }
+
+    @discardableResult
+    mutating func replaceFirst(with element: Element) -> Bool {
+        guard !isEmpty else {
+            return false
+        }
+        storage[head] = .element(element)
+        return true
+    }
+
+    mutating func removeAll(keepingCapacity: Bool = false) {
+        if keepingCapacity {
+            storage = Array(repeating: .empty, count: storage.count)
+        } else {
+            storage.removeAll(keepingCapacity: false)
+        }
+        head = 0
+        count = 0
+    }
+}
+
+private extension RingQueue {
+    mutating func reserveCapacity(_ minimumCapacity: Int) {
+        guard storage.count < minimumCapacity else {
+            return
+        }
+        var newCapacity = max(1, storage.count * 2)
+        while newCapacity < minimumCapacity {
+            newCapacity *= 2
+        }
+        var newStorage = Array(repeating: Slot.empty, count: newCapacity)
+        for offset in 0..<count {
+            newStorage[offset] = storage[index(offsetBy: offset)]
+        }
+        storage = newStorage
+        head = 0
+    }
+
+    func index(offsetBy offset: Int) -> Int {
+        (head + offset) % storage.count
+    }
+}

--- a/Sources/PartoutCore/Misc/SemaphoreMutex.swift
+++ b/Sources/PartoutCore/Misc/SemaphoreMutex.swift
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+/// A binary atomic state for mutual exclusion.
 public final class SemaphoreMutex: @unchecked Sendable {
     private let semaphore: DispatchSemaphore
 

--- a/Sources/PartoutCore/Misc/SemaphoreMutex.swift
+++ b/Sources/PartoutCore/Misc/SemaphoreMutex.swift
@@ -19,9 +19,9 @@ public final class SemaphoreMutex: @unchecked Sendable {
     }
 
     @discardableResult
-    public func with<T>(block: () -> T) -> T {
+    public func with<T>(block: () throws -> T) rethrows -> T {
         lock()
-        let result = block()
+        let result = try block()
         unlock()
         return result
     }

--- a/Sources/PartoutCore_C/include/portable/mux.h
+++ b/Sources/PartoutCore_C/include/portable/mux.h
@@ -18,6 +18,7 @@ pp_mux _Nullable pp_mux_create(int num);
 void pp_mux_free(pp_mux mux);
 
 bool pp_mux_add(pp_mux mux, int fd);
+bool pp_mux_set_read(pp_mux mux, int fd, bool enable);
 bool pp_mux_set_write(pp_mux mux, int fd, bool enable);
 void pp_mux_set_on_readable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx);
 void pp_mux_set_on_writable(pp_mux mux, void (*callback)(void *ctx, int fd), void *ctx);

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -128,22 +128,77 @@ bool pp_mux_wake(pp_mux mux) {
 #elif PARTOUT_LINUX || PARTOUT_ANDROID
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
+#include <stdint.h>
 #include <unistd.h>
 
 #ifndef EPOLLRDHUP
 #define EPOLLRDHUP 0
 #endif
 
+#define PP_MUX_ERROR_EVENTS (EPOLLERR | EPOLLHUP | EPOLLRDHUP)
+
+struct pp_mux_fd {
+    int fd;
+    bool read;
+    bool write;
+};
+
 struct __pp_mux {
     int handle;
     int wake_fd;
     struct epoll_event *events;
     int events_len;
+    struct pp_mux_fd *fds;
+    int fds_len;
+    int fds_count;
     void (*on_readable)(void *ctx, int fd);
     void (*on_writable)(void *ctx, int fd);
     void *read_ctx;
     void *write_ctx;
 };
+
+static struct pp_mux_fd *pp_mux_find_fd(pp_mux mux, int fd) {
+    for (int i = 0; i < mux->fds_count; ++i) {
+        if (mux->fds[i].fd == fd) return mux->fds + i;
+    }
+    return NULL;
+}
+
+static struct pp_mux_fd *pp_mux_track_fd(pp_mux mux, int fd) {
+    struct pp_mux_fd *tracked = pp_mux_find_fd(mux, fd);
+    if (tracked) return tracked;
+    if (mux->fds_count >= mux->fds_len) return NULL;
+    tracked = mux->fds + mux->fds_count;
+    tracked->fd = fd;
+    tracked->read = false;
+    tracked->write = false;
+    ++mux->fds_count;
+    return tracked;
+}
+
+static uint32_t pp_mux_events(const struct pp_mux_fd *fd) {
+    uint32_t events = PP_MUX_ERROR_EVENTS;
+    if (fd->read) events |= EPOLLIN;
+    if (fd->write) events |= EPOLLOUT;
+    return events;
+}
+
+static bool pp_mux_update_fd(pp_mux mux, const struct pp_mux_fd *fd, bool add_if_missing, bool ignore_missing) {
+    struct epoll_event ev;
+    pp_zero(&ev, sizeof(ev));
+    ev.events = pp_mux_events(fd);
+    ev.data.fd = fd->fd;
+
+    const int ret = epoll_ctl(mux->handle, EPOLL_CTL_MOD, fd->fd, &ev);
+    if (ret == 0) return true;
+    if (errno == ENOENT) {
+        if (ignore_missing) return true;
+        if (add_if_missing) {
+            return epoll_ctl(mux->handle, EPOLL_CTL_ADD, fd->fd, &ev) == 0;
+        }
+    }
+    return false;
+}
 
 pp_mux pp_mux_create(int num) {
     int handle = epoll_create(1); /* Size is ignored */
@@ -159,6 +214,8 @@ pp_mux pp_mux_create(int num) {
     mux->wake_fd = wake_fd;
     mux->events = pp_alloc((1 + num) * sizeof(struct epoll_event));
     mux->events_len = 1 + num;
+    mux->fds = pp_alloc(num * sizeof(struct pp_mux_fd));
+    mux->fds_len = num;
 
     struct epoll_event ev;
     pp_zero(&ev, sizeof(ev));
@@ -177,18 +234,40 @@ void pp_mux_free(pp_mux mux) {
     close(mux->handle);
     close(mux->wake_fd);
     pp_free(mux->events);
+    pp_free(mux->fds);
     pp_free(mux);
 }
 
 bool pp_mux_add(pp_mux mux, int fd) {
     if (!mux) return false;
-    struct epoll_event ev;
-    pp_zero(&ev, sizeof(ev));
-    ev.events = EPOLLIN | EPOLLERR | EPOLLHUP | EPOLLRDHUP;
-    ev.data.fd = fd;
-    const int ret = epoll_ctl(mux->handle, EPOLL_CTL_ADD, fd, &ev);
-    if (ret < 0) {
-        if (errno == EEXIST) return true;
+    const int previous_count = mux->fds_count;
+    struct pp_mux_fd *tracked = pp_mux_track_fd(mux, fd);
+    if (!tracked) return false;
+    const bool previous_read = tracked->read;
+    const bool previous_write = tracked->write;
+    tracked->read = true;
+    tracked->write = false;
+    const bool ok = pp_mux_update_fd(mux, tracked, true, false);
+    if (!ok) {
+        tracked->read = previous_read;
+        tracked->write = previous_write;
+        mux->fds_count = previous_count;
+        return false;
+    }
+    return true;
+}
+
+bool pp_mux_set_read(pp_mux mux, int fd, bool enable) {
+    if (!mux) return false;
+    struct pp_mux_fd *tracked = pp_mux_find_fd(mux, fd);
+    if (!tracked && !enable) return true;
+    if (!tracked) return false;
+
+    const bool previous_read = tracked->read;
+    tracked->read = enable;
+    const bool ok = pp_mux_update_fd(mux, tracked, false, !enable);
+    if (!ok) {
+        tracked->read = previous_read;
         return false;
     }
     return true;
@@ -196,20 +275,15 @@ bool pp_mux_add(pp_mux mux, int fd) {
 
 bool pp_mux_set_write(pp_mux mux, int fd, bool enable) {
     if (!mux) return false;
-    struct epoll_event ev;
-    pp_zero(&ev, sizeof(ev));
-    ev.events = EPOLLIN | EPOLLERR | EPOLLHUP | EPOLLRDHUP;
-    if (enable) {
-        ev.events |= EPOLLOUT;
-    }
-    ev.data.fd = fd;
-    const int ret = epoll_ctl(mux->handle, EPOLL_CTL_MOD, fd, &ev);
-    if (ret < 0) {
-        if (enable && errno == ENOENT) {
-            return epoll_ctl(mux->handle, EPOLL_CTL_ADD, fd, &ev) == 0;
-        }
-        /* Ignore failed deletion. */
-        if (!enable && errno == ENOENT) return true;
+    struct pp_mux_fd *tracked = pp_mux_find_fd(mux, fd);
+    if (!tracked && !enable) return true;
+    if (!tracked) return false;
+
+    const bool previous_write = tracked->write;
+    tracked->write = enable;
+    const bool ok = pp_mux_update_fd(mux, tracked, false, !enable);
+    if (!ok) {
+        tracked->write = previous_write;
         return false;
     }
     return true;

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -59,6 +59,19 @@ bool pp_mux_add(pp_mux mux, int fd) {
     return kevent(mux->handle, &ev, 1, NULL, 0, NULL) == 0;
 }
 
+bool pp_mux_set_read(pp_mux mux, int fd, bool enable) {
+    if (!mux) return false;
+    struct kevent ev;
+    EV_SET(&ev, fd, EVFILT_READ, enable ? EV_ADD : EV_DELETE, 0, 0, 0);
+    const int ret = kevent(mux->handle, &ev, 1, NULL, 0, NULL);
+    if (ret < 0) {
+        /* Ignore failed deletion. */
+        if (!enable && errno == ENOENT) return true;
+        return false;
+    }
+    return true;
+}
+
 bool pp_mux_set_write(pp_mux mux, int fd, bool enable) {
     if (!mux) return false;
     struct kevent ev;

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -111,6 +111,7 @@ set(PARTOUT_SOURCES
 ./PartoutCore/Misc/BidirectionalState.swift
 ./PartoutCore/Misc/DataUnit.swift
 ./PartoutCore/Misc/Keychain.swift
+./PartoutCore/Misc/RingQueue.swift
 ./PartoutCore/Misc/ScriptingEngine.swift
 ./PartoutCore/Misc/SemaphoreMutex.swift
 ./PartoutCore/Misc/Swift+Extensions.swift

--- a/Tests/PartoutCoreTests/RingQueueTests.swift
+++ b/Tests/PartoutCoreTests/RingQueueTests.swift
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+@testable import PartoutCore
+import Testing
+
+struct RingQueueTests {
+    @Test
+    func givenEmptyQueue_whenRemovingFirst_thenReturnsNil() {
+        var sut = RingQueue<Int>()
+
+        #expect(sut.isEmpty)
+        #expect(sut.count == 0)
+        #expect(sut.first == nil)
+        #expect(sut.removeFirst() == nil)
+    }
+
+    @Test
+    func givenQueue_whenAppendingAndRemoving_thenPreservesFIFOOrder() {
+        var sut = RingQueue<Int>()
+
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+
+        #expect(sut.count == 3)
+        #expect(sut.first == 1)
+        #expect(sut.removeFirst() == 1)
+        #expect(sut.removeFirst() == 2)
+
+        sut.append(4)
+        sut.append(5)
+
+        #expect(sut.removeFirst() == 3)
+        #expect(sut.removeFirst() == 4)
+        #expect(sut.removeFirst() == 5)
+        #expect(sut.isEmpty)
+    }
+
+    @Test
+    func givenQueue_whenReplacingFirst_thenOnlyHeadChanges() {
+        var sut = RingQueue<Int>()
+
+        sut.append(1)
+        sut.append(2)
+
+        let didReplaceFirst = sut.replaceFirst(with: 10)
+        #expect(didReplaceFirst)
+        #expect(sut.removeFirst() == 10)
+        #expect(sut.removeFirst() == 2)
+        let didReplaceEmptyFirst = sut.replaceFirst(with: 20)
+        #expect(!didReplaceEmptyFirst)
+    }
+
+    @Test
+    func givenQueue_whenRemovingAll_thenDropsElements() {
+        var sut = RingQueue<Int>()
+
+        sut.append(1)
+        sut.append(2)
+        sut.removeAll(keepingCapacity: true)
+
+        #expect(sut.isEmpty)
+        #expect(sut.first == nil)
+        sut.append(3)
+        #expect(sut.removeFirst() == 3)
+    }
+}


### PR DESCRIPTION
The initial stub of FdLooper from #448 lacked the hooks to interact with the outside.

This is how the PR closes the gap:

- Describe internal state: .idle, .started, .stopping, .stopped
- Get rid of any Swift Concurrency, run the loop in a long-lived DispatchQueue task with synchronous hooks
- Never require tun from the start, attach later
- Add a delegate to observe the onRead() and onFinish() hooks
- Improve write queues with ring buffers and offsets to leverage copy-on-write
- Handle backpressure in the delegate, who can now suspend reads until a manual resume
- Refactor duplicated I/O logic into SideIO for better reasoning about the overall process() flow
- Log failures