### PR TITLE
OpenVPN: Integrate V3 with FdLooper

### DIFF
--- a/Sources/Partout/Registry.swift
+++ b/Sources/Partout/Registry.swift
@@ -67,7 +67,7 @@ extension Registry: ModuleImporter {
                 return try importer.module(fromContents: contents, object: object)
             } catch {
                 // URL content is not recognized by this importer, skip to next importer
-                if (error as? PartoutError)?.code != .unknownImportedModule {
+                if error.partoutErrorCode != .unknownImportedModule {
                     errors.append(error)
                 }
                 continue

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -10,16 +10,20 @@ internal import _PartoutCore_C
 /// Delegates ``FdLooper`` events.
 public struct FdLooperDelegate: Sendable {
     public typealias OnRead = @Sendable (_ packets: [Data], _ side: FdLooper.Side) throws -> FdLooper.ReadAction
+    public typealias OnWrite = @Sendable (_ packet: Data, _ side: FdLooper.Side) throws -> Data
     public typealias OnFinish = @Sendable (_ error: Error?) -> Void
 
     public let onRead: OnRead
+    public let onWrite: OnWrite?
     public let onFinish: OnFinish
 
     public init(
         onRead: @escaping OnRead,
+        onWrite: OnWrite?,
         onFinish: @escaping OnFinish
     ) {
         self.onRead = onRead
+        self.onWrite = onWrite
         self.onFinish = onFinish
     }
 }
@@ -316,7 +320,7 @@ public final class FdLooper: @unchecked Sendable {
         pp_mux_wake(mux)
     }
 
-    public func write(_ packets: [Data], to side: Side) {
+    public func write(_ packets: [Data], to side: Side) throws {
         lock.lock()
         defer { lock.unlock() }
         switch side {
@@ -325,8 +329,9 @@ public final class FdLooper: @unchecked Sendable {
                 pp_log(ctx, .core, .error, "Ignoring link packets, not attached")
                 return
             }
-            packets.forEach {
-                link.unsafeEnqueueWrite($0)
+            try packets.forEach {
+                let packet = try delegate.onWrite?($0, side) ?? $0
+                link.unsafeEnqueueWrite(packet)
             }
             commands.append(.enableWrite(.link, nil))
         case .tun:

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -167,8 +167,11 @@ public final class FdLooper: @unchecked Sendable {
 
                     // Iterate through the fds
                     try process(mux: mux, fdSet: fdSet)
+                } catch IOError.user(let side, let reason) {
+                    // Unwrap user-defined errors
+                    detachImmediately(side, withReason: reason)
                 } catch let reason as IOError {
-                    // Can be either .user or .libc
+                    // Rethrow anything else as is
                     detachImmediately(reason.side, withReason: reason)
                 } catch {
                     pp_log(ctx, .core, .error, "Unable to process: \(error)")

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -169,15 +169,16 @@ public final class FdLooper: @unchecked Sendable {
                     try process(mux: mux, fdSet: fdSet)
                 } catch IOError.linkFailed {
                     lock.with {
-                        self.link?.detach()
+                        self.link?.detach(error: IOError.linkFailed)
                         self.link = nil
                     }
                 } catch IOError.tunFailed {
                     lock.with {
-                        self.tun?.detach()
+                        self.tun?.detach(error: IOError.tunFailed)
                         self.tun = nil
                     }
                 } catch {
+                    // FIXME: ###, Custom onRead() errors end up here
                     pp_log(ctx, .core, .error, "Unable to process: \(error)")
                     lastError = error
                     break
@@ -852,7 +853,10 @@ private extension FdLooper {
             writeQueue.append(packet)
         }
 
-        func detach() {
+        func detach(error: Error? = nil) {
+            if let error {
+                onFailure?(error)
+            }
             cleanup?()
             cleanup = nil
         }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -174,7 +174,7 @@ public final class FdLooper: @unchecked Sendable {
                     // Rethrow anything else as is
                     detachImmediately(reason.side, withReason: reason)
                 } catch {
-                    pp_log(ctx, .core, .error, "Unable to process: \(error)")
+                    pp_log(ctx, .core, .fault, "Unable to process: \(error)")
                     lastError = error
                     break
                 }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -300,7 +300,28 @@ public final class FdLooper: @unchecked Sendable {
         pp_mux_wake(mux)
     }
 
-    public func write(_ packets: [Data], to side: Side) throws {
+    public func write(_ packets: [Data], to side: Side, outOfBand: Bool = false) throws {
+        if outOfBand {
+            precondition(isOnQueue, "OOB writes must run on the looper queue")
+            switch side {
+            case .link:
+                guard let link else {
+                    pp_log(ctx, .core, .error, "Ignoring link packets, not attached")
+                    return
+                }
+                let processedPackets = try link.transformWrite?(packets) ?? packets
+                try processedPackets.forEach(link.writeOutOfBand)
+            case .tun:
+                guard let tun else {
+                    pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
+                    return
+                }
+                let processedPackets = try tun.transformWrite?(packets) ?? packets
+                try processedPackets.forEach(tun.writeOutOfBand)
+            }
+            return
+        }
+
         lock.lock()
         defer { lock.unlock() }
         switch side {
@@ -881,6 +902,12 @@ private extension FdLooper {
 
         func unsafeEnqueueWrite(_ packet: Data) {
             writeQueue.append(packet)
+        }
+
+        func writeOutOfBand(_ data: Data) throws {
+            guard try write(PendingWrite(data)) == data.count else {
+                throw PartoutError(.ioFailure)
+            }
         }
 
         func detach(reason: Error? = nil) {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -167,18 +167,18 @@ public final class FdLooper: @unchecked Sendable {
 
                     // Iterate through the fds
                     try process(mux: mux, fdSet: fdSet)
-                } catch IOError.linkFailed {
+                } catch IOError.failed(let side, let reason) {
                     lock.with {
-                        self.link?.detach(error: IOError.linkFailed)
-                        self.link = nil
-                    }
-                } catch IOError.tunFailed {
-                    lock.with {
-                        self.tun?.detach(error: IOError.tunFailed)
-                        self.tun = nil
+                        switch side {
+                        case .link:
+                            self.link?.detach(reason: reason)
+                            self.link = nil
+                        case .tun:
+                            self.tun?.detach(reason: reason)
+                            self.tun = nil
+                        }
                     }
                 } catch {
-                    // FIXME: ###, Custom onRead() errors end up here
                     pp_log(ctx, .core, .error, "Unable to process: \(error)")
                     lastError = error
                     break
@@ -759,10 +759,17 @@ private final class FdSet {
 
 private extension FdLooper {
     enum IOError: Error {
-        case wouldBlock
-        case noBufSpace
-        case linkFailed
-        case tunFailed
+        case wouldBlock(Side)
+        case noBufSpace(Side)
+        case failed(Side, Error? = nil)
+
+        var side: Side {
+            switch self {
+            case .wouldBlock(let side): side
+            case .noBufSpace(let side): side
+            case .failed(let side, _): side
+            }
+        }
     }
 
     struct PendingWrite {
@@ -822,9 +829,13 @@ private extension FdLooper {
             try read(&readBuf)
         }
 
-        // May throw user-defined errors in onRead
         func processReadPackets(_ packets: [Data]) throws -> FdLooper.ReadAction {
-            try onRead?(packets) ?? .keep
+            do {
+                return try onRead?(packets) ?? .keep
+            } catch {
+                // BEWARE: Wrap user-defined errors to prevent premature finish
+                throw IOError.failed(side, error)
+            }
         }
 
         func performWrite(_ pending: PendingWrite, lock: SemaphoreMutex) throws -> Bool {
@@ -853,9 +864,9 @@ private extension FdLooper {
             writeQueue.append(packet)
         }
 
-        func detach(error: Error? = nil) {
-            if let error {
-                onFailure?(error)
+        func detach(reason: Error? = nil) {
+            if let reason {
+                onFailure?(reason)
             }
             cleanup?()
             cleanup = nil
@@ -881,10 +892,10 @@ private extension FdLooper.SideIO {
             read: { buf in
                 let count = pp_socket_read(linkHandle, &buf, buf.count)
                 guard count != PP_SOCKET_WOULD_BLOCK else {
-                    throw FdLooper.IOError.wouldBlock
+                    throw FdLooper.IOError.wouldBlock(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.linkFailed
+                    throw FdLooper.IOError.failed(.link)
                 }
                 guard count > 0 else {
                     return nil
@@ -900,13 +911,13 @@ private extension FdLooper.SideIO {
                     )
                 }
                 guard count != PP_SOCKET_WOULD_BLOCK else {
-                    throw FdLooper.IOError.wouldBlock
+                    throw FdLooper.IOError.wouldBlock(.link)
                 }
                 guard count != PP_SOCKET_NO_BUF else {
-                    throw FdLooper.IOError.noBufSpace
+                    throw FdLooper.IOError.noBufSpace(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.linkFailed
+                    throw FdLooper.IOError.failed(.link)
                 }
                 return Int(count)
             },
@@ -932,10 +943,10 @@ private extension FdLooper.SideIO {
             read: { buf in
                 let count = pp_tun_read(tunHandle, &buf, buf.count)
                 guard count != PP_TUN_WOULD_BLOCK else {
-                    throw FdLooper.IOError.wouldBlock
+                    throw FdLooper.IOError.wouldBlock(.tun)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.tunFailed
+                    throw FdLooper.IOError.failed(.tun)
                 }
                 guard count > 0 else {
                     return nil
@@ -951,13 +962,13 @@ private extension FdLooper.SideIO {
                     )
                 }
                 guard count != PP_TUN_WOULD_BLOCK else {
-                    throw FdLooper.IOError.wouldBlock
+                    throw FdLooper.IOError.wouldBlock(.tun)
                 }
                 guard count != PP_TUN_NO_BUF else {
-                    throw FdLooper.IOError.noBufSpace
+                    throw FdLooper.IOError.noBufSpace(.tun)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.tunFailed
+                    throw FdLooper.IOError.failed(.tun)
                 }
                 return Int(count)
             },

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -19,30 +19,30 @@ public final class FdLooper: @unchecked Sendable {
         case pause
     }
 
-    public typealias BeforeRead = @Sendable (_ packets: [Data]) throws -> [Data]
-    public typealias OnRead = @Sendable (_ packets: [Data]) throws -> FdLooper.ReadAction
     public typealias TransformWrite = @Sendable (_ packets: [Data]) throws -> [Data]
+    public typealias OnRead = @Sendable (_ packets: [Data]) throws -> FdLooper.ReadAction
+    public typealias OnFailure = @Sendable (_ error: Error) -> Void
     public typealias OnFinish = @Sendable (_ error: Error?) -> Void
 
     public struct AttachArguments: Sendable {
         public let side: Side
         public let original: IOInterface
-        public let beforeRead: BeforeRead?
-        public let onRead: OnRead?
         public let transformWrite: TransformWrite?
+        public let onRead: OnRead?
+        public let onFailure: OnFailure?
 
         public init(
             side: Side,
             original: IOInterface,
-            beforeRead: BeforeRead?,
+            transformWrite: TransformWrite?,
             onRead: OnRead?,
-            transformWrite: TransformWrite?
+            onFailure: OnFailure?
         ) {
             self.side = side
             self.original = original
-            self.beforeRead = beforeRead
-            self.onRead = onRead
             self.transformWrite = transformWrite
+            self.onRead = onRead
+            self.onFailure = onFailure
         }
     }
 
@@ -782,9 +782,9 @@ private extension FdLooper {
         let fd: Int32
 
         let originalInterface: IOInterface
-        private let beforeRead: BeforeRead?
-        private let onRead: OnRead?
         let transformWrite: TransformWrite?
+        private let onRead: OnRead?
+        private let onFailure: OnFailure?
 
         private let read: (inout [UInt8]) throws -> Data?
         private let write: (PendingWrite) throws -> Int
@@ -806,9 +806,9 @@ private extension FdLooper {
             self.side = side
             self.fd = fd
             originalInterface = arguments.original
-            beforeRead = arguments.beforeRead
-            onRead = arguments.onRead
             transformWrite = arguments.transformWrite
+            onRead = arguments.onRead
+            onFailure = arguments.onFailure
             self.read = read
             self.write = write
             self.cleanup = cleanup
@@ -821,9 +821,9 @@ private extension FdLooper {
             try read(&readBuf)
         }
 
+        // May throw user-defined errors in onRead
         func processReadPackets(_ packets: [Data]) throws -> FdLooper.ReadAction {
-            let processed = try beforeRead?(packets) ?? packets
-            return try onRead?(processed) ?? .keep
+            try onRead?(packets) ?? .keep
         }
 
         func performWrite(_ pending: PendingWrite, lock: SemaphoreMutex) throws -> Bool {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -618,14 +618,16 @@ private extension FdLooper {
         readRetries.insert(io.side)
         lock.unlock()
 
+        let side = io.side
+        let command: Command = .enableRead(side, io.id)
         retryQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
             guard let self else { return }
             self.lock.with {
-                self.readRetries.remove(io.side)
+                self.readRetries.remove(side)
                 guard self.state == .started else {
                     return
                 }
-                self.commands.append(.enableRead(io.side, io.id))
+                self.commands.append(command)
                 pp_mux_wake(self.mux)
             }
         }
@@ -640,14 +642,16 @@ private extension FdLooper {
         writeRetries.insert(io.side)
         lock.unlock()
 
+        let side = io.side
+        let command: Command = .enableWrite(side, io.id)
         retryQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
             guard let self else { return }
             self.lock.with {
-                self.writeRetries.remove(io.side)
+                self.writeRetries.remove(side)
                 guard self.state == .started else {
                     return
                 }
-                self.commands.append(.enableWrite(io.side, io.id))
+                self.commands.append(command)
                 pp_mux_wake(self.mux)
             }
         }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -167,17 +167,9 @@ public final class FdLooper: @unchecked Sendable {
 
                     // Iterate through the fds
                     try process(mux: mux, fdSet: fdSet)
-                } catch IOError.failed(let side, let reason) {
-                    lock.with {
-                        switch side {
-                        case .link:
-                            self.link?.detach(reason: reason)
-                            self.link = nil
-                        case .tun:
-                            self.tun?.detach(reason: reason)
-                            self.tun = nil
-                        }
-                    }
+                } catch let reason as IOError {
+                    // Can be either .user or .libc
+                    detachImmediately(reason.side, withReason: reason)
                 } catch {
                     pp_log(ctx, .core, .error, "Unable to process: \(error)")
                     lastError = error
@@ -576,6 +568,19 @@ private extension FdLooper {
         }
     }
 
+    func detachImmediately(_ side: Side, withReason reason: Error?) {
+        lock.with {
+            switch side {
+            case .link:
+                link?.detach(reason: reason)
+                link = nil
+            case .tun:
+                tun?.detach(reason: reason)
+                tun = nil
+            }
+        }
+    }
+
     func finish(throwing error: Error? = nil) {
         if let error {
             pp_log(ctx, .core, .error, "Finish looper with error: \(error)")
@@ -758,16 +763,27 @@ private final class FdSet {
 // MARK: - SideIO
 
 private extension FdLooper {
-    enum IOError: Error {
+    enum IOError: Error, CustomDebugStringConvertible {
         case wouldBlock(Side)
         case noBufSpace(Side)
-        case failed(Side, Error? = nil)
+        case libc(Side, Int32)
+        case user(Side, Error? = nil)
 
         var side: Side {
             switch self {
             case .wouldBlock(let side): side
             case .noBufSpace(let side): side
-            case .failed(let side, _): side
+            case .libc(let side, _): side
+            case .user(let side, _): side
+            }
+        }
+
+        var debugDescription: String {
+            switch self {
+            case .wouldBlock(let side): "\(side): would block"
+            case .noBufSpace(let side): "\(side): no buffer space"
+            case .libc(let side, let code): "\(side): libc errno=\(code)"
+            case .user(let side, let reason): "\(side): user error, \(reason.debugDescription)"
             }
         }
     }
@@ -834,7 +850,7 @@ private extension FdLooper {
                 return try onRead?(packets) ?? .keep
             } catch {
                 // BEWARE: Wrap user-defined errors to prevent premature finish
-                throw IOError.failed(side, error)
+                throw IOError.user(side, error)
             }
         }
 
@@ -895,7 +911,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.wouldBlock(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.failed(.link)
+                    throw FdLooper.IOError.libc(.link, errno)
                 }
                 guard count > 0 else {
                     return nil
@@ -917,7 +933,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.noBufSpace(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.failed(.link)
+                    throw FdLooper.IOError.libc(.link, errno)
                 }
                 return Int(count)
             },
@@ -946,7 +962,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.wouldBlock(.tun)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.failed(.tun)
+                    throw FdLooper.IOError.libc(.tun, errno)
                 }
                 guard count > 0 else {
                     return nil
@@ -968,7 +984,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.noBufSpace(.tun)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.failed(.tun)
+                    throw FdLooper.IOError.libc(.tun, errno)
                 }
                 return Int(count)
             },

--- a/Sources/PartoutCore/Connection/LinkInterface.swift
+++ b/Sources/PartoutCore/Connection/LinkInterface.swift
@@ -23,6 +23,21 @@ public protocol LinkInterface: IOInterface {
     nonisolated func shutdown()
 }
 
+/// Metadata associated with a ``LinkInterface``.
+public struct LinkMetadata: Sendable {
+    public let isReliable: Bool
+    public let remoteAddress: String
+    public let remoteProtocol: EndpointProtocol
+    public let fileDescriptor: UInt64?
+
+    public init(isReliable: Bool, remoteAddress: String, remoteProtocol: EndpointProtocol, fileDescriptor: UInt64?) {
+        self.isReliable = isReliable
+        self.remoteAddress = remoteAddress
+        self.remoteProtocol = remoteProtocol
+        self.fileDescriptor = fileDescriptor
+    }
+}
+
 extension LinkInterface {
     /// The link type (UDP/TCP).
     public var linkType: IPSocketType {
@@ -32,6 +47,15 @@ extension LinkInterface {
     /// When `true`, packets delivery is guaranteed.
     public var isReliable: Bool {
         linkType.plainType == .tcp
+    }
+
+    public var metadata: LinkMetadata {
+        LinkMetadata(
+            isReliable: isReliable,
+            remoteAddress: remoteAddress,
+            remoteProtocol: remoteProtocol,
+            fileDescriptor: fileDescriptor
+        )
     }
 }
 

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -54,6 +54,7 @@ Given the main app and the daemon:
 
 - ``IOInterface``
 - ``LinkInterface``
+- ``LinkMetadata``
 - ``LinkObserver``
 - ``BSDSocket``
 - ``BSDSocketObserver``

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/ControlChannelV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/ControlChannelV3.swift
@@ -4,7 +4,6 @@
 
 internal import _PartoutOpenVPNConnection_C
 
-@OpenVPNActor
 final class ControlChannelV3 {
     private let ctx: PartoutLoggerContext
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/LinkProcessor.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/LinkProcessor.swift
@@ -4,13 +4,13 @@
 
 struct LinkProcessor: @unchecked Sendable {
     private let proc: PacketProcessor
-    let beforeRead: ([Data]) throws -> [Data]
-    let beforeWrite: ([Data]) throws -> [Data]
+    let beforeRead: @Sendable ([Data]) throws -> [Data]
+    let beforeWrite: @Sendable ([Data]) throws -> [Data]
 
     init(proc: PacketProcessor, isReliable: Bool) {
         self.proc = proc
         if isReliable {
-            var buffer = Data()
+            nonisolated(unsafe) var buffer = Data()
             beforeRead = {
                 // FIXME: #214, TCP is very slow
                 buffer.reserveCapacity(buffer.count + $0.flatCount)

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/LinkProcessor.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/LinkProcessor.swift
@@ -7,9 +7,9 @@ struct LinkProcessor: @unchecked Sendable {
     let beforeRead: @Sendable ([Data]) throws -> [Data]
     let beforeWrite: @Sendable ([Data]) throws -> [Data]
 
-    init(proc: PacketProcessor, isReliable: Bool) {
+    init(proc: PacketProcessor, isTCP: Bool) {
         self.proc = proc
-        if isReliable {
+        if isTCP {
             nonisolated(unsafe) var buffer = Data()
             beforeRead = {
                 // FIXME: #214, TCP is very slow

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/LinkProcessor.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/LinkProcessor.swift
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+struct LinkProcessor: @unchecked Sendable {
+    private let proc: PacketProcessor
+    let beforeRead: ([Data]) throws -> [Data]
+    let beforeWrite: ([Data]) throws -> [Data]
+
+    init(proc: PacketProcessor, isReliable: Bool) {
+        self.proc = proc
+        if isReliable {
+            var buffer = Data()
+            beforeRead = {
+                // FIXME: #214, TCP is very slow
+                buffer.reserveCapacity(buffer.count + $0.flatCount)
+                for p in $0 {
+                    buffer.append(p)
+                }
+                var until = 0
+                let processedPackets = proc.packets(fromStream: buffer, until: &until)
+                buffer = buffer.subdata(in: until..<buffer.count)
+                return processedPackets
+            }
+            beforeWrite = {
+                let stream = proc.stream(fromPackets: $0)
+                guard !stream.isEmpty else { return [] }
+                return [stream]
+            }
+        } else {
+            beforeRead = {
+                proc.processPackets($0, direction: .inbound)
+            }
+            beforeWrite = {
+                proc.processPackets($0, direction: .outbound)
+            }
+        }
+    }
+}

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-@OpenVPNActor
 final class NegotiatorV3 {
     struct Options {
         let configuration: OpenVPN.Configuration
@@ -13,9 +12,9 @@ final class NegotiatorV3 {
 
         let sessionOptions: OpenVPNConnectionOptions
 
-        let onConnected: (UInt8, DataChannel, PushReply) async -> Void
+        let onConnected: (UInt8, DataChannel, PushReply) -> Void
 
-        let onError: (UInt8, Error) async -> Void
+        let onError: (UInt8, Error) -> Void
     }
 
     private let ctx: PartoutLoggerContext
@@ -28,9 +27,11 @@ final class NegotiatorV3 {
 
     private let renegotiation: RenegotiationType?
 
-    let link: LinkInterface
+    let looper: FdLooper
 
-    private let channel: ControlChannel
+    private let linkMetadata: LinkMetadata
+
+    private let channel: ControlChannelV3
 
     private let prng: PRNGProtocol
 
@@ -70,8 +71,9 @@ final class NegotiatorV3 {
 
     convenience init(
         _ ctx: PartoutLoggerContext,
-        link: LinkInterface,
-        channel: ControlChannel,
+        looper: FdLooper,
+        linkMetadata: LinkMetadata,
+        channel: ControlChannelV3,
         prng: PRNGProtocol,
         tls: TLSProtocol,
         dpFactory: @escaping DataPathFactory,
@@ -82,7 +84,8 @@ final class NegotiatorV3 {
             key: 0,
             history: nil,
             renegotiation: nil,
-            link: link,
+            looper: looper,
+            linkMetadata: linkMetadata,
             channel: channel,
             prng: prng,
             tls: tls,
@@ -96,8 +99,9 @@ final class NegotiatorV3 {
         key: UInt8,
         history: NegotiationHistory?,
         renegotiation: RenegotiationType?,
-        link: LinkInterface,
-        channel: ControlChannel, // TODO: #29, abstract this for testing
+        looper: FdLooper,
+        linkMetadata: LinkMetadata,
+        channel: ControlChannelV3, // TODO: #29, abstract this for testing
         prng: PRNGProtocol,
         tls: TLSProtocol,
         dpFactory: @escaping DataPathFactory,
@@ -107,7 +111,8 @@ final class NegotiatorV3 {
         self.key = key
         self.history = history
         self.renegotiation = renegotiation
-        self.link = link
+        self.looper = looper
+        self.linkMetadata = linkMetadata
         self.channel = channel
         self.prng = prng
         self.tls = tls
@@ -137,7 +142,8 @@ final class NegotiatorV3 {
             key: newKey,
             history: history,
             renegotiation: newRenegotiation,
-            link: link,
+            looper: looper,
+            linkMetadata: linkMetadata,
             channel: channel,
             prng: prng,
             tls: tls,
@@ -218,10 +224,8 @@ extension NegotiatorV3 {
         //
     }
 
-    func sendAck(for controlPacket: CrossPacket, to link: LinkInterface) {
-        Task {
-            try await privateSendAck(for: controlPacket, to: link)
-        }
+    func sendAck(for controlPacket: CrossPacket, to looper: FdLooper) throws {
+        try privateSendAck(for: controlPacket, to: looper)
     }
 
     func shouldRenegotiate() -> Bool {
@@ -268,7 +272,7 @@ private extension NegotiatorV3 {
         if !isRenegotiating {
             try pushRequest()
         }
-        if !link.isReliable {
+        if !linkMetadata.isReliable {
             try flushControlQueue()
         }
 
@@ -283,7 +287,7 @@ private extension NegotiatorV3 {
                 do {
                     try checkNegotiationComplete()
                 } catch {
-                    await options.onError(key, error)
+                    options.onError(key, error)
                 }
             }
             return
@@ -362,14 +366,7 @@ private extension NegotiatorV3 {
         for raw in rawList {
             pp_log(ctx, .openvpn, .info, "Send control packet \(raw.asSensitiveBytes(ctx))")
         }
-        Task {
-            do {
-                try await link.writePackets(rawList)
-            } catch {
-                pp_log(ctx, .openvpn, .error, "Failed LINK write during control flush: \(error)")
-                await options.onError(key, PartoutError(.ioFailure, error))
-            }
-        }
+        looper.write(rawList, to: .link)
     }
 
     func requestsWrappedKeyResend(from payload: Data?) -> Bool {
@@ -493,7 +490,7 @@ private extension NegotiatorV3 {
         }
     }
 
-    func privateSendAck(for controlPacket: CrossPacket, to link: LinkInterface) async throws {
+    func privateSendAck(for controlPacket: CrossPacket, to looper: FdLooper) throws {
         do {
             pp_log(ctx, .openvpn, .info, "Send ack for received packetId \(controlPacket.packetId)")
             let raw = try channel.writeAcks(
@@ -501,11 +498,11 @@ private extension NegotiatorV3 {
                 ackPacketIds: [controlPacket.packetId],
                 ackRemoteSessionId: controlPacket.sessionId
             )
-            try await link.writePackets([raw])
+            looper.write([raw], to: .link)
             pp_log(ctx, .openvpn, .info, "Ack successfully written to LINK for packetId \(controlPacket.packetId)")
         } catch {
             pp_log(ctx, .openvpn, .error, "Failed LINK write during send ack for packetId \(controlPacket.packetId): \(error)")
-            await options.onError(key, PartoutError(.ioFailure, error))
+            options.onError(key, PartoutError(.ioFailure, error))
         }
     }
 
@@ -567,9 +564,7 @@ private extension NegotiatorV3 {
             do {
                 try handleControlMessage(message)
             } catch {
-                Task {
-                    await options.onError(key, error)
-                }
+                options.onError(key, error)
                 throw error
             }
         }
@@ -655,9 +650,7 @@ private extension NegotiatorV3 {
         nonisolated(unsafe) let dataChannel = try newDataChannel(with: history)
         self.history = history
         authenticator?.reset()
-        Task {
-            await options.onConnected(key, dataChannel, pushReply)
-        }
+        options.onConnected(key, dataChannel, pushReply)
     }
 
     func newDataChannel(with history: NegotiationHistory) throws -> DataChannel {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
@@ -64,9 +64,9 @@ final class NegotiatorV3: @unchecked Sendable {
 
     private var continuatedPushReplyMessage: String?
 
-    private var checkNegotiationTask: Task<Void, Never>?
-
     private var shouldResendWrappedKey: Bool
+
+    private var isCancelled: Bool
 
     // MARK: Init
 
@@ -126,6 +126,7 @@ final class NegotiatorV3: @unchecked Sendable {
         expectedPacketId = 0
         pendingPackets = [:]
         shouldResendWrappedKey = false
+        isCancelled = false
     }
 
     deinit {
@@ -172,7 +173,7 @@ extension NegotiatorV3 {
     func start() throws {
         channel.reset(forNewSession: renegotiation == nil)
 
-        // schedule this repeatedly
+        // Schedule this repeatedly
         try checkNegotiationComplete()
 
         switch renegotiation {
@@ -189,7 +190,7 @@ extension NegotiatorV3 {
     }
 
     func cancel() {
-        checkNegotiationTask?.cancel()
+        isCancelled = true
         pendingPackets.removeAll()
         authenticator = nil
     }
@@ -278,25 +279,20 @@ private extension NegotiatorV3 {
         }
 
         guard state == .connected else {
-            checkNegotiationTask?.cancel()
-            checkNegotiationTask = Task { [weak self] in
+            let delay = Int(options.sessionOptions.tickInterval * 1000)
+            looper.schedule(after: .milliseconds(delay)) { [weak self] in
                 guard let self else { return }
-                try? await Task.sleep(
-                    milliseconds: Int(options.sessionOptions.tickInterval * 1000)
-                )
-                guard !Task.isCancelled else { return }
-                looper.schedule {
-                    do {
-                        try self.checkNegotiationComplete()
-                    } catch {
-                        self.options.onError(self.key, error)
-                    }
+                guard !isCancelled else { return }
+                do {
+                    try checkNegotiationComplete()
+                } catch {
+                    self.options.onError(self.key, error)
                 }
             }
             return
         }
 
-        // let loop die when negotiation is complete
+        // Let loop die when negotiation is complete
     }
 
     func pushRequest() throws {
@@ -576,25 +572,23 @@ private extension NegotiatorV3 {
     func handleControlMessage(_ message: String) throws {
         pp_log(ctx, .openvpn, .info, "Received control message \(message.asSensitiveBytes(ctx))")
 
-        // disconnect on authentication failure
+        // Disconnect on authentication failure
         guard !message.hasPrefix("AUTH_FAILED") else {
-
-            // XXX: retry without client options
+            // XXX: Retry without client options
             if authenticator?.withLocalOptions ?? false {
                 pp_log(ctx, .openvpn, .error, "Authentication failure, retry without local options")
                 throw OpenVPNSessionError.badCredentialsWithLocalOptions
             }
-
             throw OpenVPNSessionError.badCredentials
         }
 
-        // disconnect on remote server restart (--explicit-exit-notify)
+        // Disconnect on remote server restart (--explicit-exit-notify)
         guard !message.hasPrefix("RESTART") else {
             pp_log(ctx, .openvpn, .info, "Disconnect due to server shutdown")
             throw OpenVPNSessionError.serverShutdown
         }
 
-        // handle authentication from now on
+        // Handle authentication from now on
         guard state == .push else {
             return
         }
@@ -630,7 +624,7 @@ private extension NegotiatorV3 {
             }
         } catch StandardOpenVPNParserError.continuationPushReply {
             continuatedPushReplyMessage = completeMessage.replacingOccurrences(of: "push-continuation", with: "")
-            // XXX: strip "PUSH_REPLY" and "push-continuation 2"
+            // XXX: Strip "PUSH_REPLY" and "push-continuation 2"
             return
         }
 
@@ -704,13 +698,9 @@ private extension NegotiatorV3 {
 private extension NegotiatorV3 {
     enum State: Int, Comparable {
         case idle
-
         case tls
-
         case auth
-
         case push
-
         case connected
 
         static func < (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-final class NegotiatorV3 {
+// Use looper.schedule() for synchronization
+final class NegotiatorV3: @unchecked Sendable {
     struct Options {
         let configuration: OpenVPN.Configuration
 
@@ -284,10 +285,12 @@ private extension NegotiatorV3 {
                     milliseconds: Int(options.sessionOptions.tickInterval * 1000)
                 )
                 guard !Task.isCancelled else { return }
-                do {
-                    try checkNegotiationComplete()
-                } catch {
-                    options.onError(key, error)
+                looper.schedule {
+                    do {
+                        try self.checkNegotiationComplete()
+                    } catch {
+                        self.options.onError(self.key, error)
+                    }
                 }
             }
             return

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
@@ -286,7 +286,7 @@ private extension NegotiatorV3 {
                 do {
                     try checkNegotiationComplete()
                 } catch {
-                    self.options.onError(self.key, error)
+                    options.onError(key, error)
                 }
             }
             return

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
@@ -64,9 +64,9 @@ final class NegotiatorV3: @unchecked Sendable {
 
     private var continuatedPushReplyMessage: String?
 
-    private var shouldResendWrappedKey: Bool
+    private var checkNegotiationTask: Task<Void, Never>?
 
-    private var isCancelled: Bool
+    private var shouldResendWrappedKey: Bool
 
     // MARK: Init
 
@@ -126,7 +126,6 @@ final class NegotiatorV3: @unchecked Sendable {
         expectedPacketId = 0
         pendingPackets = [:]
         shouldResendWrappedKey = false
-        isCancelled = false
     }
 
     deinit {
@@ -190,7 +189,7 @@ extension NegotiatorV3 {
     }
 
     func cancel() {
-        isCancelled = true
+        checkNegotiationTask?.cancel()
         pendingPackets.removeAll()
         authenticator = nil
     }
@@ -279,14 +278,19 @@ private extension NegotiatorV3 {
         }
 
         guard state == .connected else {
-            let delay = Int(options.sessionOptions.tickInterval * 1000)
-            looper.schedule(after: .milliseconds(delay)) { [weak self] in
+            checkNegotiationTask?.cancel()
+            checkNegotiationTask = Task { [weak self] in
                 guard let self else { return }
-                guard !isCancelled else { return }
-                do {
-                    try checkNegotiationComplete()
-                } catch {
-                    options.onError(key, error)
+                try? await Task.sleep(
+                    milliseconds: Int(options.sessionOptions.tickInterval * 1000)
+                )
+                guard !Task.isCancelled else { return }
+                looper.schedule {
+                    do {
+                        try self.checkNegotiationComplete()
+                    } catch {
+                        self.options.onError(self.key, error)
+                    }
                 }
             }
             return

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
@@ -369,7 +369,7 @@ private extension NegotiatorV3 {
         for raw in rawList {
             pp_log(ctx, .openvpn, .info, "Send control packet \(raw.asSensitiveBytes(ctx))")
         }
-        looper.write(rawList, to: .link)
+        try looper.write(rawList, to: .link)
     }
 
     func requestsWrappedKeyResend(from payload: Data?) -> Bool {
@@ -501,7 +501,7 @@ private extension NegotiatorV3 {
                 ackPacketIds: [controlPacket.packetId],
                 ackRemoteSessionId: controlPacket.sessionId
             )
-            looper.write([raw], to: .link)
+            try looper.write([raw], to: .link)
             pp_log(ctx, .openvpn, .info, "Ack successfully written to LINK for packetId \(controlPacket.packetId)")
         } catch {
             pp_log(ctx, .openvpn, .error, "Failed LINK write during send ack for packetId \(controlPacket.packetId): \(error)")

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
@@ -505,7 +505,7 @@ private extension NegotiatorV3 {
             pp_log(ctx, .openvpn, .info, "Ack successfully written to LINK for packetId \(controlPacket.packetId)")
         } catch {
             pp_log(ctx, .openvpn, .error, "Failed LINK write during send ack for packetId \(controlPacket.packetId): \(error)")
-            options.onError(key, PartoutError(.ioFailure, error))
+            options.onError(key, error)
         }
     }
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
@@ -4,7 +4,6 @@
 
 /// Observes major events notified by a `OpenVPNSessionProtocol`.
 protocol OpenVPNSessionDelegateV3: AnyObject, Sendable {
-
     /// Called after starting a session.
     ///
     /// - Parameter session: The originator.
@@ -12,35 +11,25 @@ protocol OpenVPNSessionDelegateV3: AnyObject, Sendable {
     /// - Parameter remoteProtocol: The endpoint protocol of the VPN server.
     /// - Parameter remoteOptions: The pulled tunnel settings.
     /// - Parameter remoteFd: The file descriptor of the underlying connection.
-    func sessionDidStart(_ session: OpenVPNSessionProtocolV3, remoteAddress: String, remoteProtocol: EndpointProtocol, remoteOptions: OpenVPN.Configuration, remoteFd: UInt64?) async
+    func sessionDidStart(_ session: OpenVPNSessionProtocolV3, remoteAddress: String, remoteProtocol: EndpointProtocol, remoteOptions: OpenVPN.Configuration, remoteFd: UInt64?)
 
     /// Called after stopping a session.
     ///
     /// - Parameter session: The originator.
     /// - Parameter error: An optional `Error` being the reason of the stop.
-    func sessionDidStop(_ session: OpenVPNSessionProtocolV3, withError error: Error?) async
+    func sessionDidStop(_ session: OpenVPNSessionProtocolV3, withError error: Error?)
 
     /// Called when the data count gets a significant update.
     ///
     /// - Parameter session: The originator.
     /// - Parameter dataCount: The data count.
-    func session(_ session: OpenVPNSessionProtocolV3, didUpdateDataCount dataCount: DataCount) async
+    func session(_ session: OpenVPNSessionProtocolV3, didUpdateDataCount dataCount: DataCount)
 }
 
 /// Provides methods to set up and maintain an OpenVPN session.
 protocol OpenVPNSessionProtocolV3: AnyObject, Sendable {
-
     /// Observe events with a `OpenVPNSessionDelegate`.
-    func setDelegate(_ delegate: OpenVPNSessionDelegateV3) async
-
-    /**
-     Establishes the tunnel interface for this session. The interface must be up and running for sending and receiving packets.
-
-     - Precondition: `tunnel` is an active network interface.
-     - Postcondition: The VPN data channel is open.
-     - Parameter tunnel: The `IOInterface` on which to exchange the VPN data traffic.
-     */
-    func setTunnel(_ tunnel: IOInterface) async
+    func setDelegate(_ delegate: OpenVPNSessionDelegateV3)
 
     /**
      Establishes the link interface for this session. The interface must be up and running for sending and receiving packets.
@@ -52,7 +41,16 @@ protocol OpenVPNSessionProtocolV3: AnyObject, Sendable {
     func setLink(_ link: LinkInterface) async throws
 
     /// True if a link was set via ``setLink(_:)`` and is still alive.
-    func hasLink() async -> Bool
+    func hasLink() -> Bool
+
+    /**
+     Establishes the tunnel interface for this session. The interface must be up and running for sending and receiving packets.
+
+     - Precondition: `tunnel` is an active network interface.
+     - Postcondition: The VPN data channel is open.
+     - Parameter tunnel: The `IOInterface` on which to exchange the VPN data traffic.
+     */
+    func setTunnel(_ tunnel: IOInterface) async throws
 
     /**
      Shuts down the session with an optional `Error` reason. Does nothing if the session is already stopped or about to stop.

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
@@ -57,6 +57,13 @@ protocol OpenVPNSessionProtocolV3: AnyObject, Sendable {
 
      - Parameters:
        - error: An optional `Error` being the reason of the shutdown.
+       - timeout: The optional timeout in seconds.
      */
-    func shutdown(_ error: Error?) async
+    func shutdown(_ error: Error?, timeout: TimeInterval?) async
+}
+
+extension OpenVPNSessionProtocolV3 {
+    func shutdown(_ error: Error?) async {
+        await shutdown(error, timeout: nil)
+    }
 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
@@ -57,13 +57,6 @@ protocol OpenVPNSessionProtocolV3: AnyObject, Sendable {
 
      - Parameters:
        - error: An optional `Error` being the reason of the shutdown.
-       - timeout: The optional timeout in seconds.
      */
-    func shutdown(_ error: Error?, timeout: TimeInterval?) async
-}
-
-extension OpenVPNSessionProtocolV3 {
-    func shutdown(_ error: Error?) async {
-        await shutdown(error, timeout: nil)
-    }
+    func shutdown(_ error: Error?) async
 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -19,25 +19,21 @@ extension OpenVPNSessionV3 {
     }
 
     struct ActiveContext {
+        private let ctx: PartoutLoggerContext
         private let dataLink: DataLink
         var withLocalOptions: Bool
-        var linkMetadata: LinkMetadata
-        var negotiators: [UInt8: NegotiatorV3] = [:]
-        var dataChannels: [UInt8: DataChannel] = [:]
-        var oldKeys: [UInt8] = []
-        var currentNegotiatorKey: UInt8? {
-            didSet {
-                pp_log(ctx, .openvpn, .info, "Negotiator: Current key is \(currentNegotiatorKey?.description ?? "nil")")
-            }
-        }
+        let linkMetadata: LinkMetadata
+
+        private var negotiators: [UInt8: NegotiatorV3] = [:]
+        private var dataChannels: [UInt8: DataChannel] = [:]
+        private var oldKeys: [UInt8] = []
+        private var currentNegotiatorKey: UInt8?
         private var currentDataChannelKey: UInt8?
         var pushReply: PushReply?
         var pendingPingTask: Task<Void, Error>?
         var lastReceivedDate: Date?
         var lastDataCountDate: Date?
         var dataCount = BidirectionalState<Int>(withResetValue: 0)
-
-        private let ctx: PartoutLoggerContext
 
         init(
             ctx: PartoutLoggerContext,
@@ -57,10 +53,39 @@ extension OpenVPNSessionV3 {
             }
         }
 
+        var allNegotiatorKeys: [UInt8] {
+            Array(negotiators.keys)
+        }
+
+        mutating func addNegotiator(_ negotiator: NegotiatorV3) {
+            pp_log(ctx, .openvpn, .info, "Replace negotiator with key \(negotiator.key)")
+            negotiators[negotiator.key] = negotiator
+            pp_log(ctx, .openvpn, .info, "Negotiators: \(negotiators.keys)")
+            currentNegotiatorKey = negotiator.key
+            pp_log(ctx, .openvpn, .info, "Negotiator: Current key is \(negotiator.key.description)")
+        }
+
+        mutating func removeOldNegotiators() {
+            while oldKeys.count > 1 {
+                let keyToRemove = oldKeys.removeFirst()
+                pp_log(ctx, .openvpn, .info, "Remove key \(keyToRemove) from negotiators and data channels")
+                negotiators.removeValue(forKey: keyToRemove)
+                dataChannels.removeValue(forKey: keyToRemove)
+            }
+        }
+
         var currentDataPair: DataLinkPair? {
             currentDataChannelKey.map {
                 DataLinkPair(link: dataLink, key: $0)
             }
+        }
+
+        var allDataKeys: [UInt8] {
+            Array(dataChannels.keys)
+        }
+
+        func dataChannel(forKey key: UInt8) -> DataChannel? {
+            dataChannels[key]
         }
 
         mutating func setDataChannel(_ channel: DataChannel, forKey key: UInt8) {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -28,7 +28,7 @@ extension OpenVPNSessionV3 {
         private var dataChannels: [UInt8: DataChannel] = [:]
         private var oldKeys: [UInt8] = []
         private var currentNegotiatorKey: UInt8?
-        private var currentDataChannelKey: UInt8?
+        private(set) var currentDataPair: DataLinkPair?
         var pushReply: PushReply?
         var pendingPingTask: Task<Void, Error>?
         var lastReceivedDate: Date?
@@ -74,12 +74,6 @@ extension OpenVPNSessionV3 {
             }
         }
 
-        var currentDataPair: DataLinkPair? {
-            currentDataChannelKey.map {
-                DataLinkPair(link: dataLink, key: $0)
-            }
-        }
-
         var allDataKeys: [UInt8] {
             Array(dataChannels.keys)
         }
@@ -90,10 +84,10 @@ extension OpenVPNSessionV3 {
 
         mutating func setDataChannel(_ channel: DataChannel, forKey key: UInt8) {
             dataChannels[channel.key] = channel
-            if let currentDataChannelKey {
-                oldKeys.append(currentDataChannelKey)
+            if let currentDataPair {
+                oldKeys.append(currentDataPair.key)
             }
-            currentDataChannelKey = key
+            currentDataPair = DataLinkPair(link: dataLink, key: key)
             pp_log(ctx, .openvpn, .info, "Data: Current key is \(key.description)")
         }
 
@@ -107,7 +101,7 @@ extension OpenVPNSessionV3 {
             pendingPingTask?.cancel()
             dataCount.reset()
             currentNegotiatorKey = nil
-            currentDataChannelKey = nil
+            currentDataPair = nil
             pushReply = nil
             pendingPingTask = nil
             lastDataCountDate = nil

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -19,6 +19,7 @@ extension OpenVPNSessionV3 {
     }
 
     struct ActiveContext {
+        private let dataLink: DataLink
         var withLocalOptions: Bool
         var linkMetadata: LinkMetadata
         var negotiators: [UInt8: NegotiatorV3] = [:]
@@ -29,11 +30,7 @@ extension OpenVPNSessionV3 {
                 pp_log(ctx, .openvpn, .info, "Negotiator: Current key is \(currentNegotiatorKey?.description ?? "nil")")
             }
         }
-        var currentDataChannelKey: UInt8? {
-            didSet {
-                pp_log(ctx, .openvpn, .info, "Data: Current key is \(currentDataChannelKey?.description ?? "nil")")
-            }
-        }
+        private var currentDataChannelKey: UInt8?
         var pushReply: PushReply?
         var pendingPingTask: Task<Void, Error>?
         var lastReceivedDate: Date?
@@ -42,8 +39,14 @@ extension OpenVPNSessionV3 {
 
         private let ctx: PartoutLoggerContext
 
-        init(ctx: PartoutLoggerContext, withLocalOptions: Bool, linkMetadata: LinkMetadata) {
+        init(
+            ctx: PartoutLoggerContext,
+            dataLink: DataLink,
+            withLocalOptions: Bool,
+            linkMetadata: LinkMetadata
+        ) {
             self.ctx = ctx
+            self.dataLink = dataLink
             self.withLocalOptions = withLocalOptions
             self.linkMetadata = linkMetadata
         }
@@ -54,10 +57,19 @@ extension OpenVPNSessionV3 {
             }
         }
 
-        var currentDataChannel: DataChannel? {
-            currentDataChannelKey.flatMap {
-                dataChannels[$0]
+        var currentDataPair: DataLinkPair? {
+            currentDataChannelKey.map {
+                DataLinkPair(link: dataLink, key: $0)
             }
+        }
+
+        mutating func setDataChannel(_ channel: DataChannel, forKey key: UInt8) {
+            dataChannels[channel.key] = channel
+            if let currentDataChannelKey {
+                oldKeys.append(currentDataChannelKey)
+            }
+            currentDataChannelKey = key
+            pp_log(ctx, .openvpn, .info, "Data: Current key is \(key.description)")
         }
 
         mutating func reset() {
@@ -74,6 +86,19 @@ extension OpenVPNSessionV3 {
             pushReply = nil
             pendingPingTask = nil
             lastDataCountDate = nil
+        }
+    }
+
+    struct DataLinkPair {
+        fileprivate let link: DataLink
+        fileprivate let key: UInt8
+
+        func send(_ packets: [Data], on key: UInt8? = nil) throws {
+            try link.send(packets, on: key ?? self.key)
+        }
+
+        func receive(_ packets: [Data], on key: UInt8) throws {
+            try link.receive(packets, on: key)
         }
     }
 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -116,8 +116,8 @@ extension OpenVPNSessionV3 {
         fileprivate let link: DataLink
         fileprivate let key: UInt8
 
-        func send(_ packets: [Data], on key: UInt8? = nil) throws {
-            try link.send(packets, on: key ?? self.key)
+        func send(_ packets: [Data], on key: UInt8? = nil, outOfBand: Bool = false) throws {
+            try link.send(packets, on: key ?? self.key, outOfBand: outOfBand)
         }
 
         func receive(_ packets: [Data], on key: UInt8) throws {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -24,16 +24,16 @@ extension OpenVPNSessionV3 {
         var withLocalOptions: Bool
         let linkMetadata: LinkMetadata
 
-        private var negotiators: [UInt8: NegotiatorV3] = [:]
-        private var dataChannels: [UInt8: DataChannel] = [:]
-        private var oldKeys: [UInt8] = []
+        private var negotiators: [UInt8: NegotiatorV3]
+        private var dataChannels: [UInt8: DataChannel]
+        private var oldKeys: [UInt8]
         private var currentNegotiatorKey: UInt8?
         private(set) var currentDataPair: DataLinkPair?
         var pushReply: PushReply?
         var pendingPingTask: Task<Void, Error>?
         var lastReceivedDate: Date?
         var lastDataCountDate: Date?
-        var dataCount = BidirectionalState<Int>(withResetValue: 0)
+        var dataCount: BidirectionalState<Int>
 
         init(
             ctx: PartoutLoggerContext,
@@ -45,6 +45,10 @@ extension OpenVPNSessionV3 {
             self.dataLink = dataLink
             self.withLocalOptions = withLocalOptions
             self.linkMetadata = linkMetadata
+            negotiators = [:]
+            dataChannels = [:]
+            oldKeys = []
+            dataCount = BidirectionalState(withResetValue: 0)
         }
 
         var currentNegotiator: NegotiatorV3? {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -116,8 +116,8 @@ extension OpenVPNSessionV3 {
         fileprivate let link: DataLink
         fileprivate let key: UInt8
 
-        func send(_ packets: [Data], on key: UInt8? = nil, outOfBand: Bool = false) throws {
-            try link.send(packets, on: key ?? self.key, outOfBand: outOfBand)
+        func send(_ packets: [Data], on key: UInt8? = nil, timeout: TimeInterval? = nil) throws {
+            try link.send(packets, on: key ?? self.key, timeout: timeout)
         }
 
         func receive(_ packets: [Data], on key: UInt8) throws {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+extension OpenVPNSessionV3 {
+    enum SessionState {
+        case stopped(IdleContext)
+        case active(ActivePhase, ActiveContext)
+    }
+
+    enum ActivePhase {
+        case starting
+        case started
+        case stopping
+    }
+
+    struct IdleContext {
+        var withLocalOptions: Bool
+    }
+
+    struct ActiveContext {
+        var withLocalOptions: Bool
+        var linkMetadata: LinkMetadata
+        var negotiators: [UInt8: NegotiatorV3] = [:]
+        var dataChannels: [UInt8: DataChannel] = [:]
+        var oldKeys: [UInt8] = []
+        var currentNegotiatorKey: UInt8? {
+            didSet {
+                pp_log(ctx, .openvpn, .info, "Negotiator: Current key is \(currentNegotiatorKey?.description ?? "nil")")
+            }
+        }
+        var currentDataChannelKey: UInt8? {
+            didSet {
+                pp_log(ctx, .openvpn, .info, "Data: Current key is \(currentDataChannelKey?.description ?? "nil")")
+            }
+        }
+        var pushReply: PushReply?
+        var pendingPingTask: Task<Void, Error>?
+        var lastReceivedDate: Date?
+        var lastDataCountDate: Date?
+        var dataCount = BidirectionalState<Int>(withResetValue: 0)
+
+        private let ctx: PartoutLoggerContext
+
+        init(ctx: PartoutLoggerContext, withLocalOptions: Bool, linkMetadata: LinkMetadata) {
+            self.ctx = ctx
+            self.withLocalOptions = withLocalOptions
+            self.linkMetadata = linkMetadata
+        }
+
+        var currentNegotiator: NegotiatorV3? {
+            currentNegotiatorKey.flatMap {
+                negotiators[$0]
+            }
+        }
+
+        var currentDataChannel: DataChannel? {
+            currentDataChannelKey.flatMap {
+                dataChannels[$0]
+            }
+        }
+
+        mutating func reset() {
+            for neg in negotiators.values {
+                neg.cancel()
+            }
+            negotiators.removeAll()
+            dataChannels.removeAll()
+            oldKeys.removeAll()
+            pendingPingTask?.cancel()
+            dataCount.reset()
+            currentNegotiatorKey = nil
+            currentDataChannelKey = nil
+            pushReply = nil
+            pendingPingTask = nil
+            lastDataCountDate = nil
+        }
+    }
+}

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
@@ -77,3 +77,51 @@ extension OpenVPNSessionV3 {
         }
     }
 }
+
+extension OpenVPNSessionV3 {
+    var activePhase: ActivePhase? {
+        preconditionOnQueue()
+        guard case .active(let phase, _) = sessionState else {
+            return nil
+        }
+        return phase
+    }
+
+    var idleContext: IdleContext? {
+        preconditionOnQueue()
+        guard case .stopped(let context) = sessionState else {
+            return nil
+        }
+        return context
+    }
+
+    var activeContext: ActiveContext? {
+        preconditionOnQueue()
+        guard case .active(_, let context) = sessionState else {
+            return nil
+        }
+        return context
+    }
+
+    @discardableResult
+    func withActiveContext<R>(
+        _ body: (inout ActivePhase, inout ActiveContext) throws -> R
+    ) rethrows -> R? {
+        preconditionOnQueue()
+        guard case .active(var phase, var context) = sessionState else {
+            return nil
+        }
+        let result = try body(&phase, &context)
+        sessionState = .active(phase, context)
+        return result
+    }
+
+    @discardableResult
+    func withActiveContext<R>(
+        _ body: (inout ActiveContext) throws -> R
+    ) rethrows -> R? {
+        try withActiveContext { _, context in
+            try body(&context)
+        }
+    }
+}

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -33,7 +33,7 @@ extension OpenVPNSessionV3 {
             }
         }
 
-        func send(_ packets: [Data], on key: UInt8) throws {
+        func send(_ packets: [Data], on key: UInt8, outOfBand: Bool) throws {
             do {
                 guard let channel = dataChannel(key) else {
                     return
@@ -46,13 +46,13 @@ extension OpenVPNSessionV3 {
                     return
                 }
                 reportOutboundDataCount(encryptedPackets.flatCount)
-                try looper.write(encryptedPackets, to: .link)
+                try looper.write(encryptedPackets, to: .link, outOfBand: outOfBand)
             } catch let cError as CCryptoError {
                 throw cError
             } catch let cError as CDataPathError {
                 throw cError
             } catch {
-                pp_log(ctx, .openvpn, .error, "Data: Failed LINK write during send data: \(error)")
+                pp_log(ctx, .openvpn, .error, "Data: Failed \(outOfBand ? "synchronous " : "")LINK write during send data: \(error)")
                 throw error
             }
         }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -5,9 +5,9 @@
 extension OpenVPNSessionV3 {
     func handleDataPackets(
         _ packets: [Data],
-        to tunnel: IOInterface,
+        to looper: FdLooper,
         dataChannel: DataChannel
-    ) async throws {
+    ) throws {
         do {
             guard let decryptedPackets = try dataChannel.decrypt(packets: packets) else {
                 pp_log(ctx, .openvpn, .error, "Unable to decrypt packets, is SessionKey properly configured (dataPath, peerId)?")
@@ -17,7 +17,7 @@ extension OpenVPNSessionV3 {
                 return
             }
             reportInboundDataCount(decryptedPackets.flatCount)
-            try await tunnel.writePackets(decryptedPackets)
+            looper.write(decryptedPackets, to: .tun)
         } catch let cError as CCryptoError {
             throw cError
         } catch let cError as CDataPathError {
@@ -29,9 +29,9 @@ extension OpenVPNSessionV3 {
 
     func sendDataPackets(
         _ packets: [Data],
-        to link: LinkInterface,
+        to looper: FdLooper,
         dataChannel: DataChannel
-    ) async throws {
+    ) throws {
         do {
             guard let encryptedPackets = try dataChannel.encrypt(packets: packets) else {
                 pp_log(ctx, .openvpn, .error, "Unable to encrypt packets, is SessionKey properly configured (dataPath, peerId)?")
@@ -41,14 +41,16 @@ extension OpenVPNSessionV3 {
                 return
             }
             reportOutboundDataCount(encryptedPackets.flatCount)
-            try await link.writePackets(encryptedPackets)
+            looper.write(encryptedPackets, to: .link)
         } catch let cError as CCryptoError {
             throw cError
         } catch let cError as CDataPathError {
             throw cError
         } catch {
             pp_log(ctx, .openvpn, .error, "Data: Failed LINK write during send data: \(error)")
-            await shutdown(PartoutError(.ioFailure, error))
+            Task {
+                await shutdown(PartoutError(.ioFailure, error))
+            }
         }
     }
 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -17,7 +17,7 @@ extension OpenVPNSessionV3 {
                 return
             }
             reportInboundDataCount(decryptedPackets.flatCount)
-            looper.write(decryptedPackets, to: .tun)
+            try looper.write(decryptedPackets, to: .tun)
         } catch let cError as CCryptoError {
             throw cError
         } catch let cError as CDataPathError {
@@ -41,7 +41,7 @@ extension OpenVPNSessionV3 {
                 return
             }
             reportOutboundDataCount(encryptedPackets.flatCount)
-            looper.write(encryptedPackets, to: .link)
+            try looper.write(encryptedPackets, to: .link)
         } catch let cError as CCryptoError {
             throw cError
         } catch let cError as CDataPathError {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -3,53 +3,61 @@
 // SPDX-License-Identifier: GPL-3.0
 
 extension OpenVPNSessionV3 {
-    func handleDataPackets(
-        _ packets: [Data],
-        to looper: FdLooper,
-        dataChannel: DataChannel
-    ) throws {
-        do {
-            guard let decryptedPackets = try dataChannel.decrypt(packets: packets) else {
-                pp_log(ctx, .openvpn, .error, "Unable to decrypt packets, is SessionKey properly configured (dataPath, peerId)?")
-                return
-            }
-            guard !decryptedPackets.isEmpty else {
-                return
-            }
-            reportInboundDataCount(decryptedPackets.flatCount)
-            try looper.write(decryptedPackets, to: .tun)
-        } catch let cError as CCryptoError {
-            throw cError
-        } catch let cError as CDataPathError {
-            throw cError
-        } catch {
-            throw OpenVPNSessionError.recoverable(error)
-        }
-    }
+    struct DataLink {
+        let ctx: PartoutLoggerContext
+        let looper: FdLooper
+        let dataChannel: (UInt8) -> DataChannel?
+        let reportInboundDataCount: (Int) -> Void
+        let reportOutboundDataCount: (Int) -> Void
 
-    func sendDataPackets(
-        _ packets: [Data],
-        to looper: FdLooper,
-        dataChannel: DataChannel
-    ) throws {
-        do {
-            guard let encryptedPackets = try dataChannel.encrypt(packets: packets) else {
-                pp_log(ctx, .openvpn, .error, "Unable to encrypt packets, is SessionKey properly configured (dataPath, peerId)?")
-                return
+        func receive(_ packets: [Data], on key: UInt8) throws {
+            do {
+                guard let channel = dataChannel(key) else {
+                    return
+                }
+                guard let decryptedPackets = try channel.decrypt(packets: packets) else {
+                    pp_log(ctx, .openvpn, .error, "Unable to decrypt packets, is DataChannel properly configured?")
+                    return
+                }
+                guard !decryptedPackets.isEmpty else {
+                    return
+                }
+                reportInboundDataCount(decryptedPackets.flatCount)
+                try looper.write(decryptedPackets, to: .tun)
+            } catch let cError as CCryptoError {
+                throw cError
+            } catch let cError as CDataPathError {
+                throw cError
+            } catch {
+                throw OpenVPNSessionError.recoverable(error)
             }
-            guard !encryptedPackets.isEmpty else {
-                return
-            }
-            reportOutboundDataCount(encryptedPackets.flatCount)
-            try looper.write(encryptedPackets, to: .link)
-        } catch let cError as CCryptoError {
-            throw cError
-        } catch let cError as CDataPathError {
-            throw cError
-        } catch {
-            pp_log(ctx, .openvpn, .error, "Data: Failed LINK write during send data: \(error)")
-            Task {
-                await shutdown(PartoutError(.ioFailure, error))
+        }
+
+        func send(_ packets: [Data], on key: UInt8) throws {
+            do {
+                guard let channel = dataChannel(key) else {
+                    return
+                }
+                guard let encryptedPackets = try channel.encrypt(packets: packets) else {
+                    pp_log(ctx, .openvpn, .error, "Unable to encrypt packets, is SessionKey properly configured (dataPath, peerId)?")
+                    return
+                }
+                guard !encryptedPackets.isEmpty else {
+                    return
+                }
+                reportOutboundDataCount(encryptedPackets.flatCount)
+                try looper.write(encryptedPackets, to: .link)
+            } catch let cError as CCryptoError {
+                throw cError
+            } catch let cError as CDataPathError {
+                throw cError
+            } catch {
+                pp_log(ctx, .openvpn, .error, "Data: Failed LINK write during send data: \(error)")
+                // FIXME: ###
+//                Task {
+//                    await shutdown(PartoutError(.ioFailure, error))
+//                }
+                throw error
             }
         }
     }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -39,7 +39,7 @@ extension OpenVPNSessionV3 {
                     return
                 }
                 guard let encryptedPackets = try channel.encrypt(packets: packets) else {
-                    pp_log(ctx, .openvpn, .error, "Unable to encrypt packets, is SessionKey properly configured (dataPath, peerId)?")
+                    pp_log(ctx, .openvpn, .error, "Unable to encrypt packets, is DataChannel properly configured?")
                     return
                 }
                 guard !encryptedPackets.isEmpty else {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -53,7 +53,7 @@ extension OpenVPNSessionV3 {
                 throw cError
             } catch {
                 pp_log(ctx, .openvpn, .error, "Data: Failed LINK write during send data: \(error)")
-                throw PartoutError(.ioFailure, error)
+                throw error
             }
         }
     }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -33,7 +33,7 @@ extension OpenVPNSessionV3 {
             }
         }
 
-        func send(_ packets: [Data], on key: UInt8, outOfBand: Bool) throws {
+        func send(_ packets: [Data], on key: UInt8, timeout: TimeInterval?) throws {
             do {
                 guard let channel = dataChannel(key) else {
                     return
@@ -46,13 +46,28 @@ extension OpenVPNSessionV3 {
                     return
                 }
                 reportOutboundDataCount(encryptedPackets.flatCount)
-                try looper.write(encryptedPackets, to: .link, outOfBand: outOfBand)
+
+                if let timeout {
+                    let deadline = Date().addingTimeInterval(timeout)
+                    var lastError: Error?
+                    repeat {
+                        do {
+                            try looper.write(encryptedPackets, to: .link, outOfBand: true)
+                            return
+                        } catch let error {
+                            lastError = error
+                        }
+                    } while Date() < deadline
+                    throw lastError ?? OpenVPNSessionError.writeTimeout
+                }
+
+                try looper.write(encryptedPackets, to: .link)
             } catch let cError as CCryptoError {
                 throw cError
             } catch let cError as CDataPathError {
                 throw cError
             } catch {
-                pp_log(ctx, .openvpn, .error, "Data: Failed \(outOfBand ? "synchronous " : "")LINK write during send data: \(error)")
+                pp_log(ctx, .openvpn, .error, "Data: Failed \(timeout != nil ? "synchronous " : "")LINK write during send data: \(error)")
                 throw error
             }
         }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
@@ -53,11 +53,7 @@ extension OpenVPNSessionV3 {
                 throw cError
             } catch {
                 pp_log(ctx, .openvpn, .error, "Data: Failed LINK write during send data: \(error)")
-                // FIXME: ###
-//                Task {
-//                    await shutdown(PartoutError(.ioFailure, error))
-//                }
-                throw error
+                throw PartoutError(.ioFailure, error)
             }
         }
     }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
@@ -43,7 +43,7 @@ extension OpenVPNSessionV3 {
 
             if code == .dataV1 || code == .dataV2 {
                 let key = firstByte & 0b111
-                guard hasDataChannel(for: key) else {
+                guard activeContext?.dataChannel(forKey: key) != nil else {
                     pp_log(ctx, .openvpn, .error, "Data: Channel with key \(key) not found")
                     continue
                 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
@@ -6,10 +6,9 @@ internal import _PartoutOpenVPNConnection_C
 
 extension OpenVPNSessionV3 {
     func receiveLink(_ packets: [Data]) throws {
-        guard !isStopped, let looper else {
+        guard !isStopped else {
             return
         }
-
         reportLastReceivedDate()
         var dataPacketsByKey: [UInt8: [Data]] = [:]
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
@@ -99,24 +99,9 @@ extension OpenVPNSessionV3 {
     }
 
     func receiveTunnel(_ packets: [Data]) throws {
-        guard !isStopped else {
-            return
-        }
-        guard let negotiator = currentNegotiator else {
-            pp_log(ctx, .openvpn, .fault, "No negotiator")
-            throw OpenVPNSessionError.assertion
-        }
-        guard negotiator.isConnected, let currentDataChannel else {
-            return
-        }
-
+        guard let currentDataPair else { return }
         try checkPingTimeout()
-
-        try sendDataPackets(
-            packets,
-            to: negotiator.looper,
-            dataChannel: currentDataChannel
-        )
+        try currentDataPair.send(packets)
     }
 }
 
@@ -124,17 +109,9 @@ private extension OpenVPNSessionV3 {
     @inline(always)
     func processDataPackets(_ dataPacketsByKey: [UInt8: [Data]]) throws {
         guard !dataPacketsByKey.isEmpty else { return }
-        guard let looper else { return }
+        guard let currentDataPair else { return }
         for (key, dataPackets) in dataPacketsByKey {
-            guard let dataChannel = dataChannel(for: key) else {
-                pp_log(ctx, .openvpn, .error, "Accounted a data packet for which the cryptographic key hadn't been found")
-                continue
-            }
-            try handleDataPackets(
-                dataPackets,
-                to: looper,
-                dataChannel: dataChannel
-            )
+            try currentDataPair.receive(dataPackets, on: key)
         }
     }
 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
@@ -4,93 +4,9 @@
 
 internal import _PartoutOpenVPNConnection_C
 
-// TODO: #142/notes, LINK and TUN should be able to run detached in full-duplex
 extension OpenVPNSessionV3 {
-    func loopTunnelV2() {
-        Task { [weak self] in
-            while true {
-                guard let ctx = self?.ctx else {
-                    pp_log(.global, .openvpn, .debug, "Ignore TUN read from outdated OpenVPNSession")
-                    return
-                }
-                guard let tunnel = self?.tunnel else {
-                    pp_log(ctx, .openvpn, .debug, "Ignore read from outdated TUN")
-                    return
-                }
-                guard let self else {
-                    pp_log(.global, .openvpn, .debug, "Ignore TUN packets from outdated OpenVPNSession")
-                    return
-                }
-                do {
-                    let packets = try await tunnel.readPackets()
-                    guard !packets.isEmpty else {
-//                        pp_log(ctx, .openvpn, .debug, "Skip TUN loop after empty packets")
-                        continue
-                    }
-                    try await receiveTunnel(packets: packets)
-                } catch {
-                    pp_log(ctx, .openvpn, .error, "Failed TUN read: \(error)")
-                    await shutdown(error)
-                    return
-                }
-            }
-        }
-    }
-
-    func loopLinkV2() {
-        Task { [weak self] in
-            while true {
-                guard let ctx = self?.ctx else {
-                    pp_log(.global, .openvpn, .debug, "Ignore LINK read from outdated OpenVPNSession")
-                    return
-                }
-                guard let link = self?.link else {
-                    pp_log(ctx, .openvpn, .debug, "Ignore read from outdated LINK")
-                    return
-                }
-                guard let self else {
-                    pp_log(.global, .openvpn, .debug, "Ignore LINK packets from outdated OpenVPNSession")
-                    return
-                }
-                do {
-                    let packets = try await link.readPackets()
-                    guard !packets.isEmpty else {
-//                        pp_log(ctx, .openvpn, .debug, "Skip LINK loop after empty packets")
-                        continue
-                    }
-                    try await receiveLink(packets: packets)
-                } catch {
-                    pp_log(ctx, .openvpn, .error, "Failed LINK read: \(error)")
-                    await self.shutdown(PartoutError(.ioFailure, error))
-                    return
-                }
-            }
-        }
-    }
-}
-
-// MARK: - Private
-
-private extension OpenVPNSessionV3 {
-    @inline(always)
-    func processDataPackets(_ dataPacketsByKey: [UInt8: [Data]]) async throws {
-        guard !dataPacketsByKey.isEmpty else { return }
-        guard let tunnel else { return }
-        for (key, dataPackets) in dataPacketsByKey {
-            guard let dataChannel = dataChannel(for: key) else {
-                pp_log(ctx, .openvpn, .error, "Accounted a data packet for which the cryptographic key hadn't been found")
-                continue
-            }
-            try await handleDataPackets(
-                dataPackets,
-                to: tunnel,
-                dataChannel: dataChannel
-            )
-        }
-    }
-
-    func receiveLink(packets: [Data]) async throws {
-        guard !isStopped, let link else {
+    func receiveLink(_ packets: [Data]) throws {
+        guard !isStopped, let looper else {
             return
         }
 
@@ -102,7 +18,7 @@ private extension OpenVPNSessionV3 {
             throw OpenVPNSessionError.assertion
         }
         if negotiator.shouldRenegotiate() {
-            negotiator = try startRenegotiation(after: negotiator, on: link, isServerInitiated: false)
+            negotiator = try startRenegotiation(after: negotiator, on: looper, isServerInitiated: false)
         }
 
         for packet in packets {
@@ -140,7 +56,7 @@ private extension OpenVPNSessionV3 {
                 continue
             }
 
-            try await processDataPackets(dataPacketsByKey)
+            try processDataPackets(dataPacketsByKey)
             dataPacketsByKey.removeAll(keepingCapacity: true)
 
             let controlPacket: CrossPacket
@@ -163,13 +79,13 @@ private extension OpenVPNSessionV3 {
                 }
             case .softResetV1:
                 if !negotiator.isRenegotiating {
-                    negotiator = try startRenegotiation(after: negotiator, on: link, isServerInitiated: true)
+                    negotiator = try startRenegotiation(after: negotiator, on: looper, isServerInitiated: true)
                 }
             default:
                 break
             }
 
-            negotiator.sendAck(for: controlPacket, to: link)
+            try negotiator.sendAck(for: controlPacket, to: looper)
 
             let pendingInboundQueue = negotiator.enqueueInboundPacket(packet: controlPacket)
             pp_log(ctx, .openvpn, .debug, "Pending inbound queue: \(pendingInboundQueue.map(\.packetId))")
@@ -179,10 +95,10 @@ private extension OpenVPNSessionV3 {
             }
         }
 
-        try await processDataPackets(dataPacketsByKey)
+        try processDataPackets(dataPacketsByKey)
     }
 
-    func receiveTunnel(packets: [Data]) async throws {
+    func receiveTunnel(_ packets: [Data]) throws {
         guard !isStopped else {
             return
         }
@@ -196,10 +112,29 @@ private extension OpenVPNSessionV3 {
 
         try checkPingTimeout()
 
-        try await sendDataPackets(
+        try sendDataPackets(
             packets,
-            to: negotiator.link,
+            to: negotiator.looper,
             dataChannel: currentDataChannel
         )
+    }
+}
+
+private extension OpenVPNSessionV3 {
+    @inline(always)
+    func processDataPackets(_ dataPacketsByKey: [UInt8: [Data]]) throws {
+        guard !dataPacketsByKey.isEmpty else { return }
+        guard let looper else { return }
+        for (key, dataPackets) in dataPacketsByKey {
+            guard let dataChannel = dataChannel(for: key) else {
+                pp_log(ctx, .openvpn, .error, "Accounted a data packet for which the cryptographic key hadn't been found")
+                continue
+            }
+            try handleDataPackets(
+                dataPackets,
+                to: looper,
+                dataChannel: dataChannel
+            )
+        }
     }
 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Negotiation.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Negotiation.swift
@@ -4,18 +4,17 @@
 
 extension OpenVPNSessionV3 {
     @discardableResult
-    func startNegotiation(on link: LinkInterface) throws -> NegotiatorV3 {
+    func startNegotiation(on looper: FdLooper, linkMetadata: LinkMetadata) throws -> NegotiatorV3 {
         pp_log(ctx, .openvpn, .info, "Start negotiation")
-        let neg = try newNegotiator(on: link)
+        let neg = try newNegotiator(on: looper, linkMetadata: linkMetadata)
         addNegotiator(neg)
-        loopLinkV2()
         try neg.start()
         return neg
     }
 
     func startRenegotiation(
         after negotiator: NegotiatorV3,
-        on link: LinkInterface,
+        on looper: FdLooper,
         isServerInitiated: Bool
     ) throws -> NegotiatorV3 {
         guard !negotiator.isRenegotiating else {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -154,11 +154,11 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             side: .link,
             original: link,
             beforeRead: rw.beforeRead,
-            beforeWrite: rw.beforeWrite,
             onRead: { [weak self] packets in
                 try self?.receiveLink(packets)
                 return .keep
-            }
+            },
+            transformWrite: rw.beforeWrite
         ))
         try looper.schedule { [weak self] in
             try self?.setLinkOnQueue(link)
@@ -179,11 +179,11 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             side: .tun,
             original: tunnel,
             beforeRead: nil,
-            beforeWrite: nil,
             onRead: { [weak self] packets in
                 try self?.receiveTunnel(packets)
                 return .keep
-            }
+            },
+            transformWrite: nil
         ))
     }
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -149,35 +149,12 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             return
         }
         let proc = PacketProcessor(method: configuration.xorMethod)
-        var buffer = Data()
+        let rw = LinkProcessor(proc: proc, isReliable: link.isReliable)
         try await looper.attach(.init(
             side: .link,
             original: link,
-            beforeRead: { prePackets in
-                // FIXME: ###
-                if link.metadata.isReliable {
-                    // FIXME: #214, TCP is very slow
-                    buffer.reserveCapacity(buffer.count + prePackets.flatCount)
-                    for p in prePackets {
-                        buffer.append(p)
-                    }
-                    var until = 0
-                    let processedPackets = proc.packets(fromStream: buffer, until: &until)
-                    buffer = buffer.subdata(in: until..<buffer.count)
-                    return processedPackets
-                } else {
-                    return proc.processPackets(prePackets, direction: .inbound)
-                }
-            },
-            beforeWrite: { packets in
-                if link.metadata.isReliable {
-                    let stream = proc.stream(fromPackets: packets)
-                    guard !stream.isEmpty else { return [] }
-                    return [stream]
-                } else {
-                    return proc.processPackets(packets, direction: .outbound)
-                }
-            },
+            beforeRead: rw.beforeRead,
+            beforeWrite: rw.beforeWrite,
             onRead: { [weak self] packets in
                 try self?.receiveLink(packets)
                 return .keep

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -169,10 +169,10 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         looper.isLinkAttached
     }
 
-    func shutdown(_ error: Error?) async {
+    func shutdown(_ error: Error?, timeout: TimeInterval?) async {
         do {
             let shouldDetach = try await looper.perform { [weak self] in
-                self?.prepareShutdownOnQueue(error) ?? false
+                self?.prepareShutdownOnQueue(error, timeout: timeout) ?? false
             }
             guard shouldDetach else {
                 return
@@ -228,7 +228,7 @@ private extension OpenVPNSessionV3 {
         }
     }
 
-    func prepareShutdownOnQueue(_ error: Error?) -> Bool {
+    func prepareShutdownOnQueue(_ error: Error?, timeout: TimeInterval?) -> Bool {
         preconditionOnQueue()
         guard activePhase != .stopping, activePhase != nil else {
             pp_log(ctx, .openvpn, .debug, "Ignore stop request, stopped or already stopping")

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -21,7 +21,14 @@ final class OpenVPNSessionV3: @unchecked Sendable {
     // MARK: Mutable state
 
     private let controlChannel: ControlChannelV3
-    private var sessionState: SessionState
+    var sessionState: SessionState
+
+    func preconditionOnQueue() {
+        precondition(
+            DispatchQueue.getSpecific(key: queueKey) != nil,
+            "OpenVPNSessionV3 state accessed outside its queue"
+        )
+    }
 
     /**
      Creates a VPN session.
@@ -76,61 +83,6 @@ final class OpenVPNSessionV3: @unchecked Sendable {
 
     deinit {
         pp_log(ctx, .openvpn, .debug, "Deinit OpenVPNSession")
-    }
-}
-
-private extension OpenVPNSessionV3 {
-    func preconditionOnQueue() {
-        precondition(
-            DispatchQueue.getSpecific(key: queueKey) != nil,
-            "OpenVPNSessionV3 state accessed outside its queue"
-        )
-    }
-
-    var activePhase: ActivePhase? {
-        preconditionOnQueue()
-        guard case .active(let phase, _) = sessionState else {
-            return nil
-        }
-        return phase
-    }
-
-    var idleContext: IdleContext? {
-        preconditionOnQueue()
-        guard case .stopped(let context) = sessionState else {
-            return nil
-        }
-        return context
-    }
-
-    var activeContext: ActiveContext? {
-        preconditionOnQueue()
-        guard case .active(_, let context) = sessionState else {
-            return nil
-        }
-        return context
-    }
-
-    @discardableResult
-    func withActiveContext<R>(
-        _ body: (inout ActivePhase, inout ActiveContext) throws -> R
-    ) rethrows -> R? {
-        preconditionOnQueue()
-        guard case .active(var phase, var context) = sessionState else {
-            return nil
-        }
-        let result = try body(&phase, &context)
-        sessionState = .active(phase, context)
-        return result
-    }
-
-    @discardableResult
-    func withActiveContext<R>(
-        _ body: (inout ActiveContext) throws -> R
-    ) rethrows -> R? {
-        try withActiveContext { _, context in
-            try body(&context)
-        }
     }
 }
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -170,8 +170,22 @@ private extension OpenVPNSessionV3 {
             throw PartoutError(.operationCancelled)
         }
         pp_log(ctx, .openvpn, .info, "Start VPN session")
+        let dataLink = DataLink(
+            ctx: ctx,
+            looper: looper,
+            dataChannel: { [weak self] in
+                self?.activeContext?.dataChannels[$0]
+            },
+            reportInboundDataCount: { [weak self] in
+                self?.reportInboundDataCount($0)
+            },
+            reportOutboundDataCount: { [weak self] in
+                self?.reportOutboundDataCount($0)
+            }
+        )
         sessionState = .active(.starting, ActiveContext(
             ctx: ctx,
+            dataLink: dataLink,
             withLocalOptions: idleContext.withLocalOptions,
             linkMetadata: link.metadata
         ))
@@ -251,20 +265,14 @@ private extension OpenVPNSessionV3 {
 private extension OpenVPNSessionV3 {
     func sendExitPacketOnQueue() throws {
         preconditionOnQueue()
-        guard let activeContext,
-              !activeContext.linkMetadata.isReliable,
-              let currentDataChannel = activeContext.currentDataChannel else {
-            return
+        try withActiveContext { context in
+            guard !context.linkMetadata.isReliable, let dataPair = context.currentDataPair else {
+                return
+            }
+            pp_log(ctx, .openvpn, .info, "Send OCCPacket exit")
+            try dataPair.send([OCCPacket.exit.serialized()])
+            pp_log(ctx, .openvpn, .info, "Sent OCCPacket correctly")
         }
-        guard let packets = try currentDataChannel.encrypt(packets: [OCCPacket.exit.serialized()]) else {
-            pp_log(ctx, .openvpn, .error, "Encrypted to empty OCCPacket packets")
-            assertionFailure("Empty OCCPacket packets?")
-            return
-        }
-
-        pp_log(ctx, .openvpn, .info, "Send OCCPacket exit")
-        try looper.write(packets, to: .link)
-        pp_log(ctx, .openvpn, .info, "Sent OCCPacket correctly")
     }
 }
 
@@ -279,8 +287,8 @@ extension OpenVPNSessionV3 {
         activeContext?.currentNegotiator
     }
 
-    var currentDataChannel: DataChannel? {
-        activeContext?.currentDataChannel
+    var currentDataPair: DataLinkPair? {
+        activeContext?.currentDataPair
     }
 
     func newNegotiator(on looper: FdLooper, linkMetadata: LinkMetadata) throws -> NegotiatorV3 {
@@ -348,11 +356,7 @@ extension OpenVPNSessionV3 {
 
             // Replace current channel with new
             pp_log(ctx, .openvpn, .info, "Replace key \(dataChannel.key) with new data channel")
-            context.dataChannels[dataChannel.key] = dataChannel
-            if let currentDataChannel = context.currentDataChannel {
-                context.oldKeys.append(currentDataChannel.key)
-            }
-            context.currentDataChannelKey = key
+            context.setDataChannel(dataChannel, forKey: key)
 
             // Clean up old keys
             while context.oldKeys.count > 1 {
@@ -455,26 +459,17 @@ private extension OpenVPNSessionV3 {
             pp_log(ctx, .openvpn, .debug, "Ping cancelled, session stopped")
             return
         }
-        guard looper.isLinkAttached else {
-            pp_log(ctx, .openvpn, .debug, "Ping cancelled, no link")
+        guard let currentDataPair else {
+            pp_log(ctx, .openvpn, .debug, "Ping cancelled, no data link")
             return
         }
-        guard let currentDataChannel else {
-            pp_log(ctx, .openvpn, .debug, "Ping cancelled, no data channel")
-            return
-        }
-
         pp_log(ctx, .openvpn, .debug, "Run ping check")
         try checkPingTimeout()
 
         // Is keep-alive enabled?
         if keepAliveInterval != nil {
             pp_log(ctx, .openvpn, .debug, "Send ping")
-            try sendDataPackets(
-                [Constants.DataChannel.pingString],
-                to: looper,
-                dataChannel: currentDataChannel
-            )
+            try currentDataPair.send([Constants.DataChannel.pingString])
         }
 
         // Schedule even just to check for ping timeout

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -2,82 +2,26 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-/// Default implementation of `OpenVPNSessionProtocolV3`.
-@OpenVPNActor
-final class OpenVPNSessionV3 {
-    enum SessionState {
-        case stopped
-
-        case starting
-
-        case started
-
-        case stopping
-    }
-
-    // MARK: Init
-
+/// Default implementation of `OpenVPNSessionProtocol`.
+final class OpenVPNSessionV3: @unchecked Sendable {
     let ctx: PartoutLoggerContext
-
     private let configuration: OpenVPN.Configuration
-
     private let credentials: OpenVPN.Credentials?
-
     private let prng: PRNGProtocol
-
     let cachesURL: URL
-
     let options: OpenVPNConnectionOptions
-
     private let tlsFactory: TLSFactory
-
     private let dpFactory: DataPathFactory
-
-    // MARK: Persistent state
-
-    private let controlChannel: ControlChannel
-
+    private let queue: DispatchQueue
+    private let queueKey: DispatchSpecificKey<Void>
+    // FIXME: ###, Workaround for self in init closures
+    var looper: FdLooper!
     private weak var delegate: OpenVPNSessionDelegateV3?
 
-    // MARK: State
+    // MARK: Mutable state
 
+    private let controlChannel: ControlChannelV3
     private var sessionState: SessionState
-
-    private(set) var tunnel: IOInterface?
-
-    private(set) var link: LinkInterface?
-
-    private var negotiators: [UInt8: NegotiatorV3]
-
-    private var dataChannels: [UInt8: DataChannel]
-
-    private var oldKeys: [UInt8]
-
-    private var currentNegotiatorKey: UInt8? {
-        didSet {
-            pp_log(ctx, .openvpn, .info, "Negotiator: Current key is \(currentNegotiatorKey?.description ?? "nil")")
-        }
-    }
-
-    private var currentDataChannelKey: UInt8? {
-        didSet {
-            pp_log(ctx, .openvpn, .info, "Data: Current key is \(currentDataChannelKey?.description ?? "nil")")
-        }
-    }
-
-    private var withLocalOptions: Bool
-
-    private var pushReply: PushReply?
-
-    private var pendingPingTask: Task<Void, Error>?
-
-    private var lastReceivedDate: Date?
-
-    private var lastDataCountDate: Date?
-
-    private var dataCount: BidirectionalState<Int>
-
-    // MARK: Init
 
     /**
      Creates a VPN session.
@@ -113,97 +57,242 @@ final class OpenVPNSessionV3 {
         self.tlsFactory = tlsFactory
         self.dpFactory = dpFactory
 
+        queue = DispatchQueue(label: "OpenVPNSession[\(ctx.profileId?.description ?? "*")]")
+        queueKey = DispatchSpecificKey()
+        queue.setSpecific(key: queueKey, value: ())
         controlChannel = try Self.newControlChannel(
             ctx,
             with: prng,
             configuration: configuration
         )
-        negotiators = [:]
-        dataChannels = [:]
-        oldKeys = []
+        sessionState = .stopped(IdleContext(withLocalOptions: true))
 
-        sessionState = .stopped
-        withLocalOptions = true
-        dataCount = BidirectionalState(withResetValue: 0)
+        looper = try FdLooper(ctx, queue: queue, delegate: FdLooperDelegate(
+            onRead: { [weak self] packets, side in
+                switch side {
+                case .link:
+                    try self?.receiveLink(packets)
+                case .tun:
+                    try self?.receiveTunnel(packets)
+                }
+                return .keep
+            },
+            onFinish: { [weak self] error in
+                pp_log(self?.ctx ?? .global, .openvpn, .error, "Session looper finished with error: \(error?.localizedDescription ?? "none")")
+                self?.looperDidFinish(error)
+            }
+        ))
+        looper.start()
     }
 
     deinit {
-        pp_log(ctx, .openvpn, .debug, "Deinit OpenVPNSessionV3")
+        pp_log(ctx, .openvpn, .debug, "Deinit OpenVPNSession")
+    }
+}
+
+private extension OpenVPNSessionV3 {
+    func preconditionOnQueue() {
+        precondition(
+            DispatchQueue.getSpecific(key: queueKey) != nil,
+            "OpenVPNSessionV3 state accessed outside its queue"
+        )
+    }
+
+    var activePhase: ActivePhase? {
+        preconditionOnQueue()
+        guard case .active(let phase, _) = sessionState else {
+            return nil
+        }
+        return phase
+    }
+
+    var idleContext: IdleContext? {
+        preconditionOnQueue()
+        guard case .stopped(let context) = sessionState else {
+            return nil
+        }
+        return context
+    }
+
+    var activeContext: ActiveContext? {
+        preconditionOnQueue()
+        guard case .active(_, let context) = sessionState else {
+            return nil
+        }
+        return context
+    }
+
+    @discardableResult
+    func withActiveContext<R>(
+        _ body: (inout ActivePhase, inout ActiveContext) throws -> R
+    ) rethrows -> R? {
+        preconditionOnQueue()
+        guard case .active(var phase, var context) = sessionState else {
+            return nil
+        }
+        let result = try body(&phase, &context)
+        sessionState = .active(phase, context)
+        return result
+    }
+
+    @discardableResult
+    func withActiveContext<R>(
+        _ body: (inout ActiveContext) throws -> R
+    ) rethrows -> R? {
+        try withActiveContext { _, context in
+            try body(&context)
+        }
     }
 }
 
 // MARK: - Public API
 
 extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
-    func setDelegate(_ delegate: OpenVPNSessionDelegateV3) async {
-        self.delegate = delegate
+    func setDelegate(_ delegate: OpenVPNSessionDelegateV3) {
+        looper.schedule { [weak self] in
+            self?.delegate = delegate
+        }
     }
 
-    func setTunnel(_ tunnel: IOInterface) {
-        guard self.tunnel == nil else {
+    func setLink(_ link: LinkInterface) async throws {
+        guard !looper.isLinkAttached else {
+            pp_log(ctx, .openvpn, .error, "Link interface already set")
+            return
+        }
+        try await looper.attachLink(link)
+        try looper.schedule { [weak self] in
+            try self?.setLinkOnQueue(link)
+        }
+    }
+
+    func setTunnel(_ tunnel: IOInterface) async throws {
+        guard looper.isLinkAttached else {
+            pp_log(ctx, .openvpn, .error, "Set link interface first")
+            return
+        }
+        guard !looper.isTunAttached else {
             pp_log(ctx, .openvpn, .error, "Tunnel interface already set")
             return
         }
         pp_log(ctx, .openvpn, .info, "Start TUN loop")
-        self.tunnel = tunnel
-        loopTunnelV2()
+        try await looper.attachTun(tunnel)
     }
 
-    func setLink(_ link: LinkInterface) async throws {
-        guard self.link == nil else {
-            pp_log(ctx, .openvpn, .error, "Link interface already set")
-            return
-        }
-        pp_log(ctx, .openvpn, .info, "Start VPN session")
-        self.link = link
-        sessionState = .starting
-        try startNegotiation(on: link)
-    }
-
-    func hasLink() async -> Bool {
-        link != nil
+    func hasLink() -> Bool {
+        looper.isLinkAttached
     }
 
     func shutdown(_ error: Error?, timeout: TimeInterval?) async {
-        guard sessionState != .stopping, sessionState != .stopped else {
-            pp_log(ctx, .openvpn, .debug, "Ignore stop request, stopped or already stopping")
-            return
+        do {
+            let shouldDetach = try await looper.perform { [weak self] in
+                self?.prepareShutdownOnQueue(error, timeout: timeout) ?? false
+            }
+            guard shouldDetach else {
+                return
+            }
+            await looper.detachTun()
+            await looper.detachLink()
+            try await looper.perform { [weak self] in
+                self?.finishShutdownOnQueue(error)
+            }
+        } catch {
+            pp_log(ctx, .openvpn, .error, "Unable to shut down session on looper queue: \(error)")
         }
+    }
+}
 
+private extension OpenVPNSessionV3 {
+    func setLinkOnQueue(_ link: LinkInterface) throws {
+        preconditionOnQueue()
+        guard let idleContext else {
+            pp_log(ctx, .openvpn, .error, "Session is not stopped")
+            throw PartoutError(.operationCancelled)
+        }
+        pp_log(ctx, .openvpn, .info, "Start VPN session")
+        sessionState = .active(.starting, ActiveContext(
+            ctx: ctx,
+            withLocalOptions: idleContext.withLocalOptions,
+            linkMetadata: link.metadata
+        ))
+        do {
+            try startNegotiation(on: looper, linkMetadata: link.metadata)
+        } catch {
+            withActiveContext { context in
+                context.reset()
+            }
+            sessionState = .stopped(idleContext)
+            throw error
+        }
+    }
+
+    func prepareShutdownOnQueue(_ error: Error?, timeout: TimeInterval?) -> Bool {
+        preconditionOnQueue()
+        guard activePhase != .stopping, activePhase != nil else {
+            pp_log(ctx, .openvpn, .debug, "Ignore stop request, stopped or already stopping")
+            return false
+        }
+        // Report .stopping phase
         if let error {
             pp_log(ctx, .openvpn, .error, "Shut down with failure: \(error)")
         } else {
             pp_log(ctx, .openvpn, .info, "Shut down on request")
         }
-        sessionState = .stopping
+        withActiveContext { phase, _ in
+            phase = .stopping
+        }
 
-        // shut down after sending exit notification if link is unreliable (normally UDP)
-        if error == nil || (error as? PartoutError)?.code == .networkChanged {
+        // Shut down after sending exit notification if link is unreliable (normally UDP)
+        if error == nil || error?.partoutErrorCode == .networkChanged {
             do {
-                try await sendExitPacket(timeout: timeout)
+                try sendExitPacketOnQueue()
             } catch {
                 pp_log(ctx, .openvpn, .error, "Unable to send exit packet: \(error)")
             }
         }
+        return true
+    }
 
-        await cleanup()
-        sessionState = .stopped
-
-        // retry authentication without local otpions
-        if case .badCredentialsWithLocalOptions = error as? OpenVPNSessionError {
-            withLocalOptions = false
+    func finishShutdownOnQueue(_ error: Error?) {
+        preconditionOnQueue()
+        guard activePhase != nil else {
+            return
+        }
+        withActiveContext { context in
+            context.reset()
         }
 
-        await delegate?.sessionDidStop(
+        // Migrate context to go back to .stopped state
+        let nextWithLocalOptions: Bool
+        switch sessionState {
+        case .stopped(let context):
+            nextWithLocalOptions = context.withLocalOptions
+        case .active(_, let context):
+            if case .badCredentialsWithLocalOptions = error as? OpenVPNSessionError {
+                nextWithLocalOptions = false
+            } else {
+                nextWithLocalOptions = context.withLocalOptions
+            }
+        }
+        sessionState = .stopped(IdleContext(withLocalOptions: nextWithLocalOptions))
+
+        delegate?.sessionDidStop(
             self,
             withError: error.map(OpenVPNSessionError.init) ?? error
         )
     }
+
+    func looperDidFinish(_ error: Error?) {
+        preconditionOnQueue()
+        finishShutdownOnQueue(error)
+    }
 }
 
 private extension OpenVPNSessionV3 {
-    func sendExitPacket(timeout: TimeInterval?) async throws {
-        guard let link, !link.isReliable, let currentDataChannel else {
+    func sendExitPacketOnQueue() throws {
+        preconditionOnQueue()
+        guard let activeContext,
+              !activeContext.linkMetadata.isReliable,
+              let currentDataChannel = activeContext.currentDataChannel else {
             return
         }
         guard let packets = try currentDataChannel.encrypt(packets: [OCCPacket.exit.serialized()]) else {
@@ -213,48 +302,8 @@ private extension OpenVPNSessionV3 {
         }
 
         pp_log(ctx, .openvpn, .info, "Send OCCPacket exit")
-
-        let timeoutMillis = Int((timeout ?? options.writeTimeout) * 1000.0)
-        let timeoutTask = Task {
-            try await Task.sleep(milliseconds: timeoutMillis)
-        }
-        let writeTask = Task {
-            try await link.writePackets(packets)
-            timeoutTask.cancel()
-            do {
-                try Task.checkCancellation()
-            } catch {
-                pp_log(ctx, .openvpn, .error, "Cancelled OCCPacket: \(error)")
-            }
-        }
-        do {
-            try await timeoutTask.value
-        } catch {
-            pp_log(ctx, .openvpn, .info, "Cancelled OCCPacket write timeout (completed earlier): \(error)")
-        }
-        writeTask.cancel()
-
+        looper.write(packets, to: .link)
         pp_log(ctx, .openvpn, .info, "Sent OCCPacket correctly")
-    }
-
-    func cleanup() async {
-        link?.shutdown()
-        for neg in negotiators.values {
-            neg.cancel()
-        }
-        negotiators.removeAll()
-        dataChannels.removeAll()
-        oldKeys.removeAll()
-        pendingPingTask?.cancel()
-        dataCount.reset()
-
-        link = nil
-        tunnel = nil
-        currentNegotiatorKey = nil
-        currentDataChannelKey = nil
-        pushReply = nil
-        pendingPingTask = nil
-        lastDataCountDate = nil
     }
 }
 
@@ -262,28 +311,25 @@ private extension OpenVPNSessionV3 {
 
 extension OpenVPNSessionV3 {
     var isStopped: Bool {
-        sessionState == .stopped
+        activePhase == nil
     }
 
     var currentNegotiator: NegotiatorV3? {
-        guard let key = currentNegotiatorKey else {
-            return nil
-        }
-        return negotiators[key]
+        activeContext?.currentNegotiator
     }
 
     var currentDataChannel: DataChannel? {
-        guard let key = currentDataChannelKey else {
-            return nil
-        }
-        return dataChannels[key]
+        activeContext?.currentDataChannel
     }
 
-    func newNegotiator(on link: LinkInterface) throws -> NegotiatorV3 {
+    func newNegotiator(on looper: FdLooper, linkMetadata: LinkMetadata) throws -> NegotiatorV3 {
+        guard let activeContext else {
+            throw OpenVPNSessionError.assertion
+        }
         let negOptions = NegotiatorV3.Options(
             configuration: configuration,
             credentials: credentials,
-            withLocalOptions: withLocalOptions,
+            withLocalOptions: activeContext.withLocalOptions,
             sessionOptions: options,
             onConnected: { [weak self] key, dataChannel, pushReply in
                 self?.didNegotiate(
@@ -293,7 +339,9 @@ extension OpenVPNSessionV3 {
                 )
             },
             onError: { [weak self] _, error in
-                await self?.shutdown(error)
+                Task {
+                    await self?.shutdown(error)
+                }
             }
         )
         let tlsParameters = TLSWrapper.Parameters(
@@ -308,7 +356,8 @@ extension OpenVPNSessionV3 {
         let tls = try tlsFactory(tlsParameters)
         return NegotiatorV3(
             ctx,
-            link: link,
+            looper: looper,
+            linkMetadata: linkMetadata,
             channel: controlChannel,
             prng: prng,
             tls: tls,
@@ -318,10 +367,12 @@ extension OpenVPNSessionV3 {
     }
 
     func addNegotiator(_ negotiator: NegotiatorV3) {
-        pp_log(ctx, .openvpn, .info, "Replace negotiator with key \(negotiator.key)")
-        negotiators[negotiator.key] = negotiator
-        pp_log(ctx, .openvpn, .info, "Negotiators: \(negotiators.keys)")
-        currentNegotiatorKey = negotiator.key
+        withActiveContext { context in
+            pp_log(ctx, .openvpn, .info, "Replace negotiator with key \(negotiator.key)")
+            context.negotiators[negotiator.key] = negotiator
+            pp_log(ctx, .openvpn, .info, "Negotiators: \(context.negotiators.keys)")
+            context.currentNegotiatorKey = negotiator.key
+        }
     }
 
     func didNegotiate(
@@ -329,78 +380,80 @@ extension OpenVPNSessionV3 {
         dataChannel: DataChannel,
         pushReply: PushReply
     ) {
-        pp_log(ctx, .openvpn, .info, "Negotiation succeeded, set key \(key) as current")
+        let didStart = withActiveContext { phase, context -> (LinkMetadata, OpenVPN.Configuration)? in
+            pp_log(ctx, .openvpn, .info, "Negotiation succeeded, set key \(key) as current")
 
-        self.pushReply = pushReply
+            context.pushReply = pushReply
 
-        // replace current channel with new
-        pp_log(ctx, .openvpn, .info, "Replace key \(dataChannel.key) with new data channel")
-        dataChannels[dataChannel.key] = dataChannel
-        if let currentDataChannel {
-            oldKeys.append(currentDataChannel.key)
-        }
-        currentDataChannelKey = key
+            // Replace current channel with new
+            pp_log(ctx, .openvpn, .info, "Replace key \(dataChannel.key) with new data channel")
+            context.dataChannels[dataChannel.key] = dataChannel
+            if let currentDataChannel = context.currentDataChannel {
+                context.oldKeys.append(currentDataChannel.key)
+            }
+            context.currentDataChannelKey = key
 
-        // clean up old keys
-        while oldKeys.count > 1 {
-            let keyToRemove = oldKeys.removeFirst()
-            pp_log(ctx, .openvpn, .info, "Remove key \(keyToRemove) from negotiators and data channels")
-            negotiators.removeValue(forKey: keyToRemove)
-            dataChannels.removeValue(forKey: keyToRemove)
-        }
-        pp_log(ctx, .openvpn, .info, "Negotiators: \(negotiators.keys)")
-        pp_log(ctx, .openvpn, .info, "Data channels: \(dataChannels.keys)")
+            // Clean up old keys
+            while context.oldKeys.count > 1 {
+                let keyToRemove = context.oldKeys.removeFirst()
+                pp_log(ctx, .openvpn, .info, "Remove key \(keyToRemove) from negotiators and data channels")
+                context.negotiators.removeValue(forKey: keyToRemove)
+                context.dataChannels.removeValue(forKey: keyToRemove)
+            }
+            pp_log(ctx, .openvpn, .info, "Negotiators: \(context.negotiators.keys)")
+            pp_log(ctx, .openvpn, .info, "Data channels: \(context.dataChannels.keys)")
 
-        // renegotiation stops here
-        guard sessionState != .started else {
+            // Renegotiation stops here
+            guard phase != .started else {
+                return nil
+            }
+
+            phase = .started
+            scheduleNextPing(in: &context)
+            return (context.linkMetadata, pushReply.options)
+        } ?? nil
+        guard let (linkMetadata, pushReplyOptions) = didStart else {
             return
         }
-
-        sessionState = .started
-        let pushReplyOptions = pushReply.options
-        Task { [weak self] in
-            guard let self else { return }
-            guard let remoteAddress = link?.remoteAddress,
-                  let remoteProtocol = link?.remoteProtocol else {
-                pp_log(ctx, .openvpn, .fault, "Unable to resolve link remote address/protocol")
-                await shutdown(OpenVPNSessionError.assertion)
-                return
-            }
-            await delegate?.sessionDidStart(
-                self,
-                remoteAddress: remoteAddress,
-                remoteProtocol: remoteProtocol,
-                remoteOptions: pushReplyOptions,
-                remoteFd: link?.fileDescriptor
-            )
-        }
-        scheduleNextPing()
+        delegate?.sessionDidStart(
+            self,
+            remoteAddress: linkMetadata.remoteAddress,
+            remoteProtocol: linkMetadata.remoteProtocol,
+            remoteOptions: pushReplyOptions,
+            remoteFd: linkMetadata.fileDescriptor
+        )
     }
 
     func hasDataChannel(for key: UInt8) -> Bool {
-        dataChannels[key] != nil
+        activeContext?.dataChannels[key] != nil
     }
 
     func dataChannel(for key: UInt8) -> DataChannel? {
-        dataChannels[key]
+        activeContext?.dataChannels[key]
     }
 
     func reportLastReceivedDate() {
-        lastReceivedDate = Date()
+        withActiveContext { context in
+            context.lastReceivedDate = Date()
+        }
     }
 
     func reportInboundDataCount(_ count: Int) {
-        dataCount.inbound += count
-        delegateCurrentDataCount()
+        withActiveContext { context in
+            context.dataCount.inbound += count
+            delegateCurrentDataCount(in: &context)
+        }
     }
 
     func reportOutboundDataCount(_ count: Int) {
-        dataCount.outbound += count
-        delegateCurrentDataCount()
+        withActiveContext { context in
+            context.dataCount.outbound += count
+            delegateCurrentDataCount(in: &context)
+        }
     }
 
     func checkPingTimeout() throws {
-        if let lastReceivedDate {
+        if let lastReceivedDate = activeContext?.lastReceivedDate {
             guard -lastReceivedDate.timeIntervalSinceNow <= keepAliveTimeout else {
                 throw OpenVPNSessionError.pingTimeout
             }
@@ -412,27 +465,36 @@ extension OpenVPNSessionV3 {
 
 private extension OpenVPNSessionV3 {
     func scheduleNextPing() {
-        let interval = keepAliveInterval ?? options.pingTimeoutCheckInterval
+        withActiveContext { context in
+            scheduleNextPing(in: &context)
+        }
+    }
+
+    func scheduleNextPing(in context: inout ActiveContext) {
+        let interval = keepAliveInterval(in: context) ?? options.pingTimeoutCheckInterval
         pp_log(ctx, .openvpn, .debug, "Schedule ping check after \(interval.asTimeString)")
 
-        pendingPingTask?.cancel()
-        pendingPingTask = Task { [weak self] in
+        context.pendingPingTask?.cancel()
+        context.pendingPingTask = Task { [weak self] in
             do {
                 try await Task.sleep(interval: interval)
                 guard !Task.isCancelled else { return }
-                try await self?.ping()
+                guard let self else { return }
+                try await looper.perform {
+                    try self.ping()
+                }
             } catch {
                 await self?.shutdown(error)
             }
         }
     }
 
-    func ping() async throws {
+    func ping() throws {
         guard !isStopped else {
             pp_log(ctx, .openvpn, .debug, "Ping cancelled, session stopped")
             return
         }
-        guard let link else {
+        guard looper.isLinkAttached else {
             pp_log(ctx, .openvpn, .debug, "Ping cancelled, no link")
             return
         }
@@ -444,23 +506,27 @@ private extension OpenVPNSessionV3 {
         pp_log(ctx, .openvpn, .debug, "Run ping check")
         try checkPingTimeout()
 
-        // is keep-alive enabled?
+        // Is keep-alive enabled?
         if keepAliveInterval != nil {
             pp_log(ctx, .openvpn, .debug, "Send ping")
-            try await sendDataPackets(
+            try sendDataPackets(
                 [Constants.DataChannel.pingString],
-                to: link,
+                to: looper,
                 dataChannel: currentDataChannel
             )
         }
 
-        // schedule even just to check for ping timeout
+        // Schedule even just to check for ping timeout
         scheduleNextPing()
     }
 
     var keepAliveInterval: TimeInterval? {
+        keepAliveInterval(in: activeContext)
+    }
+
+    func keepAliveInterval(in context: ActiveContext?) -> TimeInterval? {
         let interval: TimeInterval?
-        if let negInterval = pushReply?.options.keepAliveInterval, negInterval > 0.0 {
+        if let negInterval = context?.pushReply?.options.keepAliveInterval, negInterval > 0.0 {
             interval = negInterval
         } else if let cfgInterval = configuration.keepAliveInterval, cfgInterval > 0.0 {
             interval = cfgInterval
@@ -471,7 +537,7 @@ private extension OpenVPNSessionV3 {
     }
 
     var keepAliveTimeout: TimeInterval {
-        if let negTimeout = pushReply?.options.keepAliveTimeout, negTimeout > 0.0 {
+        if let negTimeout = activeContext?.pushReply?.options.keepAliveTimeout, negTimeout > 0.0 {
             return negTimeout
         } else if let cfgTimeout = configuration.keepAliveTimeout, cfgTimeout > 0.0 {
             return cfgTimeout
@@ -480,18 +546,15 @@ private extension OpenVPNSessionV3 {
         }
     }
 
-    func delegateCurrentDataCount() {
-        if let lastDataCountDate {
+    func delegateCurrentDataCount(in context: inout ActiveContext) {
+        if let lastDataCountDate = context.lastDataCountDate {
             guard -lastDataCountDate.timeIntervalSinceNow >= options.minDataCountInterval else {
                 return
             }
         }
-        lastDataCountDate = Date()
-        let currentDataCount = DataCount(UInt64(dataCount.inbound), UInt64(dataCount.outbound))
-        Task { [weak self] in
-            guard let self else { return }
-            await delegate?.session(self, didUpdateDataCount: currentDataCount)
-        }
+        context.lastDataCountDate = Date()
+        let currentDataCount = DataCount(UInt64(context.dataCount.inbound), UInt64(context.dataCount.outbound))
+        delegate?.session(self, didUpdateDataCount: currentDataCount)
     }
 }
 
@@ -500,12 +563,12 @@ private extension OpenVPNSessionV3 {
         _ ctx: PartoutLoggerContext,
         with prng: PRNGProtocol,
         configuration: OpenVPN.Configuration
-    ) throws -> ControlChannel {
-        let channel: ControlChannel
+    ) throws -> ControlChannelV3 {
+        let channel: ControlChannelV3
         if let tlsWrap = configuration.tlsWrap {
             switch tlsWrap.strategy {
             case .auth:
-                channel = try ControlChannel(
+                channel = try ControlChannelV3(
                     ctx,
                     prng: prng,
                     authKey: tlsWrap.key,
@@ -513,7 +576,7 @@ private extension OpenVPNSessionV3 {
                 )
 
             case .crypt:
-                channel = try ControlChannel(
+                channel = try ControlChannelV3(
                     ctx,
                     prng: prng,
                     cryptKey: tlsWrap.key
@@ -523,7 +586,7 @@ private extension OpenVPNSessionV3 {
                 guard let wrappedKey = tlsWrap.wrappedKey else {
                     throw OpenVPNSessionError.assertion
                 }
-                channel = try ControlChannel(
+                channel = try ControlChannelV3(
                     ctx,
                     prng: prng,
                     cryptV2Key: tlsWrap.key,
@@ -531,10 +594,10 @@ private extension OpenVPNSessionV3 {
                 )
 
             @unknown default:
-                channel = ControlChannel(ctx, prng: prng)
+                channel = ControlChannelV3(ctx, prng: prng)
             }
         } else {
-            channel = ControlChannel(ctx, prng: prng)
+            channel = ControlChannelV3(ctx, prng: prng)
         }
         return channel
     }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -107,8 +107,15 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             original: link,
             beforeRead: rw.beforeRead,
             onRead: { [weak self] packets in
-                try self?.receiveLink(packets)
-                return .keep
+                do {
+                    try self?.receiveLink(packets)
+                    return .keep
+                } catch {
+                    Task {
+                        await self?.shutdown(error)
+                    }
+                    return .pause
+                }
             },
             transformWrite: rw.beforeWrite
         ))
@@ -132,8 +139,15 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             original: tunnel,
             beforeRead: nil,
             onRead: { [weak self] packets in
-                try self?.receiveTunnel(packets)
-                return .keep
+                do {
+                    try self?.receiveTunnel(packets)
+                    return .keep
+                } catch {
+                    Task {
+                        await self?.shutdown(error)
+                    }
+                    return .pause
+                }
             },
             transformWrite: nil
         ))

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -76,7 +76,7 @@ final class OpenVPNSessionV3: @unchecked Sendable {
 
         looper = try FdLooper(ctx, queue: queue) { [weak self] error in
             pp_log(self?.ctx ?? .global, .openvpn, .error, "Session looper finished with error: \(error?.localizedDescription ?? "none")")
-            self?.looperDidFinish(error)
+            self?.looperDidFinishOnQueue(error)
         }
         looper.start()
     }
@@ -161,6 +161,8 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         }
     }
 }
+
+// MARK: Performed on queue
 
 private extension OpenVPNSessionV3 {
     func setLinkOnQueue(_ link: LinkInterface) throws {
@@ -256,13 +258,11 @@ private extension OpenVPNSessionV3 {
         )
     }
 
-    func looperDidFinish(_ error: Error?) {
+    func looperDidFinishOnQueue(_ error: Error?) {
         preconditionOnQueue()
         finishShutdownOnQueue(error)
     }
-}
 
-private extension OpenVPNSessionV3 {
     func sendExitPacketOnQueue() throws {
         preconditionOnQueue()
         try withActiveContext { context in

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -14,7 +14,7 @@ final class OpenVPNSessionV3: @unchecked Sendable {
     private let dpFactory: DataPathFactory
     private let queue: DispatchQueue
     private let queueKey: DispatchSpecificKey<Void>
-    // FIXME: ###, Workaround for self in init closures
+    // XXX: Workaround for self in init closures
     var looper: FdLooper!
     private weak var delegate: OpenVPNSessionDelegateV3?
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -105,19 +105,17 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         try await looper.attach(.init(
             side: .link,
             original: link,
-            beforeRead: rw.beforeRead,
+            transformWrite: rw.beforeWrite,
             onRead: { [weak self] packets in
-                do {
-                    try self?.receiveLink(packets)
-                    return .keep
-                } catch {
-                    Task {
-                        await self?.shutdown(error)
-                    }
-                    return .pause
-                }
+                let processed = try rw.beforeRead(packets)
+                try self?.receiveLink(processed)
+                return .keep
             },
-            transformWrite: rw.beforeWrite
+            onFailure: { [weak self] error in
+                Task {
+                    await self?.shutdown(error)
+                }
+            }
         ))
         try looper.schedule { [weak self] in
             try self?.setLinkOnQueue(link)
@@ -137,19 +135,16 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         try await looper.attach(.init(
             side: .tun,
             original: tunnel,
-            beforeRead: nil,
+            transformWrite: nil,
             onRead: { [weak self] packets in
-                do {
-                    try self?.receiveTunnel(packets)
-                    return .keep
-                } catch {
-                    Task {
-                        await self?.shutdown(error)
-                    }
-                    return .pause
-                }
+                try self?.receiveTunnel(packets)
+                return .keep
             },
-            transformWrite: nil
+            onFailure: { [weak self] error in
+                Task {
+                    await self?.shutdown(error)
+                }
+            }
         ))
     }
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -513,14 +513,12 @@ private extension OpenVPNSessionV3 {
                     authKey: tlsWrap.key,
                     digest: configuration.fallbackDigest
                 )
-
             case .crypt:
                 channel = try ControlChannelV3(
                     ctx,
                     prng: prng,
                     cryptKey: tlsWrap.key
                 )
-
             case .cryptV2:
                 guard let wrappedKey = tlsWrap.wrappedKey else {
                     throw OpenVPNSessionError.assertion
@@ -531,7 +529,6 @@ private extension OpenVPNSessionV3 {
                     cryptV2Key: tlsWrap.key,
                     wrappedKey: wrappedKey
                 )
-
             @unknown default:
                 channel = ControlChannelV3(ctx, prng: prng)
             }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -109,23 +109,33 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         }
         let proc = PacketProcessor(method: configuration.xorMethod)
         let rw = LinkProcessor(proc: proc, isTCP: link.isReliable)
-        try await looper.attach(.init(
-            side: .link,
-            original: link,
-            transformWrite: rw.beforeWrite,
-            onRead: { [weak self] packets in
-                let processed = try rw.beforeRead(packets)
-                try self?.receiveLink(processed)
-                return .keep
-            },
-            onFailure: { [weak self] error in
-                Task {
-                    await self?.shutdown(error)
+
+        var didAttach = false
+        do {
+            try await looper.attach(.init(
+                side: .link,
+                original: link,
+                transformWrite: rw.beforeWrite,
+                onRead: { [weak self] packets in
+                    let processed = try rw.beforeRead(packets)
+                    try self?.receiveLink(processed)
+                    return .keep
+                },
+                onFailure: { [weak self] error in
+                    Task {
+                        await self?.shutdown(error)
+                    }
                 }
+            ))
+            didAttach = true
+            try await looper.perform { [weak self] in
+                try self?.setLinkOnQueue(link)
             }
-        ))
-        try looper.schedule { [weak self] in
-            try self?.setLinkOnQueue(link)
+        } catch {
+            if didAttach {
+                await looper.detach(.link)
+            }
+            throw error
         }
     }
 

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -149,7 +149,7 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             return
         }
         let proc = PacketProcessor(method: configuration.xorMethod)
-        let rw = LinkProcessor(proc: proc, isReliable: link.isReliable)
+        let rw = LinkProcessor(proc: proc, isTCP: link.isReliable)
         try await looper.attach(.init(
             side: .link,
             original: link,

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -67,22 +67,10 @@ final class OpenVPNSessionV3: @unchecked Sendable {
         )
         sessionState = .stopped(IdleContext(withLocalOptions: true))
 
-        looper = try FdLooper(ctx, queue: queue, delegate: FdLooperDelegate(
-            onRead: { [weak self] packets, side in
-                switch side {
-                case .link:
-                    try self?.receiveLink(packets)
-                case .tun:
-                    try self?.receiveTunnel(packets)
-                }
-                return .keep
-            },
-            onWrite: nil,
-            onFinish: { [weak self] error in
-                pp_log(self?.ctx ?? .global, .openvpn, .error, "Session looper finished with error: \(error?.localizedDescription ?? "none")")
-                self?.looperDidFinish(error)
-            }
-        ))
+        looper = try FdLooper(ctx, queue: queue) { [weak self] error in
+            pp_log(self?.ctx ?? .global, .openvpn, .error, "Session looper finished with error: \(error?.localizedDescription ?? "none")")
+            self?.looperDidFinish(error)
+        }
         looper.start()
     }
 
@@ -160,7 +148,41 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             pp_log(ctx, .openvpn, .error, "Link interface already set")
             return
         }
-        try await looper.attachLink(link)
+        let proc = PacketProcessor(method: configuration.xorMethod)
+        var buffer = Data()
+        try await looper.attach(.init(
+            side: .link,
+            original: link,
+            beforeRead: { prePackets in
+                // FIXME: ###
+                if link.metadata.isReliable {
+                    // FIXME: #214, TCP is very slow
+                    buffer.reserveCapacity(buffer.count + prePackets.flatCount)
+                    for p in prePackets {
+                        buffer.append(p)
+                    }
+                    var until = 0
+                    let processedPackets = proc.packets(fromStream: buffer, until: &until)
+                    buffer = buffer.subdata(in: until..<buffer.count)
+                    return processedPackets
+                } else {
+                    return proc.processPackets(prePackets, direction: .inbound)
+                }
+            },
+            beforeWrite: { packets in
+                if link.metadata.isReliable {
+                    let stream = proc.stream(fromPackets: packets)
+                    guard !stream.isEmpty else { return [] }
+                    return [stream]
+                } else {
+                    return proc.processPackets(packets, direction: .outbound)
+                }
+            },
+            onRead: { [weak self] packets in
+                try self?.receiveLink(packets)
+                return .keep
+            }
+        ))
         try looper.schedule { [weak self] in
             try self?.setLinkOnQueue(link)
         }
@@ -176,7 +198,16 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             return
         }
         pp_log(ctx, .openvpn, .info, "Start TUN loop")
-        try await looper.attachTun(tunnel)
+        try await looper.attach(.init(
+            side: .tun,
+            original: tunnel,
+            beforeRead: nil,
+            beforeWrite: nil,
+            onRead: { [weak self] packets in
+                try self?.receiveTunnel(packets)
+                return .keep
+            }
+        ))
     }
 
     func hasLink() -> Bool {
@@ -191,8 +222,8 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             guard shouldDetach else {
                 return
             }
-            await looper.detachTun()
-            await looper.detachLink()
+            await looper.detach(.tun)
+            await looper.detach(.link)
             try await looper.perform { [weak self] in
                 self?.finishShutdownOnQueue(error)
             }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -76,7 +76,7 @@ final class OpenVPNSessionV3: @unchecked Sendable {
 
         looper = try FdLooper(ctx, queue: queue) { [weak self] error in
             pp_log(self?.ctx ?? .global, .openvpn, .error, "Session looper finished with error: \(error?.localizedDescription ?? "none")")
-            self?.looperDidFinishOnQueue(error)
+            self?.finishShutdownOnQueue(error)
         }
         looper.start()
     }
@@ -265,11 +265,6 @@ private extension OpenVPNSessionV3 {
             self,
             withError: error.map(OpenVPNSessionError.init) ?? error
         )
-    }
-
-    func looperDidFinishOnQueue(_ error: Error?) {
-        preconditionOnQueue()
-        finishShutdownOnQueue(error)
     }
 
     func sendExitPacketOnQueue() throws {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -169,10 +169,10 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         looper.isLinkAttached
     }
 
-    func shutdown(_ error: Error?, timeout: TimeInterval?) async {
+    func shutdown(_ error: Error?) async {
         do {
             let shouldDetach = try await looper.perform { [weak self] in
-                self?.prepareShutdownOnQueue(error, timeout: timeout) ?? false
+                self?.prepareShutdownOnQueue(error) ?? false
             }
             guard shouldDetach else {
                 return
@@ -228,7 +228,7 @@ private extension OpenVPNSessionV3 {
         }
     }
 
-    func prepareShutdownOnQueue(_ error: Error?, timeout: TimeInterval?) -> Bool {
+    func prepareShutdownOnQueue(_ error: Error?) -> Bool {
         preconditionOnQueue()
         guard activePhase != .stopping, activePhase != nil else {
             pp_log(ctx, .openvpn, .debug, "Ignore stop request, stopped or already stopping")

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -291,7 +291,7 @@ private extension OpenVPNSessionV3 {
                 return
             }
             pp_log(ctx, .openvpn, .info, "Send OCCPacket exit")
-            try dataPair.send([OCCPacket.exit.serialized()])
+            try dataPair.send([OCCPacket.exit.serialized()], outOfBand: true)
             pp_log(ctx, .openvpn, .info, "Sent OCCPacket correctly")
         }
     }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -174,7 +174,7 @@ private extension OpenVPNSessionV3 {
             ctx: ctx,
             looper: looper,
             dataChannel: { [weak self] in
-                self?.activeContext?.dataChannels[$0]
+                self?.activeContext?.dataChannel(forKey: $0)
             },
             reportInboundDataCount: { [weak self] in
                 self?.reportInboundDataCount($0)
@@ -337,10 +337,7 @@ extension OpenVPNSessionV3 {
 
     func addNegotiator(_ negotiator: NegotiatorV3) {
         withActiveContext { context in
-            pp_log(ctx, .openvpn, .info, "Replace negotiator with key \(negotiator.key)")
-            context.negotiators[negotiator.key] = negotiator
-            pp_log(ctx, .openvpn, .info, "Negotiators: \(context.negotiators.keys)")
-            context.currentNegotiatorKey = negotiator.key
+            context.addNegotiator(negotiator)
         }
     }
 
@@ -351,22 +348,16 @@ extension OpenVPNSessionV3 {
     ) {
         let didStart = withActiveContext { phase, context -> (LinkMetadata, OpenVPN.Configuration)? in
             pp_log(ctx, .openvpn, .info, "Negotiation succeeded, set key \(key) as current")
-
             context.pushReply = pushReply
 
             // Replace current channel with new
             pp_log(ctx, .openvpn, .info, "Replace key \(dataChannel.key) with new data channel")
             context.setDataChannel(dataChannel, forKey: key)
 
-            // Clean up old keys
-            while context.oldKeys.count > 1 {
-                let keyToRemove = context.oldKeys.removeFirst()
-                pp_log(ctx, .openvpn, .info, "Remove key \(keyToRemove) from negotiators and data channels")
-                context.negotiators.removeValue(forKey: keyToRemove)
-                context.dataChannels.removeValue(forKey: keyToRemove)
-            }
-            pp_log(ctx, .openvpn, .info, "Negotiators: \(context.negotiators.keys)")
-            pp_log(ctx, .openvpn, .info, "Data channels: \(context.dataChannels.keys)")
+            // Clean up old negotiator
+            context.removeOldNegotiators()
+            pp_log(ctx, .openvpn, .info, "Negotiators: \(context.allNegotiatorKeys)")
+            pp_log(ctx, .openvpn, .info, "Data channels: \(context.allDataKeys)")
 
             // Renegotiation stops here
             guard phase != .started else {
@@ -387,14 +378,6 @@ extension OpenVPNSessionV3 {
             remoteOptions: pushReplyOptions,
             remoteFd: linkMetadata.fileDescriptor
         )
-    }
-
-    func hasDataChannel(for key: UInt8) -> Bool {
-        activeContext?.dataChannels[key] != nil
-    }
-
-    func dataChannel(for key: UInt8) -> DataChannel? {
-        activeContext?.dataChannels[key]
     }
 
     func reportLastReceivedDate() {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -14,9 +14,16 @@ final class OpenVPNSessionV3: @unchecked Sendable {
     private let dpFactory: DataPathFactory
     private let queue: DispatchQueue
     private let queueKey: DispatchSpecificKey<Void>
-    // XXX: Workaround for self in init closures
-    var looper: FdLooper!
     private weak var delegate: OpenVPNSessionDelegateV3?
+
+    // XXX: Workaround for self in init closures
+    private var unsafeLooper: FdLooper?
+    var looper: FdLooper {
+        guard let unsafeLooper else {
+            fatalError("Uninitialized looper")
+        }
+        return unsafeLooper
+    }
 
     // MARK: Mutable state
 
@@ -74,7 +81,7 @@ final class OpenVPNSessionV3: @unchecked Sendable {
         )
         sessionState = .stopped(IdleContext(withLocalOptions: true))
 
-        looper = try FdLooper(ctx, queue: queue) { [weak self] error in
+        unsafeLooper = try FdLooper(ctx, queue: queue) { [weak self] error in
             pp_log(self?.ctx ?? .global, .openvpn, .error, "Session looper finished with error: \(error?.localizedDescription ?? "none")")
             self?.finishShutdownOnQueue(error)
         }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -77,6 +77,7 @@ final class OpenVPNSessionV3: @unchecked Sendable {
                 }
                 return .keep
             },
+            onWrite: nil,
             onFinish: { [weak self] error in
                 pp_log(self?.ctx ?? .global, .openvpn, .error, "Session looper finished with error: \(error?.localizedDescription ?? "none")")
                 self?.looperDidFinish(error)
@@ -302,7 +303,7 @@ private extension OpenVPNSessionV3 {
         }
 
         pp_log(ctx, .openvpn, .info, "Send OCCPacket exit")
-        looper.write(packets, to: .link)
+        try looper.write(packets, to: .link)
         pp_log(ctx, .openvpn, .info, "Sent OCCPacket correctly")
     }
 }

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -247,7 +247,7 @@ private extension OpenVPNSessionV3 {
         // Shut down after sending exit notification if link is unreliable (normally UDP)
         if error == nil || error?.partoutErrorCode == .networkChanged {
             do {
-                try sendExitPacketOnQueue()
+                try sendExitPacketOnQueue(timeout: timeout ?? options.writeTimeout)
             } catch {
                 pp_log(ctx, .openvpn, .error, "Unable to send exit packet: \(error)")
             }
@@ -284,14 +284,14 @@ private extension OpenVPNSessionV3 {
         )
     }
 
-    func sendExitPacketOnQueue() throws {
+    func sendExitPacketOnQueue(timeout: TimeInterval) throws {
         preconditionOnQueue()
         try withActiveContext { context in
             guard !context.linkMetadata.isReliable, let dataPair = context.currentDataPair else {
                 return
             }
             pp_log(ctx, .openvpn, .info, "Send OCCPacket exit")
-            try dataPair.send([OCCPacket.exit.serialized()], outOfBand: true)
+            try dataPair.send([OCCPacket.exit.serialized()], timeout: timeout)
             pp_log(ctx, .openvpn, .info, "Sent OCCPacket correctly")
         }
     }

--- a/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3+Default.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3+Default.swift
@@ -13,7 +13,7 @@ extension _OpenVPNConnectionV3 {
         guard let configuration = module.configuration else {
             fatalError("Creating session without OpenVPN configuration?")
         }
-        pp_log(ctx, .openvpn, .notice, "OpenVPN: Using v2 connection")
+        pp_log(ctx, .openvpn, .notice, "OpenVPN: Using v3 connection")
 
         // Hardcode portable implementations
         let prng = PlatformPRNG()
@@ -21,7 +21,7 @@ extension _OpenVPNConnectionV3 {
             POSIXDNSStrategy(hostname: $0, flags: $1)
         }
         let sessionFactory = {
-            try await OpenVPNSessionV3(
+            try OpenVPNSessionV3(
                 ctx,
                 configuration: configuration,
                 credentials: module.credentials,

--- a/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
@@ -456,7 +456,7 @@ private extension _OpenVPNConnectionV3 {
             pp_log(ctx, .openvpn, .fault, "Unable to create link: \(error)")
 
             // reset endpoints on exhaustion
-            if (error as? PartoutError)?.code == .exhaustedEndpoints {
+            if error.partoutErrorCode == .exhaustedEndpoints {
                 endpointResolver = EndpointResolver(ctx, endpoints: endpoints)
             }
 

--- a/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
@@ -136,7 +136,7 @@ extension _OpenVPNConnectionV3: Connection {
         sendStatus(.disconnecting)
 
         // Stop the OpenVPN connection on user request
-        await currentSession.shutdown(nil, timeout: TimeInterval(timeout) / 1000.0)
+        await currentSession.shutdown(nil)
 
         // XXX: Poll session status until link clean-up
         // In the future, make OpenVPNSession.shutdown() wait for stop async-ly

--- a/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
@@ -260,8 +260,8 @@ private extension _OpenVPNConnectionV3 {
                         requiresVirtualDevice: true
                     )
                 )
-                try await session.setTunnel(tunnelInterface)
                 self.tunnelInterface = tunnelInterface
+                try await session.setTunnel(tunnelInterface)
 
                 // In this suspended interval, sessionDidStop may have been called and
                 // the status may have changed to .disconnected in the meantime

--- a/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
@@ -405,17 +405,6 @@ private extension _OpenVPNConnectionV3 {
     }
 }
 
-private extension LinkInterface {
-    func openVPNLink(method: OpenVPN.ObfuscationMethod?) -> LinkInterface {
-        switch linkType.plainType {
-        case .udp:
-            return OpenVPNUDPLink(link: self, method: method)
-        case .tcp:
-            return OpenVPNTCPLink(link: self, method: method)
-        }
-    }
-}
-
 // MARK: - Helpers
 
 private extension _OpenVPNConnectionV3 {
@@ -444,11 +433,7 @@ private extension _OpenVPNConnectionV3 {
 
                 pp_log(ctx, .openvpn, .notice, "Link is active")
                 pp_log(ctx, .openvpn, .info, "Link type is \(newLink.linkDescription)")
-                // Wrap new link into a specific OpenVPN link
-                newLink = newLink.openVPNLink(method: configuration.xorMethod)
             }
-
-            pp_log(ctx, .openvpn, .info, "Processed link type is \(newLink.linkDescription)")
 
             currentLink = newLink
             return newLink

--- a/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
@@ -136,7 +136,7 @@ extension _OpenVPNConnectionV3: Connection {
         sendStatus(.disconnecting)
 
         // Stop the OpenVPN connection on user request
-        await currentSession.shutdown(nil)
+        await currentSession.shutdown(nil, timeout: TimeInterval(timeout) / 1000.0)
 
         // XXX: Poll session status until link clean-up
         // In the future, make OpenVPNSession.shutdown() wait for stop async-ly

--- a/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/_OpenVPNConnectionV3.swift
@@ -12,6 +12,8 @@ public actor _OpenVPNConnectionV3 {
 
     private let statusSubject: CurrentValueStream<ConnectionStatus>
 
+    private let delegateSubject: PassthroughStream<DelegateEvent>
+
     private let moduleId: UniqueID
 
     private let controller: TunnelController
@@ -26,11 +28,13 @@ public actor _OpenVPNConnectionV3 {
 
     private let configuration: OpenVPN.Configuration
 
-    private let sessionFactory: () async throws -> OpenVPNSessionProtocolV3
+    private let sessionFactory: () throws -> OpenVPNSessionProtocolV3
 
     private let dns: DNSResolver
 
     // MARK: State
+
+    private var delegateTask: Task<Void, Never>?
 
     private var currentSession: OpenVPNSessionProtocolV3?
 
@@ -48,10 +52,11 @@ public actor _OpenVPNConnectionV3 {
         module: OpenVPNModule,
         prng: PRNGProtocol,
         dns: DNSResolver,
-        sessionFactory: @escaping () async throws -> OpenVPNSessionProtocolV3
+        sessionFactory: @escaping () throws -> OpenVPNSessionProtocolV3
     ) throws {
         self.ctx = ctx
         statusSubject = CurrentValueStream(.disconnected)
+        delegateSubject = PassthroughStream()
         moduleId = module.id
         controller = parameters.controller
         reporter = parameters.reporter
@@ -74,7 +79,7 @@ public actor _OpenVPNConnectionV3 {
     }
 
     deinit {
-        pp_log(ctx, .openvpn, .debug, "Deinit _OpenVPNConnectionV2")
+        pp_log(ctx, .openvpn, .debug, "Deinit _OpenVPNConnectionV3")
     }
 }
 
@@ -89,14 +94,15 @@ extension _OpenVPNConnectionV3: Connection {
     public func start() async throws -> Bool {
         do {
             if currentSession == nil {
-                currentSession = try await sessionFactory()
+                currentSession = try sessionFactory()
             }
             guard let session = currentSession else {
                 fatalError("No session from factory?")
             }
-            await session.setDelegate(self)
+            subscribeToDelegate()
+            session.setDelegate(self)
             guard status == .disconnected else {
-                pp_log(ctx, .core, .error, "Ignore start, connection status \(status) != .disconnected")
+                pp_log(ctx, .openvpn, .error, "Ignore start, connection status \(status) != .disconnected")
                 return false
             }
             sendStatus(.connecting)
@@ -124,7 +130,7 @@ extension _OpenVPNConnectionV3: Connection {
     public func stop(timeout: Int) async {
         guard let currentSession else { return }
         guard status != .disconnected else {
-            pp_log(ctx, .core, .error, "Ignore stop, connection not started")
+            pp_log(ctx, .openvpn, .error, "Ignore stop, connection not started")
             return
         }
         sendStatus(.disconnecting)
@@ -136,7 +142,7 @@ extension _OpenVPNConnectionV3: Connection {
         // In the future, make OpenVPNSession.shutdown() wait for stop async-ly
         let delta = 500
         var remaining = timeout
-        while remaining > 0, await currentSession.hasLink() {
+        while remaining > 0, currentSession.hasLink() {
             pp_log(ctx, .openvpn, .notice, "Link active, wait \(delta) milliseconds more")
             try? await Task.sleep(milliseconds: delta)
             remaining = max(0, remaining - delta)
@@ -154,104 +160,163 @@ extension _OpenVPNConnectionV3: Connection {
 // MARK: - OpenVPNSessionDelegate
 
 extension _OpenVPNConnectionV3: OpenVPNSessionDelegateV3 {
-    func sessionDidStart(
+    nonisolated func sessionDidStart(
         _ session: OpenVPNSessionProtocolV3,
         remoteAddress: String,
         remoteProtocol: EndpointProtocol,
         remoteOptions: OpenVPN.Configuration,
         remoteFd: UInt64?
-    ) async {
-        let addressObject = Address(rawValue: remoteAddress)
-        if addressObject == nil {
-            pp_log(ctx, .openvpn, .error, "Unable to parse remote tunnel address")
-        }
+    ) {
+        delegateSubject.send(.didStart(
+            session,
+            remoteAddress: remoteAddress,
+            remoteProtocol: remoteProtocol,
+            remoteOptions: remoteOptions,
+            remoteFd: remoteFd
+        ))
+    }
 
-        pp_log(ctx, .openvpn, .notice, "Session did start")
-        pp_log(ctx, .openvpn, .info, "\tAddress: \(remoteAddress.asSensitiveAddress(ctx))")
-        pp_log(ctx, .openvpn, .info, "\tProtocol: \(remoteProtocol)")
+    nonisolated func sessionDidStop(_ session: OpenVPNSessionProtocolV3, withError error: Error?) {
+        delegateSubject.send(.didStop(
+            session,
+            error: error
+        ))
+    }
 
-        pp_log(ctx, .openvpn, .notice, "Local options:")
-        configuration.print(ctx, isLocal: true)
-        pp_log(ctx, .openvpn, .notice, "Remote options:")
-        remoteOptions.print(ctx, isLocal: false)
+    nonisolated func session(_ session: OpenVPNSessionProtocolV3, didUpdateDataCount dataCount: DataCount) {
+        delegateSubject.send(.didUpdateDataCount(
+            session,
+            dataCount: dataCount
+        ))
+    }
+}
 
-        reporter.reportEnvironmentValue(remoteOptions, forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
-
-        let builder = NetworkSettingsBuilder(
-            ctx,
-            localOptions: configuration,
-            remoteOptions: remoteOptions
+private extension _OpenVPNConnectionV3 {
+    enum DelegateEvent: Sendable {
+        case didStart(
+            _ session: OpenVPNSessionProtocolV3,
+            remoteAddress: String,
+            remoteProtocol: EndpointProtocol,
+            remoteOptions: OpenVPN.Configuration,
+            remoteFd: UInt64?
         )
-        builder.print()
-        do {
-            let tunnelInterface = try await controller.setTunnelSettings(
-                with: TunnelRemoteInfo(
-                    originalModuleId: moduleId,
-                    address: addressObject,
-                    modules: builder.modules(),
-                    requiresVirtualDevice: true
-                )
-            )
-            await session.setTunnel(tunnelInterface)
-            self.tunnelInterface = tunnelInterface
+        case didStop(
+            _ session: OpenVPNSessionProtocolV3,
+            error: Error?
+        )
+        case didUpdateDataCount(
+            _ session: OpenVPNSessionProtocolV3,
+            dataCount: DataCount
+        )
+    }
 
-            // In this suspended interval, sessionDidStop may have been called and
-            // the status may have changed to .disconnected in the meantime
-            //
-            // sendStatus() should prevent .connected from happening when in the
-            // .disconnected state, because it must go through .connecting first
-
-            // Signal success and show the "VPN" icon
-            if sendStatus(.connected) {
-                pp_log(ctx, .openvpn, .notice, "Tunnel interface is now UP")
+    func subscribeToDelegate() {
+        guard delegateTask == nil else { return }
+        let stream = delegateSubject.subscribe()
+        delegateTask = Task { [weak self] in
+            for await event in stream {
+                await self?.handleDelegate(event)
             }
-        } catch {
-            pp_log(ctx, .openvpn, .error, "Unable to start tunnel: \(error)")
-            await session.shutdown(error)
         }
     }
 
-    func sessionDidStop(_ session: OpenVPNSessionProtocolV3, withError error: Error?) async {
-        if let error {
-            pp_log(ctx, .openvpn, .error, "Session did stop: \(error)")
-        } else {
-            pp_log(ctx, .openvpn, .notice, "Session did stop")
-        }
+    func handleDelegate(_ event: DelegateEvent) async {
+        switch event {
+        case .didStart(
+            let session,
+            let remoteAddress,
+            let remoteProtocol,
+            let remoteOptions,
+            _ // remoteFd
+        ):
+            let addressObject = Address(rawValue: remoteAddress)
+            if addressObject == nil {
+                pp_log(ctx, .openvpn, .error, "Unable to parse remote tunnel address")
+            }
 
-        // Clean up tunnel
-        if let tunnelInterface {
-            await controller.clearTunnelSettings(tunnelInterface)
-            self.tunnelInterface = nil
-        }
+            pp_log(ctx, .openvpn, .notice, "Session did start")
+            pp_log(ctx, .openvpn, .info, "\tAddress: \(remoteAddress.asSensitiveAddress(ctx))")
+            pp_log(ctx, .openvpn, .info, "\tProtocol: \(remoteProtocol)")
 
-        // If user stopped the tunnel, let it go
-        guard status != .disconnecting else {
-            pp_log(ctx, .openvpn, .info, "User requested disconnection")
-            return
-        }
+            pp_log(ctx, .openvpn, .notice, "Local options:")
+            configuration.print(ctx, isLocal: true)
+            pp_log(ctx, .openvpn, .notice, "Remote options:")
+            remoteOptions.print(ctx, isLocal: false)
 
-        // Store last error
-        if let error {
-            reporter.reportLastError(error)
+            reporter.reportEnvironmentValue(remoteOptions, forKey: TunnelEnvironmentKeys.OpenVPN.serverConfiguration)
 
-            // If error is not recoverable, just fail
-            guard error.isOpenVPNRecoverable else {
-                pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
-                sendError(error)
+            let builder = NetworkSettingsBuilder(
+                ctx,
+                localOptions: configuration,
+                remoteOptions: remoteOptions
+            )
+            builder.print()
+            do {
+                let tunnelInterface = try await controller.setTunnelSettings(
+                    with: TunnelRemoteInfo(
+                        originalModuleId: moduleId,
+                        address: addressObject,
+                        modules: builder.modules(),
+                        requiresVirtualDevice: true
+                    )
+                )
+                try await session.setTunnel(tunnelInterface)
+                self.tunnelInterface = tunnelInterface
+
+                // In this suspended interval, sessionDidStop may have been called and
+                // the status may have changed to .disconnected in the meantime
+                //
+                // sendStatus() should prevent .connected from happening when in the
+                // .disconnected state, because it must go through .connecting first
+
+                // Signal success and show the "VPN" icon
+                if sendStatus(.connected) {
+                    pp_log(ctx, .openvpn, .notice, "Tunnel interface is now UP")
+                }
+            } catch {
+                pp_log(ctx, .openvpn, .error, "Unable to start tunnel: \(error)")
+                await session.shutdown(error)
+            }
+        case .didStop(_, let error):
+            if let error {
+                pp_log(ctx, .openvpn, .error, "Session did stop: \(error)")
+            } else {
+                pp_log(ctx, .openvpn, .notice, "Session did stop")
+            }
+
+            // Clean up tunnel
+            if let tunnelInterface {
+                await controller.clearTunnelSettings(tunnelInterface)
+                self.tunnelInterface = nil
+            }
+
+            // If user stopped the tunnel, let it go
+            guard status != .disconnecting else {
+                pp_log(ctx, .openvpn, .info, "User requested disconnection")
                 return
             }
-        }
 
-        // Go back to the disconnected state (e.g. daemon will reconnect)
-        sendStatus(.disconnected)
-    }
+            // Store last error
+            if let error {
+                reporter.reportLastError(error)
 
-    func session(_ session: OpenVPNSessionProtocolV3, didUpdateDataCount dataCount: DataCount) async {
-        guard status == .connected else {
-            return
+                // If error is not recoverable, just fail
+                guard error.isOpenVPNRecoverable else {
+                    pp_log(ctx, .openvpn, .error, "Disconnection is not recoverable")
+                    sendError(error)
+                    return
+                }
+            }
+
+            // Go back to the disconnected state (e.g. daemon will reconnect)
+            sendStatus(.disconnected)
+        case .didUpdateDataCount(_, let dataCount):
+            guard status == .connected else {
+                return
+            }
+            pp_log(ctx, .openvpn, .debug, "Updated data count: \(dataCount.debugDescription)")
+            reporter.reportDataCount(dataCount)
         }
-        pp_log(ctx, .openvpn, .debug, "Updated data count: \(dataCount.debugDescription)")
-        reporter.reportDataCount(dataCount)
     }
 }
 
@@ -307,17 +372,17 @@ private extension _OpenVPNConnectionV3 {
     @discardableResult
     func sendStatus(_ connectionStatus: ConnectionStatus) -> Bool {
         guard status.canChange(to: connectionStatus) else {
-            pp_log(ctx, .core, .error, "Ignore unexpected status change: \(status) -> \(connectionStatus)")
+            pp_log(ctx, .openvpn, .error, "Ignore unexpected status change: \(status) -> \(connectionStatus)")
             return false
         }
-        pp_log(ctx, .core, .info, "Report link status: \(connectionStatus.debugDescription)")
+        pp_log(ctx, .openvpn, .info, "Report link status: \(connectionStatus.debugDescription)")
         statusSubject.send(connectionStatus)
         onStatus(connectionStatus)
         return true
     }
 
     func sendError(_ connectionError: Error) {
-        pp_log(ctx, .core, .info, "Report link failure: \(connectionError)")
+        pp_log(ctx, .openvpn, .info, "Report link failure: \(connectionError)")
         statusSubject.send(completion: .failure(connectionError))
         onError(connectionError)
     }
@@ -356,17 +421,17 @@ private extension LinkInterface {
 private extension _OpenVPNConnectionV3 {
     func setupLink(upgradingCurrent: Bool) async throws -> LinkInterface {
         do {
-            pp_log(ctx, .core, .notice, "Create new link")
+            pp_log(ctx, .openvpn, .notice, "Create new link")
             var newLink: LinkInterface
 
             // upgrade current link if possible
             if upgradingCurrent, let upgradedLink = try await currentLink?.upgraded() {
-                pp_log(ctx, .core, .notice, "Will reconnect to current link")
+                pp_log(ctx, .openvpn, .notice, "Will reconnect to current link")
                 newLink = upgradedLink
             }
             // create new link
             else {
-                pp_log(ctx, .core, .notice, "Cycle to next endpoint")
+                pp_log(ctx, .openvpn, .notice, "Cycle to next endpoint")
                 let result = try await endpointResolver.withNextEndpoint(
                     dns: dns,
                     timeout: options.dnsTimeout
@@ -374,21 +439,21 @@ private extension _OpenVPNConnectionV3 {
                 endpointResolver = result.nextResolver
 
                 let linkObserver = try factory.linkObserver(to: result.endpoint)
-                pp_log(ctx, .core, .notice, "Connect to \(result.endpoint.asSensitiveAddress(ctx))")
+                pp_log(ctx, .openvpn, .notice, "Connect to \(result.endpoint.asSensitiveAddress(ctx))")
                 newLink = try await linkObserver.waitForActivity(timeout: options.linkActivityTimeout)
 
-                pp_log(ctx, .core, .notice, "Link is active")
-                pp_log(ctx, .core, .info, "Link type is \(newLink.linkDescription)")
+                pp_log(ctx, .openvpn, .notice, "Link is active")
+                pp_log(ctx, .openvpn, .info, "Link type is \(newLink.linkDescription)")
                 // Wrap new link into a specific OpenVPN link
                 newLink = newLink.openVPNLink(method: configuration.xorMethod)
             }
 
-            pp_log(ctx, .core, .info, "Processed link type is \(newLink.linkDescription)")
+            pp_log(ctx, .openvpn, .info, "Processed link type is \(newLink.linkDescription)")
 
             currentLink = newLink
             return newLink
         } catch {
-            pp_log(ctx, .core, .fault, "Unable to create link: \(error)")
+            pp_log(ctx, .openvpn, .fault, "Unable to create link: \(error)")
 
             // reset endpoints on exhaustion
             if (error as? PartoutError)?.code == .exhaustedEndpoints {
@@ -407,7 +472,7 @@ private extension _OpenVPNConnectionV3 {
             for await _ in link.hasBetterPath {
                 guard let self else { return }
                 guard !Task.isCancelled else {
-                    pp_log(ctx, .core, .debug, "Cancelled CyclingConnection.pathSubscription")
+                    pp_log(ctx, .openvpn, .debug, "Cancelled CyclingConnection.pathSubscription")
                     return
                 }
                 // TODO: #143/notes, may improve this with floating (establish the new socket FIRST, then shut down the old one, and FINALLY move work to the new one. this should be seamless with UDP)

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -287,6 +287,7 @@ set(PARTOUT_SOURCES
 ./PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
 ./PartoutOpenVPNConnection/V3/Internal/ControlChannelV3+Cross.swift
 ./PartoutOpenVPNConnection/V3/Internal/ControlChannelV3.swift
+./PartoutOpenVPNConnection/V3/Internal/LinkProcessor.swift
 ./PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
 ./PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
 ./PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -289,6 +289,7 @@ set(PARTOUT_SOURCES
 ./PartoutOpenVPNConnection/V3/Internal/ControlChannelV3.swift
 ./PartoutOpenVPNConnection/V3/Internal/NegotiatorV3.swift
 ./PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
+./PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Context.swift
 ./PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Data.swift
 ./PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Loop.swift
 ./PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3+Negotiation.swift

--- a/Tests/PartoutOpenVPNTests/OpenVPNConnectionV3Tests.swift
+++ b/Tests/PartoutOpenVPNTests/OpenVPNConnectionV3Tests.swift
@@ -1,0 +1,437 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import PartoutCore
+@testable import PartoutOpenVPNConnection
+import Testing
+
+private typealias OpenVPNConnectionType = _OpenVPNConnectionV3
+
+struct OpenVPNConnectionV3Tests {
+    private let constants = Constants()
+
+    @Test
+    func givenConnection_whenStart_thenConnects() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+
+        let expLink = Expectation()
+        let expTunnel = Expectation()
+        session.onSetLink = {
+            Task {
+                await expLink.fulfill()
+            }
+        }
+        session.onSetTunnel = {
+            Task {
+                await expTunnel.fulfill()
+            }
+        }
+
+        let sut = try await constants.newConnection(with: session)
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        try await sut.start()
+        try await expLink.fulfillment(timeout: 300)
+        try await expTunnel.fulfillment(timeout: 300)
+        status = await sut.status
+        #expect(status == .connected)
+    }
+
+    @Test
+    func givenConnectionFailingLink_whenStart_thenFails() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+        let controller = MockTunnelController()
+
+        let expLink = Expectation()
+        session.onSetLink = {
+            throw PartoutError(.crypto)
+        }
+        session.onDidFailToSetLink = {
+            Task {
+                await expLink.fulfill()
+            }
+        }
+
+        let sut = try await constants.newConnection(with: session, controller: controller)
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        do {
+            try await sut.start()
+            try await expLink.fulfillment(timeout: 300)
+        } catch {
+            #expect(error.partoutErrorCode == .crypto)
+        }
+    }
+
+    @Test
+    func givenConnectionFailingTunnelSetup_whenStart_thenFails() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+        let controller = MockTunnelController()
+        controller.onSetTunnelSettings = { _ in
+            throw PartoutError(.incompatibleModules)
+        }
+
+        session.onStop = {
+            #expect(($0 as? PartoutError)?.code == .incompatibleModules)
+        }
+
+        let sut = try await constants.newConnection(with: session, controller: controller)
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        do {
+            try await sut.start()
+        } catch {
+            #expect((error as? PartoutError)?.code == .incompatibleModules)
+        }
+    }
+
+    @Test
+    func givenConnectionFailingAsynchronously_whenStart_thenCancelsShortlyAfter() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+        let controller = MockTunnelController()
+
+        let expStop = Expectation()
+        session.onSetLink = {
+            Task {
+                try? await Task.sleep(milliseconds: 200)
+                await session.shutdown(PartoutError(.crypto))
+            }
+        }
+        session.onStop = {
+            #expect(($0 as? PartoutError)?.code == .crypto)
+            Task {
+                await expStop.fulfill()
+            }
+        }
+
+        let sut = try await constants.newConnection(with: session, controller: controller)
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        try await sut.start()
+        try await expStop.fulfillment(timeout: 1000)
+    }
+
+    @Test
+    func givenConnectionFailingWithRecoverableError_whenStart_thenDisconnects() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+        let controller = MockTunnelController()
+        let recoverableError = PartoutError(.timeout)
+        assert(recoverableError.isOpenVPNRecoverable)
+
+        let expStart = Expectation()
+        let expStop = Expectation()
+        session.onSetLink = {
+            Task {
+                await expStart.fulfill()
+            }
+        }
+        session.onStop = {
+            #expect(($0 as? PartoutError)?.code == recoverableError.code)
+            Task {
+                await expStop.fulfill()
+            }
+        }
+        controller.onCancelTunnelConnection = { _ in
+            #expect(Bool(false), "Should not cancel connection")
+        }
+
+        let sut = try await constants.newConnection(
+            with: session,
+            controller: controller
+        )
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        try await sut.start()
+        try await expStart.fulfillment(timeout: 300)
+        try await fulfillment(of: sut, to: .connected, timeout: 500)
+        status = await sut.status
+        #expect(status == .connected)
+
+        Task {
+            await session.shutdown(recoverableError)
+        }
+
+        try await expStop.fulfillment(timeout: 500)
+        try await fulfillment(of: sut, to: .disconnected, timeout: 500)
+        status = await sut.status
+        #expect(status == .disconnected)
+    }
+
+    @Test
+    func givenStartedConnection_whenStop_thenDisconnects() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+
+        let expLink = Expectation()
+        let expStop = Expectation()
+        session.onSetLink = {
+            Task {
+                await expLink.fulfill()
+            }
+        }
+        session.onStop = {
+            #expect($0 == nil)
+            Task {
+                await expStop.fulfill()
+            }
+        }
+
+        let sut = try await constants.newConnection(with: session)
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        try await sut.start()
+        try await expLink.fulfillment(timeout: 200)
+        try await fulfillment(of: sut, to: .connected, timeout: 500)
+        status = await sut.status
+        #expect(status == .connected)
+
+        await sut.stop(timeout: 100)
+        try await expStop.fulfillment(timeout: 300)
+        status = await sut.status
+        #expect(status == .disconnected)
+    }
+
+    @Test
+    func givenStartedConnectionWithHangingLink_whenStop_thenDisconnectsAfterTimeout() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+
+        let expLink = Expectation()
+        let expStop = Expectation()
+        session.onSetLink = {
+            session.mockHasLink = true
+            Task {
+                await expLink.fulfill()
+            }
+        }
+        session.onStop = {
+            #expect($0 == nil)
+            Task {
+                await expStop.fulfill()
+            }
+        }
+
+        let sut = try await constants.newConnection(with: session)
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        try await sut.start()
+        try await expLink.fulfillment(timeout: 200)
+        try await fulfillment(of: sut, to: .connected, timeout: 500)
+        status = await sut.status
+        #expect(status == .connected)
+
+        await sut.stop(timeout: 100)
+        try await expStop.fulfillment(timeout: 300)
+        status = await sut.status
+        #expect(status == .disconnected)
+    }
+
+    @Test
+    func givenStartedConnection_whenUpgraded_thenDisconnectsWithNetworkChanged() async throws {
+        let session = MockOpenVPNSession()
+        var status: ConnectionStatus
+        let hasBetterPath = PassthroughStream<Void>()
+        let factory = MockNetworkInterfaceFactory()
+        factory.linkBlock = {
+            $0.hasBetterPath = hasBetterPath.subscribe()
+        }
+
+        let expInitialLink = Expectation()
+        let expConnected = Expectation()
+        let expStop = Expectation()
+        session.onSetLink = {
+            Task {
+                await expInitialLink.fulfill()
+            }
+        }
+        session.onConnected = {
+            Task {
+                await expConnected.fulfill()
+            }
+        }
+        session.onStop = {
+            #expect(($0 as? PartoutError)?.code == .networkChanged)
+            Task {
+                await expStop.fulfill()
+            }
+        }
+
+        let sut = try await constants.newConnection(
+            with: session,
+            factory: factory
+        )
+        status = await sut.status
+        #expect(status == .disconnected)
+
+        try await sut.start()
+        try await expInitialLink.fulfillment(timeout: 500)
+        try await expConnected.fulfillment(timeout: 500)
+        try await fulfillment(of: sut, to: .connected, timeout: 500)
+        status = await sut.status
+        #expect(status == .connected)
+
+        hasBetterPath.send()
+        try await expStop.fulfillment(timeout: 500)
+        try await fulfillment(of: sut, to: .disconnected, timeout: 500)
+        status = await sut.status
+        #expect(status == .disconnected)
+    }
+}
+
+// MARK: - Helpers
+
+private func fulfillment(
+    of sut: OpenVPNConnectionType,
+    to expectedStatus: ConnectionStatus,
+    timeout: Int
+) async throws {
+    let currentStatus = await sut.status
+    if currentStatus == expectedStatus {
+        return
+    }
+    let expStatus = Expectation()
+    let task = Task {
+        do {
+            for try await status in sut.statusStream {
+                if status == expectedStatus {
+                    await expStatus.fulfill()
+                    return
+                }
+            }
+        } catch {
+        }
+    }
+    defer {
+        task.cancel()
+    }
+    try await expStatus.fulfillment(timeout: timeout)
+}
+
+private struct Constants {
+    private let prng = SimplePRNG()
+
+    private let dns = MockDNSResolver()
+
+    private let hostname = "hostname"
+
+    private let module: OpenVPNModule
+
+    init() {
+        dns.setResolvedIPv4(["1.2.3.4"], for: hostname)
+
+        var cfg = OpenVPN.Configuration.Builder()
+        cfg.ca = OpenVPN.CryptoContainer(pem: "")
+        cfg.cipher = .aes128cbc
+        cfg.remotes = [ExtendedEndpoint(rawValue: "\(hostname):UDP:1194")!]
+        do {
+            module = try OpenVPNModule.Builder(configurationBuilder: cfg).build()
+        } catch {
+            fatalError("Cannot build OpenVPNModule: \(error)")
+        }
+    }
+
+    func newConnection(
+        with session: OpenVPNSessionProtocolV3,
+        controller: TunnelController = MockTunnelController(),
+        factory: NetworkInterfaceFactory = MockNetworkInterfaceFactory(),
+        environment: TunnelEnvironment = SharedTunnelEnvironment(profileId: nil)
+    ) async throws -> OpenVPNConnectionType {
+        let profile = try Profile.Builder().build()
+        let impl = OpenVPNModule.Implementation(
+            importerBlock: {
+                StandardOpenVPNParser(decrypter: nil)
+            },
+            connectionBlock: {
+                try OpenVPNConnectionType(
+                    .global,
+                    parameters: $0,
+                    module: $1,
+                    prng: prng,
+                    dns: dns,
+                    sessionFactory: { session }
+                )
+            }
+        )
+        let options = ConnectionParameters.Options()
+        let conn = try module.newConnection(with: impl, parameters: .init(
+            profile: profile,
+            controller: controller,
+            factory: factory,
+            reachability: MockReachabilityObserver(),
+            environment: environment,
+            options: options
+        ))
+        return try #require(conn as? OpenVPNConnectionType)
+    }
+}
+
+private final class MockOpenVPNSession: OpenVPNSessionProtocolV3, @unchecked Sendable {
+    private let options: OpenVPN.Configuration = {
+        do {
+            return try OpenVPN.Configuration.Builder().build(isClient: false)
+        } catch {
+            fatalError("Cannot build remote options: \(error)")
+        }
+    }()
+
+    var onSetLink: () throws -> Void = {}
+
+    var onConnected: () -> Void = {}
+
+    var onDidFailToSetLink: () -> Void = {}
+
+    var onSetTunnel: () -> Void = {}
+
+    var onStop: (Error?) -> Void = { _ in }
+
+    var mockHasLink = false
+
+    weak var delegate: OpenVPNSessionDelegateV3?
+
+    func setDelegate(_ delegate: OpenVPNSessionDelegateV3) {
+        self.delegate = delegate
+    }
+
+    func setLink(_ link: LinkInterface) async throws {
+        do {
+            try onSetLink()
+            delegate?.sessionDidStart(
+                self,
+                remoteAddress: "100.200.100.200",
+                remoteProtocol: .init(.udp, 1234),
+                remoteOptions: options,
+                remoteFd: nil
+            )
+            onConnected()
+        } catch {
+            delegate?.sessionDidStop(self, withError: error)
+            onDidFailToSetLink()
+        }
+    }
+
+    func hasLink() -> Bool {
+        mockHasLink
+    }
+
+    func setTunnel(_ tunnel: IOInterface) async throws {
+        onSetTunnel()
+    }
+
+    func shutdown(_ error: (any Error)?, timeout: TimeInterval?) async {
+        delegate?.sessionDidStop(self, withError: error)
+        onStop(error)
+    }
+}


### PR DESCRIPTION
Rework a v3 connection with a single-threaded event loop (FdLooper) and synchronous handlers:

- Replace OpenVPNActor synchronization with the FdLooper queue
- Dispatch public ABI on the FdLooper queue for serial access without the actor
- Prefer DispatchQueue over Swift Concurrency on the hot path
- Attach and detach link/tun dynamically to/from a long-lived looper
- Wrap session context atomically to highlight the boundaries of shared mutable state
- Migrate packet processing to looper hooks with LinkProcessor
- Route session delegate through an AsyncStream for ordered synchronous callbacks
- No other async delegates
- Delete naive loops

Local iperf3 tests show a drop in CPU% (8 cores) from 75% to 35% over the same network.