### PR TITLE
Core: Defer tun lifecycle to OS layer

### DIFF
--- a/Sources/Partout/VirtualTunnelInterface.swift
+++ b/Sources/Partout/VirtualTunnelInterface.swift
@@ -214,7 +214,7 @@ final class VirtualTunnelInterface: SocketIOInterface, @unchecked Sendable {
         activeLock.unlock()
         guard shouldShutdown else { return }
         pp_log(ctx, .core, .info, "Shut down TUN")
-        pp_tun_shutdown(tun)
+        pp_tun_close(tun)
 
         // Wait for shutdown
         await readQueue.waitUntilIdle()

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -991,7 +991,7 @@ private extension FdLooper.SideIO {
         readBufSize: Int,
         arguments: FdLooper.AttachArguments
     ) {
-        let linkHandle = pp_socket_create(UInt64(linkFd))
+        let linkHandle = pp_socket_retain(UInt64(linkFd))
         // FIXME: ###, Will pass pp_socket later to tell UDP/TCP
         let closesOnEmptyRead = (arguments.original as? LinkInterface)?.isReliable == true
         self.init(

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -1036,7 +1036,7 @@ private extension FdLooper.SideIO {
             },
             cleanup: {
                 pp_mux_delete(mux, linkFd)
-                pp_socket_free(linkHandle)
+                pp_socket_release(linkHandle)
             }
         )
     }

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -701,7 +701,7 @@ private extension FdLooper {
                 results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
                 break
             }
-            let linkFd = dup(Int32(fd))
+            let linkFd = Int32(fd)
             guard linkFd >= 0 else {
                 pp_log(ctx, .core, .fault, "Unable to dup link fd")
                 results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable, fd))))
@@ -709,7 +709,6 @@ private extension FdLooper {
             }
             guard pp_mux_add(mux, linkFd) else {
                 pp_log(ctx, .core, .fault, "Unable to attach link")
-                close(linkFd)
                 results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
                 break
             }
@@ -738,7 +737,7 @@ private extension FdLooper {
                 results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
                 break
             }
