### PR TITLE
Core: Per-side looper R/W hooks

### DIFF
--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -20,29 +20,30 @@ public final class FdLooper: @unchecked Sendable {
     }
 
     public typealias BeforeRead = @Sendable (_ packets: [Data]) throws -> [Data]
-    public typealias BeforeWrite = @Sendable (_ packets: [Data]) throws -> [Data]
     public typealias OnRead = @Sendable (_ packets: [Data]) throws -> FdLooper.ReadAction
+    public typealias TransformWrite = @Sendable (_ packets: [Data]) throws -> [Data]
     public typealias OnFinish = @Sendable (_ error: Error?) -> Void
 
     public struct AttachArguments: Sendable {
         public let side: Side
         public let original: IOInterface
         public let beforeRead: BeforeRead?
-        public let beforeWrite: BeforeWrite?
         public let onRead: OnRead?
+        // BEWARE: NEVER call FdLooper API from this to avoid deadlock
+        public let transformWrite: TransformWrite?
 
         public init(
             side: Side,
             original: IOInterface,
             beforeRead: BeforeRead?,
-            beforeWrite: BeforeWrite?,
-            onRead: OnRead?
+            onRead: OnRead?,
+            transformWrite: TransformWrite?
         ) {
             self.side = side
             self.original = original
             self.beforeRead = beforeRead
-            self.beforeWrite = beforeWrite
             self.onRead = onRead
+            self.transformWrite = transformWrite
         }
     }
 
@@ -313,7 +314,7 @@ public final class FdLooper: @unchecked Sendable {
                 pp_log(ctx, .core, .error, "Ignoring link packets, not attached")
                 return
             }
-            let processedPackets = try link.beforeWrite?(packets) ?? packets
+            let processedPackets = try link.transformWrite?(packets) ?? packets
             processedPackets.forEach {
                 link.unsafeEnqueueWrite($0)
             }
@@ -323,7 +324,7 @@ public final class FdLooper: @unchecked Sendable {
                 pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
                 return
             }
-            let processedPackets = try tun.beforeWrite?(packets) ?? packets
+            let processedPackets = try tun.transformWrite?(packets) ?? packets
             processedPackets.forEach {
                 tun.unsafeEnqueueWrite($0)
             }
