### PR TITLE
Windows: Build after normalizing file vs socket descriptors

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -5,26 +5,6 @@ set(OUTPUT_DIR ${PP_BUILD_OUTPUT}/partout)
 # Include file lists
 include("partout.cmake")
 
-# Partout_C ############################################
-
-# Base configuration
-add_library(partout_c STATIC "")
-target_compile_options(partout_c PRIVATE
-    -DUSE_CMAKE
-)
-
-# Header search paths from all C targets
-set(PARTOUT_C_INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}/MiniFoundation_C/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/PartoutCore_C/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/PartoutOpenVPNConnection_C/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/PartoutWireGuard_C/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/PartoutWireGuardConnection_C/include
-)
-if(WIN32)
-    list(APPEND PARTOUT_C_INCLUDE_DIRS ${PP_BUILD_OUTPUT}/wintun)
-endif()
-
 # Set up exclusions
 set(EXCLUDED_PATTERNS "")
 
@@ -58,11 +38,42 @@ if(PP_BUILD_USE_OPENVPN)
     if(NOT HAS_CRYPTO)
         message(FATAL_ERROR "OpenVPN requires a crypto vendor")
     endif()
+    list(APPEND PARTOUT_C_INCLUDE_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/PartoutOpenVPNConnection_C/include
+    )
 else()
-    list(APPEND EXCLUDED_PATTERNS PartoutOpenVPNConnection_C\/)
+    list(APPEND EXCLUDED_PATTERNS
+        PartoutOpenVPNConnection\/
+        PartoutOpenVPNConnection_C\/
+    )
 endif()
-if(NOT PP_BUILD_USE_WIREGUARD)
-    list(APPEND EXCLUDED_PATTERNS PartoutWireGuardConnection_C\/)
+if(PP_BUILD_USE_WIREGUARD)
+    list(APPEND PARTOUT_C_INCLUDE_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/PartoutWireGuardConnection_C/include
+    )
+else()
+    list(APPEND EXCLUDED_PATTERNS
+        PartoutWireGuardConnection\/
+        PartoutWireGuardConnection_C\/
+    )
+endif()
+
+# Partout_C ############################################
+
+# Base configuration
+add_library(partout_c STATIC "")
+target_compile_options(partout_c PRIVATE
+    -DUSE_CMAKE
+)
+
+# Header search paths from all C targets
+set(PARTOUT_C_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/MiniFoundation_C/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/PartoutCore_C/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/PartoutWireGuard_C/include
+)
+if(WIN32)
+    list(APPEND PARTOUT_C_INCLUDE_DIRS ${PP_BUILD_OUTPUT}/wintun)
 endif()
 
 # Account for exclusions in source files
@@ -97,7 +108,7 @@ if(USE_COMPAT)
     target_compile_options(partout PRIVATE
         -DMINIF_COMPAT
     )