-            let tunFd = dup(Int32(fd))
+            let tunFd = Int32(fd)
             guard tunFd >= 0 else {
                 pp_log(ctx, .core, .fault, "Unable to dup tun fd")
                 results.append(.attach(continuation, .failure(PartoutError(.fdUnavailable, fd))))
@@ -746,7 +745,6 @@ private extension FdLooper {
             }
             guard pp_mux_add(mux, tunFd) else {
                 pp_log(ctx, .core, .fault, "Unable to attach tun")
-                close(tunFd)
                 results.append(.attach(continuation, .failure(PartoutError(.muxFailure, fd))))
                 break
             }
@@ -1049,7 +1047,7 @@ private extension FdLooper.SideIO {
         readBufSize: Int,
         arguments: FdLooper.AttachArguments
     ) {
-        let tunHandle = pp_tun_create(tunFd)
+        let tunHandle = pp_tun_retain(tunFd)
         self.init(
             side: .tun,
             fd: tunFd,
@@ -1089,7 +1087,7 @@ private extension FdLooper.SideIO {
             },
             cleanup: {
                 pp_mux_delete(mux, tunFd)
-                pp_tun_free(tunHandle)
+                pp_tun_release(tunHandle)
             }
         )
     }

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -38,9 +38,7 @@ static inline void pp_socket_free(pp_socket sock) {
     pp_socket_free_and_close(sock, true);
 }
 
-/* Create a socket wrapper from an already open native descriptor. The
- * wrapper acquires ownership and will close the descriptor on
- * pp_socket_close() or pp_socket_free(). */
+/* Create a socket wrapper from an already open native descriptor. */
 pp_socket pp_socket_retain(uint64_t fd);
 static inline void pp_socket_release(pp_socket sock) {
     pp_socket_free_and_close(sock, false);

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -30,19 +30,20 @@ typedef enum {
 /* The opaque socket type. */
 typedef struct __pp_socket_struct *pp_socket;
 
-/* Create a socket wrapper from an already open native descriptor. The
- * wrapper acquires ownership and will close the descriptor on
- * pp_socket_close() or pp_socket_free(). */
-pp_socket pp_socket_create(uint64_t fd);
 void pp_socket_shutdown(pp_socket sock);
 void pp_socket_close(pp_socket sock);
 void pp_socket_free_and_close(pp_socket sock, bool and_close);
 
-static inline void pp_socket_release(pp_socket sock) {
-    pp_socket_free_and_close(sock, false);
-}
 static inline void pp_socket_free(pp_socket sock) {
     pp_socket_free_and_close(sock, true);
+}
+
+/* Create a socket wrapper from an already open native descriptor. The
+ * wrapper acquires ownership and will close the descriptor on
+ * pp_socket_close() or pp_socket_free(). */
+pp_socket pp_socket_retain(uint64_t fd);
+static inline void pp_socket_release(pp_socket sock) {
+    pp_socket_free_and_close(sock, false);
 }
 
 /* Create socket to endpoint. */

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -50,7 +50,11 @@ static inline void pp_tun_free(pp_tun tun) {
 /* With manual file descriptor. */
 pp_tun pp_tun_retain(int fd);
 static inline void pp_tun_release(pp_tun tun) {
+#if PARTOUT_APPLE && !PARTOUT_MACOS
+    pp_tun_free_and_close(tun, true);
+#else
     pp_tun_free_and_close(tun, false);
+#endif
 }
 #endif
 

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -56,7 +56,7 @@ static inline int pp_tun_handle_result(int ret) {
 pp_tun _Nullable pp_tun_open(const char *uuid);
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len);
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len);
-void pp_tun_shutdown(const pp_tun tun);
+void pp_tun_close(const pp_tun tun);
 void pp_tun_free_and_close(pp_tun tun, bool and_close);
 
 static inline void pp_tun_release(pp_tun tun) {

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -35,10 +35,32 @@ struct sockaddr_ctl {
 /* Opaque tun device. */
 typedef struct __pp_tun_struct *pp_tun;
 
+/* Platform-specific implementations. */
+pp_tun _Nullable pp_tun_open(const char *uuid);
+int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len);
+int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len);
+void pp_tun_close(const pp_tun tun);
+void pp_tun_free_and_close(pp_tun tun, bool and_close);
+
+static inline void pp_tun_free(pp_tun tun) {
+    pp_tun_free_and_close(tun, true);
+}
+
 #if !PARTOUT_WINDOWS
 /* With manual file descriptor. */
-pp_tun pp_tun_create(int fd);
+pp_tun pp_tun_retain(int fd);
+static inline void pp_tun_release(pp_tun tun) {
+    pp_tun_free_and_close(tun, false);
+}
+#endif
 
+/* Return the file descriptor or -1 if none. */
+int pp_tun_fd(const pp_tun tun);
+
+/* Return the device name or NULL if none. */
+const char *_Nullable pp_tun_name(const pp_tun tun);
+
+/* Reusable cross-platform. */
 static inline int pp_tun_handle_result(int ret) {
     if (ret < 0) {
         if (PP_IO_WOULDBLOCK()) {
@@ -50,27 +72,6 @@ static inline int pp_tun_handle_result(int ret) {
     }
     return ret;
 }
-#endif
-
-/* Platform-specific implementations. */
-pp_tun _Nullable pp_tun_open(const char *uuid);
-int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len);
-int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len);
-void pp_tun_close(const pp_tun tun);
-void pp_tun_free_and_close(pp_tun tun, bool and_close);
-
-static inline void pp_tun_release(pp_tun tun) {
-    pp_tun_free_and_close(tun, false);
-}
-static inline void pp_tun_free(pp_tun tun) {
-    pp_tun_free_and_close(tun, true);
-}
-
-/* Return the file descriptor or -1 if none. */
-int pp_tun_fd(const pp_tun tun);
-
-/* Return the device name or NULL if none. */
-const char *_Nullable pp_tun_name(const pp_tun tun);
 
 /* Tunnel controller. */
 typedef struct {

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -64,7 +64,7 @@ struct __pp_socket_struct {
 
 /* Create a socket from a formerly opened file descriptor. Use uint64_t to
  * cover the whole range of possible platform values. */
-pp_socket pp_socket_create(uint64_t fd) {
+pp_socket pp_socket_retain(uint64_t fd) {
     pp_socket sock = pp_alloc(sizeof(*sock));
     sock->fd = (os_socket_fd)fd;
     return sock;
@@ -121,7 +121,7 @@ pp_socket pp_socket_open(const char *ip_addr,
             local_print_error("connect()");
             goto failure;
         }
-        return pp_socket_create(new_fd);
+        return pp_socket_retain(new_fd);
     }
 
     pp_zero(&hints, sizeof(hints));
@@ -185,7 +185,7 @@ pp_socket pp_socket_open(const char *ip_addr,
     }
 
     // Success
-    return pp_socket_create(new_fd);
+    return pp_socket_retain(new_fd);
 
 failure:
     if (!local_is_invalid_fd(new_fd)) local_close_fd(new_fd);

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -21,7 +21,7 @@ struct __pp_tun_struct {
     int fd;
 };
 
-pp_tun pp_tun_create(int fd) {
+pp_tun pp_tun_retain(int fd) {
     pp_tun tun = pp_alloc(sizeof(*tun));
     tun->fd = fd;
     return tun;

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -30,7 +30,7 @@ pp_tun pp_tun_create(int fd) {
 void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
     if (and_close) {
-        pp_tun_shutdown(tun);
+        pp_tun_close(tun);
     }
     pp_free(tun);
 }
@@ -49,7 +49,7 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     return pp_tun_handle_result(ret);
 }
 
-void pp_tun_shutdown(const pp_tun tun) {
+void pp_tun_close(const pp_tun tun) {
     if (!tun || tun->fd < 0) return;
     shutdown(tun->fd, SHUT_RDWR);
 }

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -26,7 +26,11 @@ struct __pp_tun_struct {
 
 pp_tun pp_tun_retain(int fd) {
     pp_tun tun = pp_alloc(sizeof(*tun));
+#if PARTOUT_MACOS
     tun->fd = fd;
+#else
+    tun->fd = dup(fd);
+#endif
     return tun;
 }
 

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -24,7 +24,7 @@ struct __pp_tun_struct {
     const char *dev_name;
 };
 
-pp_tun pp_tun_create(int fd) {
+pp_tun pp_tun_retain(int fd) {
     pp_tun tun = pp_alloc(sizeof(*tun));
     tun->fd = fd;
     return tun;

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -90,7 +90,7 @@ failure:
 void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
     if (and_close) {
-        pp_tun_shutdown(tun);
+        pp_tun_close(tun);
     }
     if (tun->dev_name) {
         pp_free((void *)tun->dev_name);
@@ -154,7 +154,7 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     return (int)src_len;
 }
 
-void pp_tun_shutdown(const pp_tun tun) {
+void pp_tun_close(const pp_tun tun) {
     if (!tun || tun->fd < 0) return;
     close(tun->fd);
     tun->fd = -1;

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -25,7 +25,7 @@ struct __pp_tun_struct {
     const char *dev_name;
 };
 
-pp_tun pp_tun_create(int fd) {
+pp_tun pp_tun_retain(int fd) {
     pp_tun tun = pp_alloc(sizeof(*tun));
     tun->fd = fd;
     return tun;

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -70,7 +70,7 @@ failure:
 void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
     if (and_close) {
-        pp_tun_shutdown(tun);
+        pp_tun_close(tun);
     }
     if (tun->dev_name) {
         pp_free((void *)tun->dev_name);
@@ -92,7 +92,7 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     return pp_tun_handle_result(ret);
 }
 
-void pp_tun_shutdown(const pp_tun tun) {
+void pp_tun_close(const pp_tun tun) {
     if (!tun || tun->fd < 0) return;
     close(tun->fd);
     tun->fd = -1;

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -134,7 +134,7 @@ failure:
 void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
     if (and_close) {
-        pp_tun_shutdown(tun);
+        pp_tun_close(tun);
         if (tun->adapter) {
             WintunCloseAdapter(tun->adapter);
         }
@@ -198,7 +198,7 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     return src_len;
 }
 
-void pp_tun_shutdown(const pp_tun tun) {
+void pp_tun_close(const pp_tun tun) {
     if (!tun || !tun->session) return;
     WintunEndSession(tun->session);
     tun->session = NULL;


### PR DESCRIPTION
Do not dup/close fds in the looper. Instead, use tun retain/release semantics and delegate dup/close to the OS implementation.

- iOS/tvOS: dup() is required on retain, therefore, remember to close() the duplicated fd on release (as per #457)
- Android: duplicating the VpnService.Builder fd is wrong instead, as closing the duplicated fd will not close the tun device properly, resulting in the persistent "key" icon

Rename:

- pp_tun_create to pp_tun_retain to balance with release
- pp_tun_shutdown to pp_tun_close because it was highly misleading