### PR TITLE
Core: Wrap native I/O and socket errors

### DIFF
--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -845,7 +845,7 @@ private extension FdLooper {
         let code: Int32
 
         var debugDescription: String {
-            "wait: errno=\(code)"
+            "wait: last_error=\(code)"
         }
     }
 
@@ -871,7 +871,7 @@ private extension FdLooper {
             case .wouldBlock(let side): "\(side): would block"
             case .noBufSpace(let side): "\(side): no buffer space"
             case .eof(let side): "\(side): EOF"
-            case .libc(let side, let code): "\(side): libc errno=\(code)"
+            case .libc(let side, let code): "\(side): last_error=\(code)"
             case .user(let side, let reason): "\(side): user error, \(reason.debugDescription)"
             }
         }
@@ -1005,7 +1005,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.wouldBlock(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.libc(.link, errno)
+                    throw FdLooper.IOError.libc(.link, pp_io_last_error())
                 }
                 guard count > 0 else {
                     if closesOnEmptyRead {
@@ -1030,7 +1030,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.noBufSpace(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.libc(.link, errno)
+                    throw FdLooper.IOError.libc(.link, pp_io_last_error())
                 }
                 return Int(count)
             },
@@ -1059,7 +1059,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.wouldBlock(.tun)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.libc(.tun, errno)
+                    throw FdLooper.IOError.libc(.tun, pp_io_last_error())
                 }
                 guard count > 0 else {
                     return nil
@@ -1081,7 +1081,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.noBufSpace(.tun)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.libc(.tun, errno)
+                    throw FdLooper.IOError.libc(.tun, pp_io_last_error())
                 }
                 return Int(count)
             },

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -1005,7 +1005,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.wouldBlock(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.libc(.link, pp_io_last_error())
+                    throw FdLooper.IOError.libc(.link, pp_socket_last_error())
                 }
                 guard count > 0 else {
                     if closesOnEmptyRead {
@@ -1030,7 +1030,7 @@ private extension FdLooper.SideIO {
                     throw FdLooper.IOError.noBufSpace(.link)
                 }
                 guard count >= 0 else {
-                    throw FdLooper.IOError.libc(.link, pp_io_last_error())
+                    throw FdLooper.IOError.libc(.link, pp_socket_last_error())
                 }
                 return Int(count)
             },

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -112,7 +112,10 @@ extern const int PPIOErrorWouldBlock;
 extern const int PPIOErrorNoBufs;
 
 #if PARTOUT_WINDOWS
+
 #include <ws2tcpip.h>
+#pragma clang assume_nonnull begin
+
 typedef _Nonnull HANDLE pp_fd;
 typedef SOCKET pp_socket_fd;
 
@@ -123,26 +126,21 @@ typedef SOCKET pp_socket_fd;
         } while ((result) < 0 && WSAGetLastError() == WSAEINTR); \
     } while (0)
 
-static inline bool PP_IO_INTR(void) {
-    return WSAGetLastError() == WSAEINTR;
+static inline int pp_io_last_error(void) {
+    return GetLastError();
 }
+#pragma clang assume_nonnull end
 
-static inline bool PP_IO_WOULDBLOCK(void) {
-    return WSAGetLastError() == WSAEWOULDBLOCK;
-}
-
-static inline bool PP_IO_NOBUFS(void) {
-    return WSAGetLastError() == WSAENOBUFS;
-}
 #else
+
 #include <errno.h>
+#pragma clang assume_nonnull begin
+
 typedef int pp_fd;
 typedef pp_fd pp_socket_fd;
 
-#pragma clang assume_nonnull begin
 int pp_fd_set_nonblocking(pp_fd fd, int *_Nullable original_flags);
 int pp_fd_restore_blocking(pp_fd fd, int original_flags);
-#pragma clang assume_nonnull end
 
 #define PP_IO_RETRY(result, fn) \
     do { \
@@ -151,17 +149,19 @@ int pp_fd_restore_blocking(pp_fd fd, int original_flags);
         } while ((result) < 0 && errno == EINTR); \
     } while (0)
 