@@ -465,8 +466,7 @@ private extension FdLooper {
                 }
             }
             if !inbox.isEmpty {
-                let processedInbox = try tun.beforeRead?(inbox) ?? inbox
-                let action = try tun.onRead?(processedInbox)
+                let action = try tun.processReadPackets(inbox)
                 if action == .pause {
                     pp_mux_set_read(mux, tun.fd, false)
                 }
@@ -492,8 +492,7 @@ private extension FdLooper {
                 }
             }
             if !inbox.isEmpty {
-                let processedInbox = try link.beforeRead?(inbox) ?? inbox
-                let action = try link.onRead?(processedInbox)
+                let action = try link.processReadPackets(inbox)
                 if action == .pause {
                     pp_mux_set_read(mux, link.fd, false)
                 }
@@ -768,9 +767,9 @@ private extension FdLooper {
         let fd: Int32
 
         let originalInterface: IOInterface
-        let beforeRead: BeforeRead?
-        let beforeWrite: BeforeWrite?
-        let onRead: OnRead?
+        private let beforeRead: BeforeRead?
+        private let onRead: OnRead?
+        let transformWrite: TransformWrite?
 
         private let read: (inout [UInt8]) throws -> Data?
         private let write: (PendingWrite) throws -> Int
@@ -793,8 +792,8 @@ private extension FdLooper {
             self.fd = fd
             originalInterface = arguments.original
             beforeRead = arguments.beforeRead
-            beforeWrite = arguments.beforeWrite
             onRead = arguments.onRead
+            transformWrite = arguments.transformWrite
             self.read = read
             self.write = write
             self.cleanup = cleanup
@@ -805,6 +804,11 @@ private extension FdLooper {
 
         func dequeueRead() throws -> Data? {
             try read(&readBuf)
+        }
+
+        func processReadPackets(_ packets: [Data]) throws -> FdLooper.ReadAction {
+            let processed = try beforeRead?(packets) ?? packets
+            return try onRead?(processed) ?? .keep
         }
 
         func performWrite(_ pending: PendingWrite, lock: SemaphoreMutex) throws -> Bool {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -315,8 +315,14 @@ public final class FdLooper: @unchecked Sendable {
                 return
             }
             lock.unlock()
+
             let processedPackets = try link.transformWrite?(packets) ?? packets
+
             lock.lock()
+            guard link === self.link else {
+                pp_log(ctx, .core, .error, "Ignoring detached link during processing")
+                return
+            }
             processedPackets.forEach {
                 link.unsafeEnqueueWrite($0)
             }
@@ -327,8 +333,14 @@ public final class FdLooper: @unchecked Sendable {
                 return
             }
             lock.unlock()
+
             let processedPackets = try tun.transformWrite?(packets) ?? packets
+
             lock.lock()
+            guard tun === self.tun else {
+                pp_log(ctx, .core, .error, "Ignoring detached tun during processing")
+                return
+            }
             processedPackets.forEach {
                 tun.unsafeEnqueueWrite($0)
             }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -7,23 +7,6 @@
 #if !os(Windows)
 internal import _PartoutCore_C
 
-/// Delegates ``FdLooper`` events.
-public struct FdLooperDelegate: Sendable {
-    public typealias OnRead = @Sendable (_ packets: [Data], _ side: FdLooper.Side) throws -> FdLooper.ReadAction
-    public typealias OnFinish = @Sendable (_ error: Error?) -> Void
-
-    public let onRead: OnRead
-    public let onFinish: OnFinish
-
-    public init(
-        onRead: @escaping OnRead,
-        onFinish: @escaping OnFinish
-    ) {
-        self.onRead = onRead
-        self.onFinish = onFinish
-    }
-}
-
 /// Loops through a set of file descriptors.
 public final class FdLooper: @unchecked Sendable {
     public enum Side: Hashable, Sendable {
@@ -36,58 +19,66 @@ public final class FdLooper: @unchecked Sendable {
         case pause
     }
 
-    private enum State: Sendable {
-        case idle
-        case started
-        case stopping
-        case stopped
-    }
+    public typealias BeforeRead = @Sendable (_ packets: [Data]) throws -> [Data]
+    public typealias BeforeWrite = @Sendable (_ packets: [Data]) throws -> [Data]
+    public typealias OnRead = @Sendable (_ packets: [Data]) throws -> FdLooper.ReadAction
+    public typealias OnFinish = @Sendable (_ error: Error?) -> Void
 
-    fileprivate enum Command {
-        case attachLink(IOInterface, CheckedContinuation<Void, Error>)
-        case attachTun(IOInterface, CheckedContinuation<Void, Error>)
-        case detachLink(CheckedContinuation<Void, Never>)
-        case detachTun(CheckedContinuation<Void, Never>)
-        case enableRead(Side, UUID?)
-        case enableWrite(Side, UUID?)
-        case custom(@Sendable () throws -> Void)
-        case stop
+    public struct AttachArguments: Sendable {
+        public let side: Side
+        public let original: IOInterface
+        public let beforeRead: BeforeRead?
+        public let beforeWrite: BeforeWrite?
+        public let onRead: OnRead?
+
+        public init(
+            side: Side,
+            original: IOInterface,
+            beforeRead: BeforeRead?,
+            beforeWrite: BeforeWrite?,
+            onRead: OnRead?
+        ) {
+            self.side = side
+            self.original = original
+            self.beforeRead = beforeRead
+            self.beforeWrite = beforeWrite
+            self.onRead = onRead
+        }
     }
 
     private static let numberOfDescriptors = 2
+    private static let noBufRetryDelay: DispatchTimeInterval = .milliseconds(10)
 
     private let ctx: PartoutLoggerContext
     private let mux: pp_mux
-    private var link: SideIO?
-    private var tun: SideIO?
-    private var linkHandle: pp_socket?
-    private var tunHandle: pp_tun?
-    private let delegate: FdLooperDelegate
     private let linkBufSize: Int
     private let tunBufSize: Int
     private let maxReadSize: Int
     private let maxReadCount: Int
-    private static let noBufRetryDelay: DispatchTimeInterval = .milliseconds(10)
+    private let onFinish: OnFinish
 
     private let loopQueue: DispatchQueue
     private let loopQueueKey: DispatchSpecificKey<Void>
     private let retryQueue: DispatchQueue
     private let lock: SemaphoreMutex
+
+    private var state: State
     private var commands: [Command]
     private var readRetries: Set<Side>
     private var writeRetries: Set<Side>
-    private var state: State
+    private var link: SideIO?
+    private var tun: SideIO?
     private var stopContinuation: CheckedContinuation<Void, Error>?
     private var terminalError: Error?
 
     public init(
         _ ctx: PartoutLoggerContext,
         queue: DispatchQueue,
-        delegate: FdLooperDelegate,
         linkBufSize: Int = 64 * 1024,
         tunBufSize: Int = 16 * 1024,
         maxReadSize: Int = 256 * 1024,
-        maxReadCount: Int = 128
+        maxReadCount: Int = 128,
+        onFinish: @escaping OnFinish
     ) throws {
         guard let newMux = pp_mux_create(Int32(Self.numberOfDescriptors)) else {
             pp_log(ctx, .core, .fault, "Unable to create mux")
@@ -96,21 +87,22 @@ public final class FdLooper: @unchecked Sendable {
 
         self.ctx = ctx
         mux = newMux
-        self.delegate = delegate
         self.linkBufSize = linkBufSize
         self.tunBufSize = tunBufSize
         self.maxReadSize = max(maxReadSize, linkBufSize, tunBufSize)
         self.maxReadCount = maxReadCount
+        self.onFinish = onFinish
 
         loopQueue = queue
         loopQueueKey = DispatchSpecificKey()
         loopQueue.setSpecific(key: loopQueueKey, value: ())
         retryQueue = DispatchQueue(label: "\(queue.label).retry")
         lock = SemaphoreMutex()
+
+        state = .idle
         commands = []
         readRetries = []
         writeRetries = []
-        state = .idle
     }
 
     deinit {
@@ -257,41 +249,21 @@ public final class FdLooper: @unchecked Sendable {
         }
     }
 
-    public func attachLink(_ linkInterface: IOInterface) async throws {
+    public func attach(_ arguments: AttachArguments) async throws {
         try await withCheckedThrowingContinuation { continuation in
             lock.with {
-                precondition(state == .started, "Attach link after start()")
-                commands.append(.attachLink(linkInterface, continuation))
+                precondition(state == .started, "Attach after start()")
+                commands.append(.attach(arguments, continuation))
                 pp_mux_wake(mux)
             }
         }
     }
 
-    public func attachTun(_ tunInterface: IOInterface) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            lock.with {
-                precondition(state == .started, "Attach tun after start()")
-                commands.append(.attachTun(tunInterface, continuation))
-                pp_mux_wake(mux)
-            }
-        }
-    }
-
-    public func detachLink() async {
+    public func detach(_ side: Side) async {
         await withCheckedContinuation { continuation in
             lock.with {
-                precondition(state == .started, "Detach link after start()")
-                commands.append(.detachLink(continuation))
-                pp_mux_wake(mux)
-            }
-        }
-    }
-
-    public func detachTun() async {
-        await withCheckedContinuation { continuation in
-            lock.with {
-                precondition(state == .started, "Detach link after start()")
-                commands.append(.detachTun(continuation))
+                precondition(state == .started, "Detach after start()")
+                commands.append(.detach(side, continuation))
                 pp_mux_wake(mux)
             }
         }
@@ -316,7 +288,7 @@ public final class FdLooper: @unchecked Sendable {
         pp_mux_wake(mux)
     }
 
-    public func write(_ packets: [Data], to side: Side) {
+    public func write(_ packets: [Data], to side: Side) throws {
         lock.lock()
         defer { lock.unlock() }
         switch side {
@@ -325,7 +297,8 @@ public final class FdLooper: @unchecked Sendable {
                 pp_log(ctx, .core, .error, "Ignoring link packets, not attached")
                 return
             }
-            packets.forEach {
+            let processedPackets = try link.beforeWrite?(packets) ?? packets
+            processedPackets.forEach {
                 link.unsafeEnqueueWrite($0)
             }
             commands.append(.enableWrite(.link, nil))
@@ -334,7 +307,8 @@ public final class FdLooper: @unchecked Sendable {
                 pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
                 return
             }
-            packets.forEach {
+            let processedPackets = try tun.beforeWrite?(packets) ?? packets
+            processedPackets.forEach {
                 tun.unsafeEnqueueWrite($0)
             }
             commands.append(.enableWrite(.tun, nil))
@@ -344,6 +318,22 @@ public final class FdLooper: @unchecked Sendable {
 }
 
 private extension FdLooper {
+    enum State: Sendable {
+        case idle
+        case started
+        case stopping
+        case stopped
+    }
+
+    enum Command {
+        case attach(AttachArguments, CheckedContinuation<Void, Error>)
+        case detach(Side, CheckedContinuation<Void, Never>)
+        case enableRead(Side, UUID?)
+        case enableWrite(Side, UUID?)
+        case custom(@Sendable () throws -> Void)
+        case stop
+    }
+
     enum CommandResult {
         case attach(CheckedContinuation<Void, Error>, Result<Void, Error>)
         case detach(CheckedContinuation<Void, Never>)
@@ -358,80 +348,86 @@ private extension FdLooper {
         var results: [CommandResult] = []
         for cmd in pendingCommands {
             switch cmd {
-            case .attachLink(let linkInterface, let continuation):
-                guard let fd = linkInterface.fileDescriptor else {
-                    results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
-                    break
-                }
-                // Cancel attach if stopping
-                guard state != .stopping else {
-                    results.append(.attach(continuation, .failure(CancellationError())))
-                    break
-                }
-                // Can only attach once
-                guard link == nil else {
-                    results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
-                    break
-                }
-                let linkFd = Int32(fd)
-                guard pp_mux_add(mux, linkFd) else {
-                    pp_log(ctx, .core, .fault, "Unable to attach link")
-                    results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
-                    break
-                }
-                pp_log(ctx, .core, .info, "Attach link (fd=\(fd))")
+            case .attach(let arguments, let continuation):
+                switch arguments.side {
+                case .link:
+                    guard let fd = arguments.original.fileDescriptor else {
+                        results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
+                        break
+                    }
+                    // Cancel attach if stopping
+                    guard state != .stopping else {
+                        results.append(.attach(continuation, .failure(CancellationError())))
+                        break
+                    }
+                    // Can only attach once
+                    guard link == nil else {
+                        results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
+                        break
+                    }
+                    let linkFd = Int32(fd)
+                    guard pp_mux_add(mux, linkFd) else {
+                        pp_log(ctx, .core, .fault, "Unable to attach link")
+                        results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
+                        break
+                    }
+                    pp_log(ctx, .core, .info, "Attach link (fd=\(fd))")
 
-                // Create new side
-                link = SideIO(
-                    mux: mux,
-                    linkFd: linkFd,
-                    originalInterface: linkInterface,
-                    readBufSize: linkBufSize
-                )
-                results.append(.attach(continuation, .success(())))
-            case .attachTun(let tunInterface, let continuation):
-                guard let fd = tunInterface.fileDescriptor else {
-                    results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
-                    break
-                }
-                // Cancel attach if stopping
-                guard state != .stopping else {
-                    results.append(.attach(continuation, .failure(CancellationError())))
-                    break
-                }
-                // Can only attach once
-                guard tun == nil else {
-                    results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
-                    break
-                }
-                let tunFd = Int32(fd)
-                guard pp_mux_add(mux, tunFd) else {
-                    pp_log(ctx, .core, .fault, "Unable to attach tun")
-                    results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
-                    break
-                }
-                pp_log(ctx, .core, .info, "Attach tun (fd=\(fd))")
+                    // Create new side
+                    link = SideIO(
+                        mux: mux,
+                        linkFd: linkFd,
+                        readBufSize: linkBufSize,
+                        arguments: arguments
+                    )
+                    results.append(.attach(continuation, .success(())))
+                case .tun:
+                    guard let fd = arguments.original.fileDescriptor else {
+                        results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
+                        break
+                    }
+                    // Cancel attach if stopping
+                    guard state != .stopping else {
+                        results.append(.attach(continuation, .failure(CancellationError())))
+                        break
+                    }
+                    // Can only attach once
+                    guard tun == nil else {
+                        results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
+                        break
+                    }
+                    let tunFd = Int32(fd)
+                    guard pp_mux_add(mux, tunFd) else {
+                        pp_log(ctx, .core, .fault, "Unable to attach tun")
+                        results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
+                        break
+                    }
+                    pp_log(ctx, .core, .info, "Attach tun (fd=\(fd))")
 
-                // Create new side
-                tun = SideIO(
-                    mux: mux,
-                    tunFd: tunFd,
-                    originalInterface: tunInterface,
-                    readBufSize: tunBufSize
-                )
-                results.append(.attach(continuation, .success(())))
-            case .detachLink(let continuation):
-                link?.detach()
-                link = nil
-                readRetries.remove(.link)
-                writeRetries.remove(.link)
-                results.append(.detach(continuation))
-            case .detachTun(let continuation):
-                tun?.detach()
-                tun = nil
-                readRetries.remove(.tun)
-                writeRetries.remove(.tun)
-                results.append(.detach(continuation))
+                    // Create new side
+                    tun = SideIO(
+                        mux: mux,
+                        tunFd: tunFd,
+                        readBufSize: tunBufSize,
+                        arguments: arguments
+                    )
+                    results.append(.attach(continuation, .success(())))
+                }
+            case .detach(let side, let continuation):
+                switch side {
+                case .link:
+                    link?.detach()
+                    link = nil
+                    readRetries.remove(.link)
+                    writeRetries.remove(.link)
+                    results.append(.detach(continuation))
+                case .tun:
+                    tun?.detach()
+                    tun = nil
+                    readRetries.remove(.tun)
+                    writeRetries.remove(.tun)
+                    results.append(.detach(continuation))
+                }
             case .enableRead(let side, let id):
                 if let id {
                     guard !isOutdated(id, side: side) else {
@@ -566,7 +562,8 @@ private extension FdLooper {
                 }
             }
             if !inbox.isEmpty {
-                let action = try delegate.onRead(inbox, .tun)
+                let processedInbox = try tun.beforeRead?(inbox) ?? inbox
+                let action = try tun.onRead?(processedInbox)
                 if action == .pause {
                     pp_mux_set_read(mux, tun.fd, false)
                 }
@@ -592,7 +589,8 @@ private extension FdLooper {
                 }
             }
             if !inbox.isEmpty {
-                let action = try delegate.onRead(inbox, .link)
+                let processedInbox = try link.beforeRead?(inbox) ?? inbox
+                let action = try link.onRead?(processedInbox)
                 if action == .pause {
                     pp_mux_set_read(mux, link.fd, false)
                 }
@@ -679,7 +677,7 @@ private extension FdLooper {
             stopContinuation?.resume()
         }
         stopContinuation = nil
-        delegate.onFinish(error)
+        onFinish(error)
     }
 }
 
@@ -723,10 +721,16 @@ private extension FdLooper {
         let id = UUID()
         let side: Side
         let fd: Int32
+
         let originalInterface: IOInterface
+        let beforeRead: BeforeRead?
+        let beforeWrite: BeforeWrite?
+        let onRead: OnRead?
+
         private let read: (inout [UInt8]) throws -> Data?
         private let write: (PendingWrite) throws -> Int
         private var cleanup: (() -> Void)?
+
         private var readBuf: [UInt8]
         private var writeQueue: RingQueue<Data>
         private var writeOffset: Int
@@ -734,15 +738,18 @@ private extension FdLooper {
         init(
             side: Side,
             fd: Int32,
-            originalInterface: IOInterface,
             readBufSize: Int,
+            arguments: FdLooper.AttachArguments,
             read: @escaping (inout [UInt8]) throws -> Data?,
             write: @escaping (PendingWrite) throws -> Int,
-            cleanup: @escaping () -> Void
+            cleanup: @escaping () -> Void,
         ) {
             self.side = side
             self.fd = fd
-            self.originalInterface = originalInterface
+            originalInterface = arguments.original
+            beforeRead = arguments.beforeRead
+            beforeWrite = arguments.beforeWrite
+            onRead = arguments.onRead
             self.read = read
             self.write = write
             self.cleanup = cleanup
@@ -794,15 +801,15 @@ private extension FdLooper.SideIO {
     convenience init(
         mux: pp_mux,
         linkFd: Int32,
-        originalInterface: IOInterface,
-        readBufSize: Int
+        readBufSize: Int,
+        arguments: FdLooper.AttachArguments
     ) {
         let linkHandle = pp_socket_create(UInt64(linkFd))
         self.init(
             side: .link,
             fd: linkFd,
-            originalInterface: originalInterface,
             readBufSize: readBufSize,
+            arguments: arguments,
             read: { buf in
                 let count = pp_socket_read(linkHandle, &buf, buf.count)
                 guard count != PP_SOCKET_WOULD_BLOCK else {
@@ -845,15 +852,15 @@ private extension FdLooper.SideIO {
     convenience init(
         mux: pp_mux,
         tunFd: Int32,
-        originalInterface: IOInterface,
-        readBufSize: Int
+        readBufSize: Int,
+        arguments: FdLooper.AttachArguments
     ) {
         let tunHandle = pp_tun_create(tunFd)
         self.init(
             side: .tun,
             fd: tunFd,
-            originalInterface: originalInterface,
             readBufSize: readBufSize,
+            arguments: arguments,
             read: { buf in
                 let count = pp_tun_read(tunHandle, &buf, buf.count)
                 guard count != PP_TUN_WOULD_BLOCK else {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -382,12 +382,9 @@ private extension FdLooper {
                 pp_log(ctx, .core, .info, "Attach link (fd=\(fd))")
 
                 // Create new side
-                let linkHandle = pp_socket_create(fd)
-                self.linkHandle = linkHandle
                 link = SideIO(
                     mux: mux,
                     linkFd: linkFd,
-                    handle: linkHandle,
                     originalInterface: linkInterface,
                     readBufSize: linkBufSize
                 )
@@ -416,12 +413,9 @@ private extension FdLooper {
                 pp_log(ctx, .core, .info, "Attach tun (fd=\(fd))")
 
                 // Create new side
-                let tunHandle = pp_tun_create(tunFd)
-                self.tunHandle = tunHandle
                 tun = SideIO(
                     mux: mux,
                     tunFd: tunFd,
-                    handle: tunHandle,
                     originalInterface: tunInterface,
                     readBufSize: tunBufSize
                 )
@@ -618,14 +612,16 @@ private extension FdLooper {
         readRetries.insert(io.side)
         lock.unlock()
 
+        let side = io.side
+        let command: Command = .enableRead(side, io.id)
         retryQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
             guard let self else { return }
             self.lock.with {
-                self.readRetries.remove(io.side)
+                self.readRetries.remove(side)
                 guard self.state == .started else {
                     return
                 }
-                self.commands.append(.enableRead(io.side, io.id))
+                self.commands.append(command)
                 pp_mux_wake(self.mux)
             }
         }
@@ -640,14 +636,16 @@ private extension FdLooper {
         writeRetries.insert(io.side)
         lock.unlock()
 
+        let side = io.side
+        let command: Command = .enableWrite(side, io.id)
         retryQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
             guard let self else { return }
             self.lock.with {
-                self.writeRetries.remove(io.side)
+                self.writeRetries.remove(side)
                 guard self.state == .started else {
                     return
                 }
-                self.commands.append(.enableWrite(io.side, io.id))
+                self.commands.append(command)
                 pp_mux_wake(self.mux)
             }
         }
@@ -796,11 +794,10 @@ private extension FdLooper.SideIO {
     convenience init(
         mux: pp_mux,
         linkFd: Int32,
-        handle: pp_socket,
         originalInterface: IOInterface,
         readBufSize: Int
     ) {
-        nonisolated(unsafe) let linkHandle = handle
+        let linkHandle = pp_socket_create(UInt64(linkFd))
         self.init(
             side: .link,
             fd: linkFd,
@@ -848,11 +845,10 @@ private extension FdLooper.SideIO {
     convenience init(
         mux: pp_mux,
         tunFd: Int32,
-        handle: pp_tun,
         originalInterface: IOInterface,
         readBufSize: Int
     ) {
-        nonisolated(unsafe) let tunHandle = handle
+        let tunHandle = pp_tun_create(tunFd)
         self.init(
             side: .tun,
             fd: tunFd,

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -29,7 +29,6 @@ public final class FdLooper: @unchecked Sendable {
         public let original: IOInterface
         public let beforeRead: BeforeRead?
         public let onRead: OnRead?
-        // BEWARE: NEVER call FdLooper API from this to avoid deadlock
         public let transformWrite: TransformWrite?
 
         public init(

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -351,131 +351,18 @@ private extension FdLooper {
         lock.lock()
         let pendingCommands = commands
         commands.removeAll(keepingCapacity: true)
-
-        var shouldStop = false
         var results: [CommandResult] = []
+        var shouldStop = false
         for cmd in pendingCommands {
             switch cmd {
             case .attach(let arguments, let continuation):
-                switch arguments.side {
-                case .link:
-                    guard let fd = arguments.original.fileDescriptor else {
-                        results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
-                        break
-                    }
-                    // Cancel attach if stopping
-                    guard state != .stopping else {
-                        results.append(.attach(continuation, .failure(CancellationError())))
-                        break
-                    }
-                    // Can only attach once
-                    guard link == nil else {
-                        results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
-                        break
-                    }
-                    let linkFd = Int32(fd)
-                    guard pp_mux_add(mux, linkFd) else {
-                        pp_log(ctx, .core, .fault, "Unable to attach link")
-                        results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
-                        break
-                    }
-                    pp_log(ctx, .core, .info, "Attach link (fd=\(fd))")
-
-                    // Create new side
-                    link = SideIO(
-                        mux: mux,
-                        linkFd: linkFd,
-                        readBufSize: linkBufSize,
-                        arguments: arguments
-                    )
-                    results.append(.attach(continuation, .success(())))
-                case .tun:
-                    guard let fd = arguments.original.fileDescriptor else {
-                        results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
-                        break
-                    }
-                    // Cancel attach if stopping
-                    guard state != .stopping else {
-                        results.append(.attach(continuation, .failure(CancellationError())))
-                        break
-                    }
-                    // Can only attach once
-                    guard tun == nil else {
-                        results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
-                        break
-                    }
-                    let tunFd = Int32(fd)
-                    guard pp_mux_add(mux, tunFd) else {
-                        pp_log(ctx, .core, .fault, "Unable to attach tun")
-                        results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
-                        break
-                    }
-                    pp_log(ctx, .core, .info, "Attach tun (fd=\(fd))")
-
-                    // Create new side
-                    tun = SideIO(
-                        mux: mux,
-                        tunFd: tunFd,
-                        readBufSize: tunBufSize,
-                        arguments: arguments
-                    )
-                    results.append(.attach(continuation, .success(())))
-                }
+                handleAttach(arguments, continuation: continuation, results: &results)
             case .detach(let side, let continuation):
-                switch side {
-                case .link:
-                    link?.detach()
-                    link = nil
-                    readRetries.remove(.link)
-                    writeRetries.remove(.link)
-                    results.append(.detach(continuation))
-                case .tun:
-                    tun?.detach()
-                    tun = nil
-                    readRetries.remove(.tun)
-                    writeRetries.remove(.tun)
-                    results.append(.detach(continuation))
-                }
+                handleDetach(side, continuation: continuation, results: &results)
             case .enableRead(let side, let id):
-                if let id {
-                    guard !isOutdated(id, side: side) else {
-                        break
-                    }
-                }
-                switch side {
-                case .link:
-                    if let link {
-                        pp_mux_set_read(mux, link.fd, true)
-                    } else {
-                        pp_log(ctx, .core, .error, "Ignoring link enableRead(), not attached")
-                    }
-                case .tun:
-                    if let tun {
-                        pp_mux_set_read(mux, tun.fd, true)
-                    } else {
-                        pp_log(ctx, .core, .error, "Ignoring tun enableRead(), not attached")
-                    }
-                }
+                handleEnableRead(side, id: id)
             case .enableWrite(let side, let id):
-                if let id {
-                    guard !isOutdated(id, side: side) else {
-                        break
-                    }
-                }
-                switch side {
-                case .link:
-                    if let link {
-                        pp_mux_set_write(mux, link.fd, true)
-                    } else {
-                        pp_log(ctx, .core, .error, "Ignoring link enableWrite(), not attached")
-                    }
-                case .tun:
-                    if let tun {
-                        pp_mux_set_write(mux, tun.fd, true)
-                    } else {
-                        pp_log(ctx, .core, .error, "Ignoring tun enableWrite(), not attached")
-                    }
-                }
+                handleEnableWrite(side, id: id)
             case .custom(let body):
                 lock.unlock()
                 try body()
@@ -688,6 +575,148 @@ private extension FdLooper {
         onFinish(error)
     }
 }
+
+// MARK: - Commands (inside lock)
+
+private extension FdLooper {
+    func handleAttach(
+        _ arguments: AttachArguments,
+        continuation: CheckedContinuation<Void, Error>,
+        results: inout [CommandResult]
+    ) {
+        switch arguments.side {
+        case .link:
+            guard let fd = arguments.original.fileDescriptor else {
+                results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
+                break
+            }
+            // Cancel attach if stopping
+            guard state != .stopping else {
+                results.append(.attach(continuation, .failure(CancellationError())))
+                break
+            }
+            // Can only attach once
+            guard link == nil else {
+                results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
+                break
+            }
+            let linkFd = Int32(fd)
+            guard pp_mux_add(mux, linkFd) else {
+                pp_log(ctx, .core, .fault, "Unable to attach link")
+                results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
+                break
+            }
+            pp_log(ctx, .core, .info, "Attach link (fd=\(fd))")
+
+            // Create new side
+            link = SideIO(
+                mux: mux,
+                linkFd: linkFd,
+                readBufSize: linkBufSize,
+                arguments: arguments
+            )
+            results.append(.attach(continuation, .success(())))
+        case .tun:
+            guard let fd = arguments.original.fileDescriptor else {
+                results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable))))
+                break
+            }
+            // Cancel attach if stopping
+            guard state != .stopping else {
+                results.append(.attach(continuation, .failure(CancellationError())))
+                break
+            }
+            // Can only attach once
+            guard tun == nil else {
+                results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
+                break
+            }
+            let tunFd = Int32(fd)
+            guard pp_mux_add(mux, tunFd) else {
+                pp_log(ctx, .core, .fault, "Unable to attach tun")
+                results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
+                break
+            }
+            pp_log(ctx, .core, .info, "Attach tun (fd=\(fd))")
+
+            // Create new side
+            tun = SideIO(
+                mux: mux,
+                tunFd: tunFd,
+                readBufSize: tunBufSize,
+                arguments: arguments
+            )
+            results.append(.attach(continuation, .success(())))
+        }
+    }
+
+    func handleDetach(
+        _ side: Side,
+        continuation: CheckedContinuation<Void, Never>,
+        results: inout [CommandResult]
+    ) {
+        switch side {
+        case .link:
+            link?.detach()
+            link = nil
+            readRetries.remove(.link)
+            writeRetries.remove(.link)
+            results.append(.detach(continuation))
+        case .tun:
+            tun?.detach()
+            tun = nil
+            readRetries.remove(.tun)
+            writeRetries.remove(.tun)
+            results.append(.detach(continuation))
+        }
+    }
+
+    func handleEnableRead(_ side: Side, id: UUID?) {
+        if let id {
+            guard !isOutdated(id, side: side) else {
+                return
+            }
+        }
+        switch side {
+        case .link:
+            if let link {
+                pp_mux_set_read(mux, link.fd, true)
+            } else {
+                pp_log(ctx, .core, .error, "Ignoring link enableRead(), not attached")
+            }
+        case .tun:
+            if let tun {
+                pp_mux_set_read(mux, tun.fd, true)
+            } else {
+                pp_log(ctx, .core, .error, "Ignoring tun enableRead(), not attached")
+            }
+        }
+    }
+
+    func handleEnableWrite(_ side: Side, id: UUID?) {
+        if let id {
+            guard !isOutdated(id, side: side) else {
+                return
+            }
+        }
+        switch side {
+        case .link:
+            if let link {
+                pp_mux_set_write(mux, link.fd, true)
+            } else {
+                pp_log(ctx, .core, .error, "Ignoring link enableWrite(), not attached")
+            }
+        case .tun:
+            if let tun {
+                pp_mux_set_write(mux, tun.fd, true)
+            } else {
+                pp_log(ctx, .core, .error, "Ignoring tun enableWrite(), not attached")
+            }
+        }
+    }
+}
+
+// MARK: - Descriptors
 
 private final class FdSet {
     var readable: Set<Int32>

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -314,7 +314,9 @@ public final class FdLooper: @unchecked Sendable {
                 pp_log(ctx, .core, .error, "Ignoring link packets, not attached")
                 return
             }
+            lock.unlock()
             let processedPackets = try link.transformWrite?(packets) ?? packets
+            lock.lock()
             processedPackets.forEach {
                 link.unsafeEnqueueWrite($0)
             }
@@ -324,7 +326,9 @@ public final class FdLooper: @unchecked Sendable {
                 pp_log(ctx, .core, .error, "Ignoring tun packets, not attached")
                 return
             }
+            lock.unlock()
             let processedPackets = try tun.transformWrite?(packets) ?? packets
+            lock.lock()
             processedPackets.forEach {
                 tun.unsafeEnqueueWrite($0)
             }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -241,11 +241,19 @@ public final class FdLooper: @unchecked Sendable {
         after delay: DispatchTimeInterval? = nil,
         _ body: @escaping @Sendable () throws -> Void
     ) rethrows {
-        var deadline: DispatchTime = .now()
-        if let delay {
-            deadline = deadline + delay
+        guard let delay else {
+            if isOnQueue {
+                try body()
+            } else {
+                lock.with {
+                    precondition(state == .started, "Schedule after start()")
+                    commands.append(.custom(body))
+                    pp_mux_wake(mux)
+                }
+            }
+            return
         }
-        scheduleQueue.asyncAfter(deadline: deadline) { [weak self] in
+        scheduleQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self else { return }
             self.lock.with {
                 guard self.state == .started else {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -59,7 +59,7 @@ public final class FdLooper: @unchecked Sendable {
 
     private let loopQueue: DispatchQueue
     private let loopQueueKey: DispatchSpecificKey<Void>
-    private let retryQueue: DispatchQueue
+    private let scheduleQueue: DispatchQueue
     private let lock: SemaphoreMutex
 
     private var state: State
@@ -96,7 +96,7 @@ public final class FdLooper: @unchecked Sendable {
         loopQueue = queue
         loopQueueKey = DispatchSpecificKey()
         loopQueue.setSpecific(key: loopQueueKey, value: ())
-        retryQueue = DispatchQueue(label: "\(queue.label).retry")
+        scheduleQueue = DispatchQueue(label: "\(queue.label).schedule")
         lock = SemaphoreMutex()
 
         state = .idle
@@ -245,7 +245,7 @@ public final class FdLooper: @unchecked Sendable {
         if let delay {
             deadline = deadline + delay
         }
-        retryQueue.asyncAfter(deadline: deadline) { [weak self] in
+        scheduleQueue.asyncAfter(deadline: deadline) { [weak self] in
             guard let self else { return }
             self.lock.with {
                 guard self.state == .started else {
@@ -507,7 +507,7 @@ private extension FdLooper {
 
         let side = io.side
         let command: Command = .enableRead(side, io.id)
-        retryQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
+        scheduleQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
             guard let self else { return }
             self.lock.with {
                 self.readRetries.remove(side)
@@ -531,7 +531,7 @@ private extension FdLooper {
 
         let side = io.side
         let command: Command = .enableWrite(side, io.id)
-        retryQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
+        scheduleQueue.asyncAfter(deadline: .now() + Self.noBufRetryDelay) { [weak self] in
             guard let self else { return }
             self.lock.with {
                 self.writeRetries.remove(side)

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -237,15 +237,23 @@ public final class FdLooper: @unchecked Sendable {
         }
     }
 
-    public func schedule(_ body: @escaping @Sendable () throws -> Void) rethrows {
-        if isOnQueue {
-            try body()
-            return
+    public func schedule(
+        after delay: DispatchTimeInterval? = nil,
+        _ body: @escaping @Sendable () throws -> Void
+    ) rethrows {
+        var deadline: DispatchTime = .now()
+        if let delay {
+            deadline = deadline + delay
         }
-        lock.with {
-            precondition(state == .started, "Schedule after start()")
-            commands.append(.custom(body))
-            pp_mux_wake(mux)
+        retryQueue.asyncAfter(deadline: deadline) { [weak self] in
+            guard let self else { return }
+            self.lock.with {
+                guard self.state == .started else {
+                    return
+                }
+                self.commands.append(.custom(body))
+                pp_mux_wake(self.mux)
+            }
         }
     }
 

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -36,7 +36,6 @@ Given the main app and the daemon:
 - ``DataCount``
 - ``EndpointResolver``
 - ``FdLooper``
-- ``FdLooperDelegate``
 - ``NetworkInterfaceFactory``
 - ``SocketConfigurator``
 


### PR DESCRIPTION
- Rather than a looper-scoped delegate, configure R/W hooks on attach
- `beforeRead` runs in the looper queue before delivering to `onRead`
- `transformWrite` is invoked synchronously before enqueueing packets to write
- Support an optional delay in the schedule command
- Refactor handleCommands() because it was growing huge