-    set(EXCLUDED_PATTERNS
+    list(APPEND EXCLUDED_PATTERNS
         PartoutOpenVPNConnection\/V1
         PartoutOS\/Apple.*
         PartoutWireGuardConnection\/V1

--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -109,15 +109,18 @@ public final class NativeTunnelController: TunnelController, Sendable {
         return TunWrapper(ctx, tun: tun)
     }
 
-    public func configureSockets(with descriptors: [FileDescriptor]) throws {
+    public func configureSockets(with descriptors: [SocketDescriptor]) throws {
         let result = descriptors
             .withUnsafeBufferPointer { fds in
+                guard let fdsBase = fds.baseAddress else {
+                    return false
+                }
                 if let info = reachabilityInfo?.toCReachability {
-                    withUnsafePointer(to: info) { infoPtr in
-                        pp_tun_ctrl_configure_sockets(ref, infoPtr, fds.baseAddress, fds.count)
+                    return withUnsafePointer(to: info) { infoPtr in
+                        pp_tun_ctrl_configure_sockets(ref, infoPtr, fdsBase, fds.count)
                     }
                 } else {
-                    pp_tun_ctrl_configure_sockets(ref, nil, fds.baseAddress, fds.count)
+                    return pp_tun_ctrl_configure_sockets(ref, nil, fdsBase, fds.count)
                 }
             }
         guard result else {

--- a/Sources/PartoutCore/Connection/NativeSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/NativeSocketFactory.swift
@@ -151,7 +151,12 @@ final class SocketWrapper: @unchecked Sendable {
 
 extension SocketWrapper: LinkInterface {
     var fileDescriptor: FileDescriptor? {
+#if os(Windows)
+        // FIXME: ###, Get HANDLE from SOCKET
+        nil
+#else
         pp_socket_get_fd(socket)
+#endif
     }
 
     var remoteAddress: String {

--- a/Sources/PartoutCore/Connection/SocketConfigurator.swift
+++ b/Sources/PartoutCore/Connection/SocketConfigurator.swift
@@ -5,11 +5,11 @@
 /// Provides methods to configure sockets on a native platform.
 public final class SocketConfigurator: Sendable {
     public let reachability: @Sendable () -> ReachabilityInfo?
-    public let configureSocket: @Sendable (_ fd: FileDescriptor) -> Bool
+    public let configureSocket: @Sendable (_ fd: SocketDescriptor) -> Bool
 
     public init(
         reachability: @Sendable @escaping () -> ReachabilityInfo?,
-        configureSocket: @Sendable @escaping (_: FileDescriptor) -> Bool
+        configureSocket: @Sendable @escaping (_: SocketDescriptor) -> Bool
     ) {
         self.reachability = reachability
         self.configureSocket = configureSocket

--- a/Sources/PartoutCore/Connection/TunnelController.swift
+++ b/Sources/PartoutCore/Connection/TunnelController.swift
@@ -6,7 +6,7 @@
 public protocol TunnelController: AnyObject, Sendable {
     func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface
 
-    func configureSockets(with descriptors: [FileDescriptor]) throws
+    func configureSockets(with descriptors: [SocketDescriptor]) throws
 
     func reportSnapshot(_ snapshot: TunnelSnapshot)
 

--- a/Sources/PartoutCore/Logging/PPLog.swift
+++ b/Sources/PartoutCore/Logging/PPLog.swift
@@ -48,10 +48,14 @@ public func pp_clog(
     _ cLevel: Int,
     _ cMessage: UnsafePointer<CChar>
 ) {
+#if !os(Windows)
     let savedErrno = errno
+#endif
     let category = LoggerCategory(rawValue: String(cString: cCategory))
     let level = DebugLog.Level(rawValue: cLevel) ?? .info
     let message = String(cString: cMessage)
     pp_log_g(category, level, message)
+#if !os(Windows)
     errno = savedErrno
+#endif
 }

--- a/Sources/PartoutCore/Misc/FileDescriptor.swift
+++ b/Sources/PartoutCore/Misc/FileDescriptor.swift
@@ -4,8 +4,10 @@
 
 #if os(Windows)
 /// A native handle for a file descriptor.
-public typealias FileDescriptor = UInt64
+public typealias FileDescriptor = HANDLE
+public typealias SocketDescriptor = SOCKET
 #else
 /// A native handle for a file descriptor.
 public typealias FileDescriptor = Int32
+public typealias SocketDescriptor = FileDescriptor
 #endif

--- a/Sources/PartoutCore/Testing/MockTunnelController.swift
+++ b/Sources/PartoutCore/Testing/MockTunnelController.swift
@@ -15,7 +15,7 @@ public final class MockTunnelController: TunnelController, @unchecked Sendable {
         return MockTunnelInterface()
     }
 
-    public func configureSockets(with descriptors: [FileDescriptor]) {
+    public func configureSockets(with descriptors: [SocketDescriptor]) {
     }
 
     public func clearTunnelSettings(_ tunnel: IOInterface, withKillSwitch: Bool) async {

--- a/Sources/PartoutCore_C/common.c
+++ b/Sources/PartoutCore_C/common.c
@@ -16,7 +16,9 @@ pp_log_category PPLogCategoryCore = "core";
 void pp_clog_v(pp_log_category category,
                pp_log_level level,
                const char *fmt, ...) {
+#if !PARTOUT_WINDOWS
     const int saved_errno = errno;
+#endif
     va_list args;
     va_start(args, fmt);
     // Add 1 to include the null terminator
@@ -26,7 +28,9 @@ void pp_clog_v(pp_log_category category,
     va_end(args);
     pp_clog(category, level, msg);
     pp_free(msg);
+#if !PARTOUT_WINDOWS
     errno = saved_errno;
+#endif
 }
 
 #if PARTOUT_ANDROID

--- a/Sources/PartoutCore_C/common.c
+++ b/Sources/PartoutCore_C/common.c
@@ -117,29 +117,7 @@ void pp_log_simple_append(const char *tag, pp_log_level level, const char *messa
 }
 #endif
 
-#if PARTOUT_WINDOWS
-#include <winsock2.h>
-
-int pp_fd_set_nonblocking(pp_fd fd, int *original_flags) {
-    (void)original_flags;
-    u_long mode = 1;
-    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
-        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): set");
-        return -1;
-    }
-    return 0;
-}
-
-int pp_fd_restore_blocking(pp_fd fd, int original_flags) {
-    (void)original_flags;
-    u_long mode = 0;
-    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
-        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): restore");
-        return -1;
-    }
-    return 0;
-}
-#else
+#if !PARTOUT_WINDOWS
 #include <fcntl.h>
 
 int pp_fd_set_nonblocking(pp_fd fd, int *original_flags) {

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -116,11 +116,6 @@ extern const int PPIOErrorNoBufs;
 typedef _Nonnull HANDLE pp_fd;
 typedef SOCKET pp_socket_fd;
 
-#pragma clang assume_nonnull begin
-int pp_fd_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
-int pp_fd_restore_blocking(pp_socket_fd fd, int original_flags);
-#pragma clang assume_nonnull end
-
 #define PP_IO_RETRY(result, fn) \
     do { \
         do { \

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -113,7 +113,13 @@ extern const int PPIOErrorNoBufs;
 
 #if PARTOUT_WINDOWS
 #include <ws2tcpip.h>
-typedef SOCKET pp_fd;
+typedef _Nonnull HANDLE pp_fd;
+typedef SOCKET pp_socket_fd;
+
+#pragma clang assume_nonnull begin
+int pp_fd_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
+int pp_fd_restore_blocking(pp_socket_fd fd, int original_flags);
+#pragma clang assume_nonnull end
 
 #define PP_IO_RETRY(result, fn) \
     do { \
@@ -136,6 +142,12 @@ static inline bool PP_IO_NOBUFS(void) {
 #else
 #include <errno.h>
 typedef int pp_fd;
+typedef pp_fd pp_socket_fd;
+
+#pragma clang assume_nonnull begin
+int pp_fd_set_nonblocking(pp_fd fd, int *_Nullable original_flags);
+int pp_fd_restore_blocking(pp_fd fd, int original_flags);
+#pragma clang assume_nonnull end
 
 #define PP_IO_RETRY(result, fn) \
     do { \
@@ -156,11 +168,6 @@ static inline bool PP_IO_NOBUFS(void) {
     return errno == ENOBUFS;
 }
 #endif
-
-#pragma clang assume_nonnull begin
-int pp_fd_set_nonblocking(pp_fd fd, int *_Nullable original_flags);
-int pp_fd_restore_blocking(pp_fd fd, int original_flags);
-#pragma clang assume_nonnull end
 
 /* Android only. */
 

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -67,4 +67,9 @@ bool pp_socket_set_buffers(pp_socket sock,
 /* Universal file descriptor. */
 pp_socket_fd pp_socket_get_fd(pp_socket sock);
 
+#if PARTOUT_WINDOWS
+int pp_socket_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
+int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags);
+#endif
+
 #pragma clang assume_nonnull end

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -67,9 +67,8 @@ bool pp_socket_set_buffers(pp_socket sock,
 /* Universal file descriptor. */
 pp_socket_fd pp_socket_get_fd(pp_socket sock);
 
-#if PARTOUT_WINDOWS
+/* Tied to sockets on Windows. */
 int pp_socket_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
 int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags);
-#endif
 
 #pragma clang assume_nonnull end

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -40,7 +40,7 @@ static inline void pp_socket_free(pp_socket sock) {
 }
 
 /* Create a socket wrapper from an already open native descriptor. */
-pp_socket pp_socket_retain(pp_fd fd);
+pp_socket pp_socket_retain(pp_socket_fd fd);
 static inline void pp_socket_release(pp_socket sock) {
     pp_socket_free_and_close(sock, false);
 }
@@ -52,7 +52,7 @@ pp_socket _Nullable pp_socket_open(const char *ip_addr,
                                    bool blocking,
                                    int timeout_ms,
                                    const pp_reachability *_Nullable info,
-                                   bool (*_Nullable configure)(void *_Nullable ctx, pp_fd fd),
+                                   bool (*_Nullable configure)(void *_Nullable ctx, pp_socket_fd fd),
                                    void *_Nullable configure_ctx);
 
 /* I/O. Returns PPIOErrorWouldBlock when a non-blocking operation would block. */
@@ -65,6 +65,6 @@ bool pp_socket_set_buffers(pp_socket sock,
                            int sendbuf_len);
 
 /* Universal file descriptor. */
-pp_fd pp_socket_get_fd(pp_socket sock);
+pp_socket_fd pp_socket_get_fd(pp_socket sock);
 
 #pragma clang assume_nonnull end

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -91,7 +91,7 @@ pp_tun _Nullable pp_tun_ctrl_set_tunnel(void *_Nullable ref,
                                         const char *_Nullable info_json);
 bool pp_tun_ctrl_configure_sockets(void *_Nullable ref,
                                    const pp_reachability *_Nullable info,
-                                   const int *_Nullable fds,
+                                   const pp_socket_fd *_Nonnull fds,
                                    const size_t fds_len);
 void pp_tun_ctrl_report_snapshot(void *_Nullable ref,
                                  const char *snapshot_json);

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -27,20 +27,23 @@ typedef socklen_t os_socklen_t;
 #endif
 
 static bool local_platform_init(void);
-static pp_fd local_invalid_fd(void);
-static bool local_is_invalid_fd(pp_fd fd);
+static pp_socket_fd local_invalid_fd(void);
+static bool local_is_invalid_fd(pp_socket_fd fd);
 static void local_print_error(const char *msg);
 static void local_set_not_socket_error(void);
 static void local_set_timeout_error(void);
 static void local_set_reset_error(void);
 static void local_set_error(int err);
 static bool local_is_connect_pending(void);
-static int local_close_fd(pp_fd fd);
-static int local_shutdown_fd(pp_fd fd);
-static int local_recv_fd(pp_fd fd, void *dst, size_t dst_len);
-static int local_send_fd(pp_fd fd, const void *src, size_t src_len);
-static int local_select_nfds(pp_fd fd);
-static int local_connect_with_timeout(pp_fd fd,
+static int local_close_fd(pp_socket_fd fd);
+static int local_shutdown_fd(pp_socket_fd fd);
+static int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len);
+static int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len);
+static int local_select_nfds(pp_socket_fd fd);
+static int local_set_nonblocking(pp_socket_fd fd, int *original_flags);
+static int local_restore_blocking(pp_socket_fd fd, int original_flags);
+
+static int local_connect_with_timeout(pp_socket_fd fd,
                                       const struct sockaddr *addr,
                                       os_socklen_t addrlen,
                                       bool blocking,
@@ -54,14 +57,14 @@ static void local_close_impl(pp_socket sock);
 /* Host a file descriptor with the specific platform type. POSIX systems
  * use int, whereas Windows uses SOCKET.  */
 struct __pp_socket_struct {
-    pp_fd fd;
+    pp_socket_fd fd;
 };
 
 /* Create a socket from a formerly opened file descriptor. Use uint64_t to
  * cover the whole range of possible platform values. */
-pp_socket pp_socket_retain(pp_fd fd) {
+pp_socket pp_socket_retain(pp_socket_fd fd) {
     pp_socket sock = pp_alloc(sizeof(*sock));
-    sock->fd = (pp_fd)fd;
+    sock->fd = (pp_socket_fd)fd;
     return sock;
 }
 
@@ -74,13 +77,13 @@ pp_socket pp_socket_open(const char *ip_addr,
                          bool blocking,
                          int timeout_ms,
                          const pp_reachability *info,
-                         bool (*configure)(void *ctx, pp_fd fd),
+                         bool (*configure)(void *ctx, pp_socket_fd fd),
                          void *configure_ctx) {
     (void)info;
     int socktype = 0;
     struct addrinfo hints, *resolved = NULL;
     char port_str[16] = { 0 };
-    pp_fd new_fd = local_invalid_fd();
+    pp_socket_fd new_fd = local_invalid_fd();
     int ipproto = 0;
 
     if (!local_platform_init()) {
@@ -295,7 +298,7 @@ bool pp_socket_set_buffers(pp_socket sock, int recvbuf_len, int sendbuf_len) {
 }
 
 /* Return the native file descriptor. */
-pp_fd pp_socket_get_fd(const pp_socket sock) {
+pp_socket_fd pp_socket_get_fd(const pp_socket sock) {
     pp_assert(sock && !local_is_invalid_fd(sock->fd));
     return sock->fd;
 }
@@ -338,14 +341,14 @@ void local_close_impl(pp_socket sock) {
     sock->fd = local_invalid_fd();
 }
 
-int local_connect_with_timeout(pp_fd fd,
+int local_connect_with_timeout(pp_socket_fd fd,
                                const struct sockaddr *addr,
                                os_socklen_t addrlen,
                                bool blocking,
                                int timeout_ms) {
     // Set non-blocking
     int original_flags = 0;
-    if (pp_fd_set_nonblocking(fd, &original_flags) < 0) {
+    if (local_set_nonblocking(fd, &original_flags) < 0) {
         return -1;
     }
 
@@ -399,7 +402,7 @@ int local_connect_with_timeout(pp_fd fd,
 done:
     // Store/restore blocking mode as needed
     if (blocking) {
-        if (pp_fd_restore_blocking(fd, original_flags) < 0) {
+        if (local_restore_blocking(fd, original_flags) < 0) {
             return -1;
         }
     }
@@ -428,11 +431,11 @@ void local_print_error(const char *msg) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed with error %d", msg, WSAGetLastError());
 }
 
-pp_fd local_invalid_fd(void) {
+pp_socket_fd local_invalid_fd(void) {
     return INVALID_SOCKET;
 }
 
-bool local_is_invalid_fd(pp_fd fd) {
+bool local_is_invalid_fd(pp_socket_fd fd) {
     return fd == INVALID_SOCKET;
 }
 
@@ -457,24 +460,44 @@ bool local_is_connect_pending(void) {
     return err == WSAEWOULDBLOCK || err == WSAEINPROGRESS;
 }
 
-int local_close_fd(pp_fd fd) {
+int local_close_fd(pp_socket_fd fd) {
     return closesocket(fd);
 }
 
-int local_shutdown_fd(pp_fd fd) {
+int local_shutdown_fd(pp_socket_fd fd) {
     return shutdown(fd, SD_BOTH);
 }
 
-int local_recv_fd(pp_fd fd, void *dst, size_t dst_len) {
+int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len) {
     return (int)recv(fd, dst, (int)dst_len, 0);
 }
 
-int local_send_fd(pp_fd fd, const void *src, size_t src_len) {
+int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len) {
     return (int)send(fd, src, (int)src_len, 0);
 }
 
-int local_select_nfds(pp_fd fd) {
+int local_select_nfds(pp_socket_fd fd) {
     (void)fd;
+    return 0;
+}
+
+int local_set_nonblocking(pp_socket_fd fd, int *original_flags) {
+    (void)original_flags;
+    u_long mode = 1;
+    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): set");
+        return -1;
+    }
+    return 0;
+}
+
+int local_restore_blocking(pp_socket_fd fd, int original_flags) {
+    (void)original_flags;
+    u_long mode = 0;
+    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): restore");
+        return -1;
+    }
     return 0;
 }
 #else
@@ -486,11 +509,11 @@ void local_print_error(const char *msg) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed: %s", msg, strerror(errno));
 }
 
-pp_fd local_invalid_fd(void) {
+pp_socket_fd local_invalid_fd(void) {
     return -1;
 }
 
-bool local_is_invalid_fd(pp_fd fd) {
+bool local_is_invalid_fd(pp_socket_fd fd) {
     return fd == -1;
 }
 
@@ -514,23 +537,33 @@ bool local_is_connect_pending(void) {
     return errno == EINPROGRESS;
 }
 
-int local_close_fd(pp_fd fd) {
+int local_close_fd(pp_socket_fd fd) {
     return close(fd);
 }
 
-int local_shutdown_fd(pp_fd fd) {
+int local_shutdown_fd(pp_socket_fd fd) {
     return shutdown(fd, SHUT_RDWR);
 }
 
-int local_recv_fd(pp_fd fd, void *dst, size_t dst_len) {
+int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len) {
     return (int)read(fd, dst, dst_len);
 }
 
-int local_send_fd(pp_fd fd, const void *src, size_t src_len) {
+int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len) {
     return (int)write(fd, src, src_len);
 }
 
-int local_select_nfds(pp_fd fd) {
+int local_select_nfds(pp_socket_fd fd) {
     return fd + 1;
+}
+
+// pp_socket_fd == pp_fd in POSIX
+
+int local_set_nonblocking(pp_socket_fd fd, int *original_flags) {
+    return pp_fd_set_nonblocking(fd, original_flags);
+}
+
+int local_restore_blocking(pp_socket_fd fd, int original_flags) {
+    return pp_fd_restore_blocking(fd, original_flags);
 }
 #endif

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -40,8 +40,6 @@ static int local_shutdown_fd(pp_socket_fd fd);
 static int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len);
 static int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len);
 static int local_select_nfds(pp_socket_fd fd);
-static int local_set_nonblocking(pp_socket_fd fd, int *original_flags);
-static int local_restore_blocking(pp_socket_fd fd, int original_flags);
 
 static int local_connect_with_timeout(pp_socket_fd fd,
                                       const struct sockaddr *addr,
@@ -348,7 +346,7 @@ int local_connect_with_timeout(pp_socket_fd fd,
                                int timeout_ms) {
     // Set non-blocking
     int original_flags = 0;
-    if (local_set_nonblocking(fd, &original_flags) < 0) {
+    if (pp_socket_set_nonblocking(fd, &original_flags) < 0) {
         return -1;
     }
 
@@ -402,7 +400,7 @@ int local_connect_with_timeout(pp_socket_fd fd,
 done:
     // Store/restore blocking mode as needed
     if (blocking) {
-        if (local_restore_blocking(fd, original_flags) < 0) {
+        if (pp_socket_restore_blocking(fd, original_flags) < 0) {
             return -1;
         }
     }
@@ -481,7 +479,7 @@ int local_select_nfds(pp_socket_fd fd) {
     return 0;
 }
 
-int local_set_nonblocking(pp_socket_fd fd, int *original_flags) {
+int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
     (void)original_flags;
     u_long mode = 1;
     if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
@@ -491,7 +489,7 @@ int local_set_nonblocking(pp_socket_fd fd, int *original_flags) {
     return 0;
 }
 
-int local_restore_blocking(pp_socket_fd fd, int original_flags) {
+int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
     (void)original_flags;
     u_long mode = 0;
     if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
@@ -499,14 +497,6 @@ int local_restore_blocking(pp_socket_fd fd, int original_flags) {
         return -1;
     }
     return 0;
-}
-
-int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
-    return local_set_nonblocking(fd, original_flags);
-}
-
-int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
-    return local_restore_blocking(fd, original_flags);
 }
 
 #else
@@ -568,11 +558,11 @@ int local_select_nfds(pp_socket_fd fd) {
 
 // pp_socket_fd == pp_fd in POSIX
 
-int local_set_nonblocking(pp_socket_fd fd, int *original_flags) {
+int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
     return pp_fd_set_nonblocking(fd, original_flags);
 }
 
-int local_restore_blocking(pp_socket_fd fd, int original_flags) {
+int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
     return pp_fd_restore_blocking(fd, original_flags);
 }
 #endif

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -500,6 +500,15 @@ int local_restore_blocking(pp_socket_fd fd, int original_flags) {
     }
     return 0;
 }
+
+int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
+    return local_set_nonblocking(fd, original_flags);
+}
+
+int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
+    return local_restore_blocking(fd, original_flags);
+}
+
 #else
 bool local_platform_init(void) {
     return true;

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -193,7 +193,7 @@ cleanup:
 }
 
 bool pp_tun_ctrl_configure_sockets(void *jni_ref, const pp_reachability *info,
-                                   const int *fds, const size_t fds_len) {
+                                   const pp_socket_fd *fds, const size_t fds_len) {
     assert(jni_ref);
     pp_clog_v(PPLogCategoryCore, PPLogLevelDebug, "tun_android: ctrl_configure_sockets(%p)", jni_ref);
     if (!fds || fds_len == 0) return false;

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -188,7 +188,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
 }
 
 bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
-                                   const int *fds, const size_t fds_len) {
+                                   const pp_socket_fd *fds, const size_t fds_len) {
     (void)ref;
     (void)info;
     (void)fds;

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -122,7 +122,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
 }
 
 bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
-                                   const int *fds, const size_t fds_len) {
+                                   const pp_socket_fd *fds, const size_t fds_len) {
     (void)ref;
     (void)info;
     (void)fds;

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -229,7 +229,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
 }
 
 bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,
-                                   const int *fds, const size_t fds_len) {
+                                   const pp_socket_fd *fds, const size_t fds_len) {
     (void)ref;
     (void)info;
     (void)fds;

--- a/Sources/PartoutOS/AppleNE/Connection/NETunnelController.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NETunnelController.swift
@@ -61,7 +61,7 @@ public final class NETunnelController: TunnelController {
         return tun
     }
 
-    public func configureSockets(with descriptors: [FileDescriptor]) {
+    public func configureSockets(with descriptors: [SocketDescriptor]) {
     }
 
     public func clearTunnelSettings(_ tunnel: IOInterface, withKillSwitch: Bool) async {


### PR DESCRIPTION
Fix build issues caused by `pp_fd` and `pp_socket_fd` being different on Windows (HANDLE and SOCKET, respectively).

- Split non-blocking public API because on Windows, it only applies to SOCKET
- Fix types in socket configuration functions
- Do not save `errno`
- Fix OpenVPN/WireGuard exclusions in CMake

Remains to do: get a HANDLE from the SocketWrapper SOCKET.