-static inline bool PP_IO_INTR(void) {
-    return errno == EINTR;
+static inline int pp_io_last_error(void) {
+    return errno;
 }
 
-static inline bool PP_IO_WOULDBLOCK(void) {
+static inline bool pp_io_wouldblock(void) {
     return errno == EAGAIN || errno == EWOULDBLOCK;
 }
 
-static inline bool PP_IO_NOBUFS(void) {
+static inline bool pp_io_nobufs(void) {
     return errno == ENOBUFS;
 }
+#pragma clang assume_nonnull end
+
 #endif
 
 /* Android only. */

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -71,4 +71,14 @@ pp_socket_fd pp_socket_get_fd(pp_socket sock);
 int pp_socket_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
 int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags);
 
+#if PARTOUT_WINDOWS
+static inline int pp_socket_last_error(void) {
+    return WSAGetLastError();
+}
+#else
+static inline int pp_socket_last_error(void) {
+    return errno;
+}
+#endif
+
 #pragma clang assume_nonnull end

--- a/Sources/PartoutCore_C/include/portable/socket_posix.h
+++ b/Sources/PartoutCore_C/include/portable/socket_posix.h
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+static inline bool local_platform_init(void) {
+    return true;
+}
+
+static inline void local_print_error(const char *msg) {
+    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed: %s", msg, strerror(errno));
+}
+
+static inline pp_socket_fd local_invalid_fd(void) {
+    return -1;
+}
+
+static inline bool local_is_invalid_fd(pp_socket_fd fd) {
+    return fd == -1;
+}
+
+static inline void local_set_not_socket_error(void) {
+    errno = EBADF;
+}
+
+static inline void local_set_timeout_error(void) {
+    errno = ETIMEDOUT;
+}
+
+static inline void local_set_reset_error(void) {
+    errno = EPIPE;
+}
+
+static inline void local_set_error(int err) {
+    errno = err;
+}
+
+static inline bool local_is_connect_pending(void) {
+    return errno == EINPROGRESS;
+}
+
+static inline int local_close_fd(pp_socket_fd fd) {
+    return close(fd);
+}
+
+static inline int local_shutdown_fd(pp_socket_fd fd) {
+    return shutdown(fd, SHUT_RDWR);
+}
+
+static inline int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len) {
+    return (int)read(fd, dst, dst_len);
+}
+
+static inline int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len) {
+    return (int)write(fd, src, src_len);
+}
+
+static inline int local_select_nfds(pp_socket_fd fd) {
+    return fd + 1;
+}
+
+static inline bool local_is_interrupted(void) {
+    return errno == EINTR;
+}
+
+static inline bool local_is_wouldblock(void) {
+    return errno == EAGAIN || errno == EWOULDBLOCK;
+}
+
+static inline bool local_is_nobufs(void) {
+    return errno == ENOBUFS;
+}
+
+// pp_socket_fd == pp_fd in POSIX
+
+int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
+    return pp_fd_set_nonblocking(fd, original_flags);
+}
+
+int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
+    return pp_fd_restore_blocking(fd, original_flags);
+}

--- a/Sources/PartoutCore_C/include/portable/socket_windows.h
+++ b/Sources/PartoutCore_C/include/portable/socket_windows.h
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+static inline bool local_platform_init(void) {
+    static int wsa_initialized = 0;
+    if (!wsa_initialized) {
+        WSADATA wsa;
+        if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+            local_print_error("WSAStartup()");
+            return false;
+        }
+        wsa_initialized = 1;
+    }
+    return true;
+}
+
+static inline void local_print_error(const char *msg) {
+    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed with error %d", msg, WSAGetLastError());
+}
+
+static inline pp_socket_fd local_invalid_fd(void) {
+    return INVALID_SOCKET;
+}
+
+static inline bool local_is_invalid_fd(pp_socket_fd fd) {
+    return fd == INVALID_SOCKET;
+}
+
+static inline void local_set_not_socket_error(void) {
+    WSASetLastError(WSAENOTSOCK);
+}
+
+static inline void local_set_timeout_error(void) {
+    WSASetLastError(WSAETIMEDOUT);
+}
+
+static inline void local_set_reset_error(void) {
+    WSASetLastError(WSAECONNRESET);
+}
+
+static inline void local_set_error(int err) {
+    WSASetLastError(err);
+}
+
+static inline bool local_is_connect_pending(void) {
+    const int err = WSAGetLastError();
+    return err == WSAEWOULDBLOCK || err == WSAEINPROGRESS;
+}
+
+static inline int local_close_fd(pp_socket_fd fd) {
+    return closesocket(fd);
+}
+
+static inline int local_shutdown_fd(pp_socket_fd fd) {
+    return shutdown(fd, SD_BOTH);
+}
+
+static inline int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len) {
+    return (int)recv(fd, dst, (int)dst_len, 0);
+}
+
+static inline int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len) {
+    return (int)send(fd, src, (int)src_len, 0);
+}
+
+static inline int local_select_nfds(pp_socket_fd fd) {
+    (void)fd;
+    return 0;
+}
+
+static inline bool local_is_interrupted(void) {
+    return WSAGetLastError() == WSAEINTR;
+}
+
+static inline bool local_is_wouldblock(void) {
+    return WSAGetLastError() == WSAEWOULDBLOCK;
+}
+
+static inline bool local_is_nobufs(void) {
+    return WSAGetLastError() == WSAENOBUFS;
+}
+
+int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
+    (void)original_flags;
+    u_long mode = 1;
+    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): set");
+        return -1;
+    }
+    return 0;
+}
+
+int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
+    (void)original_flags;
+    u_long mode = 0;
+    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
+        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): restore");
+        return -1;
+    }
+    return 0;
+}

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -64,18 +64,20 @@ int pp_tun_get_fd(const pp_tun tun);
 /* Return the device name or NULL if none. */
 const char *_Nullable pp_tun_name(const pp_tun tun);
 
-/* Reusable cross-platform. */
+#if !PARTOUT_WINDOWS
+/* Reusable with POSIX-like tun device. */
 static inline int pp_tun_handle_result(int ret) {
     if (ret < 0) {
-        if (PP_IO_WOULDBLOCK()) {
+        if (pp_io_wouldblock()) {
             return PPIOErrorWouldBlock;
         }
-        if (PP_IO_NOBUFS()) {
+        if (pp_io_nobufs()) {
             return PPIOErrorNoBufs;
         }
     }
     return ret;
 }
+#endif
 
 /* Tunnel controller. */
 typedef struct {

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -406,7 +406,7 @@ int pp_mux_wait(pp_mux mux, int *error_code) {
                 PP_IO_RETRY(ret, eventfd_read(mux->wake_fd, &value));
                 if (ret < 0) {
                     /* Fully drained */
-                    if (PP_IO_WOULDBLOCK()) break;
+                    if (pp_io_wouldblock()) break;
                     /* Unexpected error */
                     pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "pp_mux_wait eventfd_read() failed: errno=%d", errno);
                     return ret;

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -137,15 +137,17 @@ pp_socket pp_socket_open(const char *ip_addr,
 #endif
 
     snprintf(port_str, sizeof(port_str), "%u", port);
+    int ret;
 #if PARTOUT_ANDROID
     if (!info || info->network_handle <= 0) {
         local_print_error("android_getaddrinfofornetwork(): missing network handle");
         goto failure;
     }
-    if (android_getaddrinfofornetwork(info->network_handle, ip_addr, port_str, &hints, &resolved) != 0) {
+    ret = android_getaddrinfofornetwork(info->network_handle, ip_addr, port_str, &hints, &resolved)
 #else
-    if (getaddrinfo(ip_addr, port_str, &hints, &resolved) != 0) {
+    ret = getaddrinfo(ip_addr, port_str, &hints, &resolved);
 #endif
+    if (ret != 0) {
         local_print_error("getaddrinfo()");
         goto failure;
     }

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -149,7 +149,7 @@ pp_socket pp_socket_open(const char *ip_addr,
         local_print_error("android_getaddrinfofornetwork(): missing network handle");
         goto failure;
     }
-    ret = android_getaddrinfofornetwork(info->network_handle, ip_addr, port_str, &hints, &resolved)
+    ret = android_getaddrinfofornetwork(info->network_handle, ip_addr, port_str, &hints, &resolved);
 #else
     ret = getaddrinfo(ip_addr, port_str, &hints, &resolved);
 #endif

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -34,7 +34,6 @@ static void local_set_not_socket_error(void);
 static void local_set_timeout_error(void);
 static void local_set_reset_error(void);
 static void local_set_error(int err);
-static int local_last_error(void);
 static bool local_is_connect_pending(void);
 static int local_close_fd(pp_socket_fd fd);
 static int local_shutdown_fd(pp_socket_fd fd);

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -34,6 +34,7 @@ static void local_set_not_socket_error(void);
 static void local_set_timeout_error(void);
 static void local_set_reset_error(void);
 static void local_set_error(int err);
+static int local_last_error(void);
 static bool local_is_connect_pending(void);
 static int local_close_fd(pp_socket_fd fd);
 static int local_shutdown_fd(pp_socket_fd fd);
@@ -51,6 +52,12 @@ static bool local_parse_numeric_addr(const char *ip_addr,
                                      struct sockaddr_storage *addr,
                                      os_socklen_t *addrlen);
 static void local_close_impl(pp_socket sock);
+
+#if PARTOUT_WINDOWS
+#include "portable/socket_windows.h"
+#else
+#include "portable/socket_posix.h"
+#endif
 
 /* Host a file descriptor with the specific platform type. POSIX systems
  * use int, whereas Windows uses SOCKET.  */
@@ -221,7 +228,7 @@ int pp_socket_read(pp_socket sock, uint8_t *dst, size_t dst_len) {
 
     while (true) {
         const int read_len = local_recv_fd(sock->fd, dst, dst_len);
-        if (read_len < 0 && PP_IO_INTR()) {
+        if (read_len < 0 && local_is_interrupted()) {
             continue;
         }
         if (read_len < 0) {
@@ -229,7 +236,7 @@ int pp_socket_read(pp_socket sock, uint8_t *dst, size_t dst_len) {
              * for a message to arrive, unless the socket is nonblocking (see fcntl(2))
              * in which case the value -1 is returned and the external variable errno
              * set to EAGAIN. */
-            if (PP_IO_WOULDBLOCK()) {
+            if (local_is_wouldblock()) {
                 return PPIOErrorWouldBlock;
             }
             local_print_error("recv()");
@@ -253,13 +260,13 @@ int pp_socket_write(pp_socket sock, const uint8_t *src, size_t src_len) {
 
         const int written_len = local_send_fd(sock->fd, current_src, remaining);
         if (written_len < 0) {
-            if (PP_IO_INTR()) {
+            if (local_is_interrupted()) {
                 continue;
             }
-            if (PP_IO_WOULDBLOCK()) {
+            if (local_is_wouldblock()) {
                 return offset > 0 ? (int)offset : PPIOErrorWouldBlock;
             }
-            if (PP_IO_NOBUFS()) {
+            if (local_is_nobufs()) {
                 return offset > 0 ? (int)offset : PPIOErrorNoBufs;
             }
             local_print_error("send()");
@@ -359,7 +366,7 @@ int local_connect_with_timeout(pp_socket_fd fd,
         goto done;
     }
     // Tell real errors from non-blocking pending states
-    if (!local_is_connect_pending() && !PP_IO_INTR()) {
+    if (!local_is_connect_pending() && !local_is_interrupted()) {
         local_print_error("connect()");
         return -1;
     }
@@ -380,7 +387,7 @@ int local_connect_with_timeout(pp_socket_fd fd,
             local_set_timeout_error();
             return -2;  // Timeout
         } else if (ret < 0) {
-            if (PP_IO_INTR()) continue;
+            if (local_is_interrupted()) continue;
             local_print_error("select()");
             return -1;  // Select error
         }
@@ -410,161 +417,3 @@ done:
     // Success
     return 0;
 }
-
-/* OS-specific helpers. */
-
-#if PARTOUT_WINDOWS
-bool local_platform_init(void) {
-    static int wsa_initialized = 0;
-    if (!wsa_initialized) {
-        WSADATA wsa;
-        if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
-            local_print_error("WSAStartup()");
-            return false;
-        }
-        wsa_initialized = 1;
-    }
-    return true;
-}
-
-void local_print_error(const char *msg) {
-    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed with error %d", msg, WSAGetLastError());
-}
-
-pp_socket_fd local_invalid_fd(void) {
-    return INVALID_SOCKET;
-}
-
-bool local_is_invalid_fd(pp_socket_fd fd) {
-    return fd == INVALID_SOCKET;
-}
-
-void local_set_not_socket_error(void) {
-    WSASetLastError(WSAENOTSOCK);
-}
-
-void local_set_timeout_error(void) {
-    WSASetLastError(WSAETIMEDOUT);
-}
-
-void local_set_reset_error(void) {
-    WSASetLastError(WSAECONNRESET);
-}
-
-void local_set_error(int err) {
-    WSASetLastError(err);
-}
-
-bool local_is_connect_pending(void) {
-    const int err = WSAGetLastError();
-    return err == WSAEWOULDBLOCK || err == WSAEINPROGRESS;
-}
-
-int local_close_fd(pp_socket_fd fd) {
-    return closesocket(fd);
-}
-
-int local_shutdown_fd(pp_socket_fd fd) {
-    return shutdown(fd, SD_BOTH);
-}
-
-int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len) {
-    return (int)recv(fd, dst, (int)dst_len, 0);
-}
-
-int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len) {
-    return (int)send(fd, src, (int)src_len, 0);
-}
-
-int local_select_nfds(pp_socket_fd fd) {
-    (void)fd;
-    return 0;
-}
-
-int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
-    (void)original_flags;
-    u_long mode = 1;
-    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
-        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): set");
-        return -1;
-    }
-    return 0;
-}
-
-int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
-    (void)original_flags;
-    u_long mode = 0;
-    if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
-        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): restore");
-        return -1;
-    }
-    return 0;
-}
-
-#else
-bool local_platform_init(void) {
-    return true;
-}
-
-void local_print_error(const char *msg) {
-    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed: %s", msg, strerror(errno));
-}
-
-pp_socket_fd local_invalid_fd(void) {
-    return -1;
-}
-
-bool local_is_invalid_fd(pp_socket_fd fd) {
-    return fd == -1;
-}
-
-void local_set_not_socket_error(void) {
-    errno = EBADF;
-}
-
-void local_set_timeout_error(void) {
-    errno = ETIMEDOUT;
-}
-
-void local_set_reset_error(void) {
-    errno = EPIPE;
-}
-
-void local_set_error(int err) {
-    errno = err;
-}
-
-bool local_is_connect_pending(void) {
-    return errno == EINPROGRESS;
-}
-
-int local_close_fd(pp_socket_fd fd) {
-    return close(fd);
-}
-
-int local_shutdown_fd(pp_socket_fd fd) {
-    return shutdown(fd, SHUT_RDWR);
-}
-
-int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len) {
-    return (int)read(fd, dst, dst_len);
-}
-
-int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len) {
-    return (int)write(fd, src, src_len);
-}
-
-int local_select_nfds(pp_socket_fd fd) {
-    return fd + 1;
-}
-
-// pp_socket_fd == pp_fd in POSIX
-
-int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
-    return pp_fd_set_nonblocking(fd, original_flags);
-}
-
-int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
-    return pp_fd_restore_blocking(fd, original_flags);
-}
-#endif


### PR DESCRIPTION
- Expose last errors per platform (Windows has two)
- Replace errno with pp_io_last_error()
- Only expose pp_io_wouldblock() and pp_io_nobufs() on POSIX (reused by tun and mux)
- Split socket differences into files
- Replace in logs