### PR TITLE
Core: Return descriptor pairs from link and tun interfaces

### DIFF
--- a/Sources/Partout/NativeTunnelController.swift
+++ b/Sources/Partout/NativeTunnelController.swift
@@ -81,7 +81,7 @@ public final class NativeTunnelController: TunnelController, Sendable {
 #endif
     }
 
-    public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface {
+    public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> TunInterface {
         guard let info else {
             throw PartoutError(.notFound)
         }
@@ -346,7 +346,11 @@ struct TunnelRemoteInfoWrapper: Encodable, Sendable {
     }
 }
 
-final class DummyTunnelInterface: IOInterface {
+final class DummyTunnelInterface: TunInterface {
+    var ioDescriptor: Any? {
+        nil
+    }
+
     func readPackets() async throws -> [Data] {
         []
     }

--- a/Sources/Partout/TunWrapper.swift
+++ b/Sources/Partout/TunWrapper.swift
@@ -24,18 +24,15 @@ final class TunWrapper: @unchecked Sendable {
     }
 }
 
-extension TunWrapper: IOInterface {
-    var fileDescriptor: FileDescriptor? {
-#if os(Windows)
-        nil
-#else
-        let fd = pp_tun_get_fd(tun)
-        guard fd >= 0 else {
-            assertionFailure("Invalid fd")
-            return nil
-        }
+extension TunWrapper: TunInterface {
+    var ioDescriptor: Any? {
+        tun
+    }
+
+    var muxDescriptor: FileDescriptor? {
+        let fd = pp_tun_get_watch_fd(tun)
+        guard pp_fd_is_valid(fd) else { return nil }
         return fd
-#endif
     }
 
     func readPackets() async throws -> [Data] {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -23,23 +23,25 @@ public final class FdLooper: @unchecked Sendable {
     public typealias OnFinish = @Sendable (_ error: Error?) -> Void
 
     public struct AttachArguments: Sendable {
-        public let side: Side
-        public let fd: FileDescriptor
+        public enum DescriptorPair: @unchecked Sendable {
+            case link(FileDescriptor, SocketDescriptor)
+            case tun(FileDescriptor, Any)
+        }
+
+        public let pair: DescriptorPair
         public let closesOnEmptyRead: Bool
         public let transformWrite: TransformWrite?
         public let onRead: OnRead?
         public let onFailure: OnFailure?
 
         public init(
-            side: Side,
-            fd: FileDescriptor,
+            pair: DescriptorPair,
             closesOnEmptyRead: Bool,
             transformWrite: TransformWrite?,
             onRead: OnRead?,
             onFailure: OnFailure?
         ) {
-            self.side = side
-            self.fd = fd
+            self.pair = pair
             self.closesOnEmptyRead = closesOnEmptyRead
             self.transformWrite = transformWrite
             self.onRead = onRead
@@ -83,7 +85,7 @@ public final class FdLooper: @unchecked Sendable {
     ) throws {
         guard let newMux = pp_mux_create(Int32(Self.numberOfDescriptors)) else {
             pp_log(ctx, .core, .fault, "Unable to create mux")
-            throw PartoutError(.muxFailure)
+            throw MuxError(side: nil)
         }
 
         self.ctx = ctx
@@ -176,7 +178,7 @@ public final class FdLooper: @unchecked Sendable {
 
                 do {
                     // Handle commands on wake signal (true = continue)
-                    guard try handleCommands() else {
+                    guard try handleCommands(fdSet: fdSet) else {
                         pp_log(.global, .core, .info, "Looper: stop requested")
                         break
                     }
@@ -432,7 +434,7 @@ private extension FdLooper {
         case detach(CheckedContinuation<Void, Never>)
     }
 
-    func handleCommands() throws -> Bool {
+    func handleCommands(fdSet: FdSet) throws -> Bool {
         lock.lock()
         let pendingCommands = commands
         commands.removeAll(keepingCapacity: true)
@@ -447,7 +449,7 @@ private extension FdLooper {
             case .enableRead(let side, let id):
                 handleEnableRead(side, id: id)
             case .enableWrite(let side, let id):
-                handleEnableWrite(side, id: id)
+                handleEnableWrite(side, id: id, fdSet: fdSet)
             case .custom(let body):
                 lock.unlock()
                 try body()
@@ -688,8 +690,8 @@ private extension FdLooper {
         continuation: CheckedContinuation<Void, Error>,
         results: inout [CommandResult]
     ) {
-        switch arguments.side {
-        case .link:
+        switch arguments.pair {
+        case .link(let linkFd, let socketFd):
             // Cancel attach if stopping
             guard state != .stopping else {
                 results.append(.attach(continuation, .failure(CancellationError())))
@@ -700,15 +702,9 @@ private extension FdLooper {
                 results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
                 break
             }
-            let linkFd = arguments.fd
-            guard pp_fd_set_nonblocking(linkFd, nil) == 0 else {
-                pp_log(ctx, .core, .fault, "Unable to set link non-blocking mode")
-                results.append(.attach(continuation, .failure(PartoutError(.muxFailure, linkFd))))
-                break
-            }
             guard pp_mux_add(mux, linkFd) else {
-                pp_log(ctx, .core, .fault, "Unable to attach link")
-                results.append(.attach(continuation, .failure(PartoutError(.muxFailure, linkFd))))
+                pp_log(ctx, .core, .fault, "Unable to attach link (fd=\(linkFd))")
+                results.append(.attach(continuation, .failure(MuxError(side: .link))))
                 break
             }
             pp_log(ctx, .core, .info, "Attach link (fd=\(linkFd))")
@@ -717,11 +713,12 @@ private extension FdLooper {
             link = SideIO(
                 mux: mux,
                 linkFd: linkFd,
+                socketFd: socketFd,
                 readBufSize: linkBufSize,
                 arguments: arguments
             )
             results.append(.attach(continuation, .success(())))
-        case .tun:
+        case .tun(let tunFd, let ioFd):
             // Cancel attach if stopping
             guard state != .stopping else {
                 results.append(.attach(continuation, .failure(CancellationError())))
@@ -732,27 +729,28 @@ private extension FdLooper {
                 results.append(.attach(continuation, .failure(PartoutError(.operationCancelled))))
                 break
             }
-            let tunFd = arguments.fd
-            guard pp_fd_set_nonblocking(tunFd, nil) == 0 else {
-                pp_log(ctx, .core, .fault, "Unable to set tun non-blocking mode")
-                results.append(.attach(continuation, .failure(PartoutError(.muxFailure, tunFd))))
-                break
-            }
             guard pp_mux_add(mux, tunFd) else {
-                pp_log(ctx, .core, .fault, "Unable to attach tun")
-                results.append(.attach(continuation, .failure(PartoutError(.muxFailure, tunFd))))
+                pp_log(ctx, .core, .fault, "Unable to attach tun (fd=\(tunFd))")
+                results.append(.attach(continuation, .failure(MuxError(side: .tun))))
                 break
             }
             pp_log(ctx, .core, .info, "Attach tun (fd=\(tunFd))")
 
             // Create new side
-            tun = SideIO(
-                mux: mux,
-                tunFd: tunFd,
-                readBufSize: tunBufSize,
-                arguments: arguments
-            )
-            results.append(.attach(continuation, .success(())))
+            do {
+                tun = try SideIO(
+                    mux: mux,
+                    tunFd: tunFd,
+                    ioFd: ioFd,
+                    readBufSize: tunBufSize,
+                    arguments: arguments
+                )
+                results.append(.attach(continuation, .success(())))
+            } catch {
+                pp_log(ctx, .core, .fault, "Unable to retain tun: \(error)")
+                pp_mux_delete(mux, tunFd)
+                results.append(.attach(continuation, .failure(MuxError(side: .tun))))
+            }
         }
     }
 
@@ -799,7 +797,7 @@ private extension FdLooper {
         }
     }
 
-    func handleEnableWrite(_ side: Side, id: UUID?) {
+    func handleEnableWrite(_ side: Side, id: UUID?, fdSet: FdSet) {
         if let id {
             guard !isOutdated(id, side: side) else {
                 return
@@ -809,12 +807,14 @@ private extension FdLooper {
         case .link:
             if let link {
                 pp_mux_set_write(mux, link.fd, true)
+                fdSet.writable.insert(link.fd)
             } else {
                 pp_log(ctx, .core, .error, "Ignoring enableWrite(.link), not attached")
             }
         case .tun:
             if let tun {
                 pp_mux_set_write(mux, tun.fd, true)
+                fdSet.writable.insert(tun.fd)
             } else {
                 pp_log(ctx, .core, .error, "Ignoring enableWrite(.tun), not attached")
             }
@@ -841,6 +841,10 @@ private final class FdSet {
 // MARK: - SideIO
 
 private extension FdLooper {
+    struct MuxError: Error {
+        let side: Side?
+    }
+
     struct WaitError: Error, CustomDebugStringConvertible {
         let code: Int32
 
@@ -989,10 +993,11 @@ private extension FdLooper.SideIO {
     convenience init(
         mux: pp_mux,
         linkFd: FileDescriptor,
+        socketFd: SocketDescriptor,
         readBufSize: Int,
         arguments: FdLooper.AttachArguments
     ) {
-        let linkHandle = pp_socket_retain(linkFd)
+        let socketHandle = pp_socket_retain(socketFd)
         let closesOnEmptyRead = arguments.closesOnEmptyRead
         self.init(
             side: .link,
@@ -1000,7 +1005,7 @@ private extension FdLooper.SideIO {
             readBufSize: readBufSize,
             arguments: arguments,
             read: { buf in
-                let count = pp_socket_read(linkHandle, &buf, buf.count)
+                let count = pp_socket_read(socketHandle, &buf, buf.count)
                 guard count != PPIOErrorWouldBlock else {
                     throw FdLooper.IOError.wouldBlock(.link)
                 }
@@ -1018,7 +1023,7 @@ private extension FdLooper.SideIO {
             write: { pending in
                 let count = pending.data.withUnsafeBytes {
                     pp_socket_write(
-                        linkHandle,
+                        socketHandle,
                         $0.bytePointer + pending.offset,
                         pending.count
                     )
@@ -1036,7 +1041,7 @@ private extension FdLooper.SideIO {
             },
             cleanup: {
                 pp_mux_delete(mux, linkFd)
-                pp_socket_release(linkHandle)
+                pp_socket_release(socketHandle)
             }
         )
     }
@@ -1044,10 +1049,14 @@ private extension FdLooper.SideIO {
     convenience init(
         mux: pp_mux,
         tunFd: FileDescriptor,
+        ioFd: Any,
         readBufSize: Int,
         arguments: FdLooper.AttachArguments
-    ) {
-        let tunHandle = pp_tun_retain(tunFd)
+    ) throws {
+        guard let ctrlTun = ioFd as? pp_tun else {
+            throw PartoutError(.tunNotAvailable)
+        }
+        let tunHandle = pp_tun_retain(ctrlTun)
         self.init(
             side: .tun,
             fd: tunFd,

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -989,6 +989,34 @@ private extension FdLooper {
 
 // MARK: - Link/Tun initializers
 
+extension LinkInterface {
+    public var descriptorPair: FdLooper.AttachArguments.DescriptorPair? {
+        guard let muxDescriptor else {
+            pp_log_g(.core, .fault, "LinkInterface has no .muxDescriptor")
+            return nil
+        }
+        guard let socketDescriptor else {
+            pp_log_g(.core, .fault, "LinkInterface has no .socketDescriptor")
+            return nil
+        }
+        return .link(muxDescriptor, socketDescriptor)
+    }
+}
+
+extension TunInterface {
+    public var descriptorPair: FdLooper.AttachArguments.DescriptorPair? {
+        guard let muxDescriptor else {
+            pp_log_g(.core, .fault, "TunInterface has no .muxDescriptor")
+            return nil
+        }
+        guard let ioDescriptor else {
+            pp_log_g(.core, .fault, "TunInterface has no .ioDescriptor")
+            return nil
+        }
+        return .tun(muxDescriptor, ioDescriptor)
+    }
+}
+
 private extension FdLooper.SideIO {
     convenience init(
         mux: pp_mux,

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -1081,6 +1081,7 @@ private extension FdLooper.SideIO {
         readBufSize: Int,
         arguments: FdLooper.AttachArguments
     ) throws {
+        // FIXME: ###, Assume pp_tun (private type)
         guard let ctrlTun = ioFd as? pp_tun else {
             throw PartoutError(.tunNotAvailable)
         }

--- a/Sources/PartoutCore/Connection/IOInterface.swift
+++ b/Sources/PartoutCore/Connection/IOInterface.swift
@@ -8,11 +8,13 @@ public protocol IOInterface: AnyObject, Sendable {
     var muxDescriptor: FileDescriptor? { get }
 
     /// Reads packets from the interface.
+    @available(*, deprecated, message: "Use FdLooper")
     func readPackets() async throws -> [Data]
 
     /// Writes packets to the interface.
     ///
     /// - Parameter packets: The packets to write.
+    @available(*, deprecated, message: "Use FdLooper")
     func writePackets(_ packets: [Data]) async throws
 }
 

--- a/Sources/PartoutCore/Connection/IOInterface.swift
+++ b/Sources/PartoutCore/Connection/IOInterface.swift
@@ -5,7 +5,7 @@
 /// Represents an I/O interface able to read and write data.
 public protocol IOInterface: AnyObject, Sendable {
     /// The file descriptor, if available.
-    var fileDescriptor: FileDescriptor? { get }
+    var muxDescriptor: FileDescriptor? { get }
 
     /// Reads packets from the interface.
     func readPackets() async throws -> [Data]
@@ -17,7 +17,7 @@ public protocol IOInterface: AnyObject, Sendable {
 }
 
 extension IOInterface {
-    public var fileDescriptor: FileDescriptor? {
+    public var muxDescriptor: FileDescriptor? {
         nil
     }
 }

--- a/Sources/PartoutCore/Connection/LinkInterface.swift
+++ b/Sources/PartoutCore/Connection/LinkInterface.swift
@@ -4,6 +4,9 @@
 
 /// Represents a specific I/O interface meant to work at the link layer (e.g. TCP/IP).
 public protocol LinkInterface: IOInterface {
+    /// The socket descriptor, if available.
+    var socketDescriptor: SocketDescriptor? { get }
+
     /// The link description.
     nonisolated var linkDescription: String { get }
 
@@ -24,6 +27,10 @@ public protocol LinkInterface: IOInterface {
 }
 
 extension LinkInterface {
+    public var socketDescriptor: SocketDescriptor? {
+        nil
+    }
+
     /// The link type (UDP/TCP).
     public var linkType: IPSocketType {
         remoteProtocol.socketType

--- a/Sources/PartoutCore/Connection/NativeSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/NativeSocketFactory.swift
@@ -142,15 +142,24 @@ final class SocketWrapper: @unchecked Sendable {
             }
         }
 #if os(Windows)
-        guard let handle = WSACreateEvent() else {
-            throw PartoutError(.fdUnavailable)
-        }
-        guard WSAEventSelect(
-            pp_socket_get_fd(socket),
-            handle,
-            FD_READ | FD_WRITE | FD_CLOSE
-        ) == 0 else {
-            throw PartoutError(.linkNotActive)
+        let handle = WSACreateEvent()
+        do {
+            guard let handle else {
+                throw PartoutError(.fdUnavailable)
+            }
+            guard WSAEventSelect(
+                pp_socket_get_fd(socket),
+                handle,
+                FD_READ | FD_WRITE | FD_CLOSE
+            ) == 0 else {
+                throw PartoutError(.linkNotActive)
+            }
+        } catch {
+            if let handle {
+                WSACloseEvent(handle)
+            }
+            pp_socket_free(socket)
+            throw error
         }
         self.handle = handle
 #endif

--- a/Sources/PartoutCore/Connection/NativeSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/NativeSocketFactory.swift
@@ -88,6 +88,9 @@ final class SocketWrapper: @unchecked Sendable {
     private let ctx: PartoutLoggerContext
     let socket: pp_socket
     private let options: Options
+#if os(Windows)
+    private let handle: FileDescriptor
+#endif
 
     init(_ ctx: PartoutLoggerContext, options: Options) async throws {
         let socket: pp_socket = try await withCheckedThrowingContinuation { continuation in
@@ -138,6 +141,19 @@ final class SocketWrapper: @unchecked Sendable {
                 continuation.resume(returning: newSock)
             }
         }
+#if os(Windows)
+        guard let handle = WSACreateEvent() else {
+            throw PartoutError(.fdUnavailable)
+        }
+        guard WSAEventSelect(
+            pp_socket_get_fd(socket),
+            handle,
+            FD_READ | FD_WRITE | FD_CLOSE
+        ) == 0 else {
+            throw PartoutError(.linkNotActive)
+        }
+        self.handle = handle
+#endif
         self.ctx = ctx
         self.socket = socket
         self.options = options
@@ -145,18 +161,24 @@ final class SocketWrapper: @unchecked Sendable {
 
     deinit {
         pp_log(ctx, .core, .debug, "Deinit SocketWrapper")
+#if os(Windows)
+        WSACloseEvent(handle)
+#endif
         pp_socket_free(socket)
     }
 }
 
 extension SocketWrapper: LinkInterface {
-    var fileDescriptor: FileDescriptor? {
+    var muxDescriptor: FileDescriptor? {
 #if os(Windows)
-        // FIXME: ###, Get HANDLE from SOCKET
-        nil
+        handle
 #else
-        pp_socket_get_fd(socket)
+        socketDescriptor
 #endif
+    }
+
+    var socketDescriptor: SocketDescriptor? {
+        pp_socket_get_fd(socket)
     }
 
     var remoteAddress: String {

--- a/Sources/PartoutCore/Connection/TunInterface.swift
+++ b/Sources/PartoutCore/Connection/TunInterface.swift
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+/// Represents a specific I/O interface meant to work at a L3 virtual tun layer.
+public protocol TunInterface: IOInterface {
+    var ioDescriptor: Any? { get }
+}

--- a/Sources/PartoutCore/Connection/TunnelController.swift
+++ b/Sources/PartoutCore/Connection/TunnelController.swift
@@ -4,7 +4,7 @@
 
 /// Abstracts tunnel configuration.
 public protocol TunnelController: AnyObject, Sendable {
-    func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface
+    func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> TunInterface
 
     func configureSockets(with descriptors: [SocketDescriptor]) throws
 

--- a/Sources/PartoutCore/Docs.docc/StartingTunnel.md
+++ b/Sources/PartoutCore/Docs.docc/StartingTunnel.md
@@ -53,6 +53,7 @@ Given the main app and the daemon:
 - ``IOInterface``
 - ``LinkInterface``
 - ``LinkObserver``
+- ``TunInterface``
 
 ### Applying network settings
 

--- a/Sources/PartoutCore/Partout+Core.swift
+++ b/Sources/PartoutCore/Partout+Core.swift
@@ -99,9 +99,6 @@ extension PartoutError.Code {
     /// Link device is not active.
     public static let linkNotActive = Self("linkNotActive")
 
-    /// Multiplexer failure.
-    public static let muxFailure = Self("muxFailure")
-
     /// Network changed.
     public static let networkChanged = Self("networkChanged")
 

--- a/Sources/PartoutCore/Testing/MockTunnelController.swift
+++ b/Sources/PartoutCore/Testing/MockTunnelController.swift
@@ -10,7 +10,7 @@ public final class MockTunnelController: TunnelController, @unchecked Sendable {
     public init() {
     }
 
-    public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface {
+    public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> TunInterface {
         try await onSetTunnelSettings(info)
         return MockTunnelInterface()
     }

--- a/Sources/PartoutCore/Testing/MockTunnelInterface.swift
+++ b/Sources/PartoutCore/Testing/MockTunnelInterface.swift
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-public final class MockTunnelInterface: IOInterface {
+public final class MockTunnelInterface: TunInterface {
     public init() {
+    }
+
+    public var ioDescriptor: Any? {
+        nil
     }
 
     public func readPackets() async throws -> [Data] {

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -119,6 +119,10 @@ extern const int PPIOErrorNoBufs;
 typedef _Nonnull HANDLE pp_fd;
 typedef SOCKET pp_socket_fd;
 
+static inline bool pp_fd_is_valid(pp_fd fd) {
+    return fd != INVALID_HANDLE_VALUE;
+}
+
 #define PP_IO_RETRY(result, fn) \
     do { \
         do { \
@@ -138,6 +142,10 @@ static inline int pp_io_last_error(void) {
 
 typedef int pp_fd;
 typedef pp_fd pp_socket_fd;
+
+static inline bool pp_fd_is_valid(pp_fd fd) {
+    return fd != -1;
+}
 
 int pp_fd_set_nonblocking(pp_fd fd, int *_Nullable original_flags);
 int pp_fd_restore_blocking(pp_fd fd, int original_flags);

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -9,7 +9,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <errno.h>
 #include "portable/common.h"
 #include "portable/socket.h"
 
@@ -46,9 +45,8 @@ static inline void pp_tun_free(pp_tun tun) {
     pp_tun_free_and_close(tun, true);
 }
 
-#if !PARTOUT_WINDOWS
 /* With manual file descriptor. */
-pp_tun pp_tun_retain(int fd);
+pp_tun pp_tun_retain(pp_tun other);
 static inline void pp_tun_release(pp_tun tun) {
 #if PARTOUT_APPLE && !PARTOUT_MACOS
     pp_tun_free_and_close(tun, true);
@@ -56,10 +54,9 @@ static inline void pp_tun_release(pp_tun tun) {
     pp_tun_free_and_close(tun, false);
 #endif
 }
-#endif
 
-/* Return the file descriptor or -1 if none. */
-int pp_tun_get_fd(const pp_tun tun);
+/* Return the file descriptor. Check result with pp_fd_is_valid(). */
+pp_fd pp_tun_get_watch_fd(const pp_tun tun);
 
 /* Return the device name or NULL if none. */
 const char *_Nullable pp_tun_name(const pp_tun tun);

--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -18,12 +18,13 @@
 #include <sys/socket.h>
 
 struct __pp_tun_struct {
-    int fd;
+    pp_fd fd;
 };
 
-pp_tun pp_tun_retain(int fd) {
+pp_tun pp_tun_retain(pp_tun other) {
+    pp_assert(other);
     pp_tun tun = pp_alloc(sizeof(*tun));
-    tun->fd = fd;
+    tun->fd = other->fd;
     return tun;
 }
 
@@ -54,7 +55,7 @@ void pp_tun_close(const pp_tun tun) {
     shutdown(tun->fd, SHUT_RDWR);
 }
 
-int pp_tun_get_fd(const pp_tun tun) {
+pp_fd pp_tun_get_watch_fd(const pp_tun tun) {
     if (!tun) return -1;
     return tun->fd;
 }

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -20,16 +20,17 @@
 #include "portable/endian.h"
 
 struct __pp_tun_struct {
-    int fd;
+    pp_fd fd;
     const char *dev_name;
 };
 
-pp_tun pp_tun_retain(int fd) {
+pp_tun pp_tun_retain(pp_tun other) {
+    pp_assert(other);
     pp_tun tun = pp_alloc(sizeof(*tun));
 #if PARTOUT_MACOS
-    tun->fd = fd;
+    tun->fd = other->fd;
 #else
-    tun->fd = dup(fd);
+    tun->fd = dup(other->fd);
 #endif
     return tun;
 }
@@ -164,7 +165,7 @@ void pp_tun_close(const pp_tun tun) {
     tun->fd = -1;
 }
 
-int pp_tun_get_fd(const pp_tun tun) {
+pp_fd pp_tun_get_watch_fd(const pp_tun tun) {
     if (!tun) return -1;
     return tun->fd;
 }
@@ -184,7 +185,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     (void)uuid;
     (void)info_json;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_darwin: ctrl_set_tunnel(%p)", ref);
-    return NULL;
+    return pp_tun_open(uuid);
 }
 
 bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -21,13 +21,15 @@
 #include <sys/unistd.h>
 
 struct __pp_tun_struct {
-    int fd;
+    pp_fd fd;
     const char *dev_name;
 };
 
-pp_tun pp_tun_retain(int fd) {
+pp_tun pp_tun_retain(pp_tun other) {
+    pp_assert(other);
     pp_tun tun = pp_alloc(sizeof(*tun));
-    tun->fd = fd;
+    tun->fd = other->fd;
+    tun->dev_name = pp_dup(other->dev_name);
     return tun;
 }
 
@@ -98,7 +100,7 @@ void pp_tun_close(const pp_tun tun) {
     tun->fd = -1;
 }
 
-int pp_tun_get_fd(const pp_tun tun) {
+pp_fd pp_tun_get_watch_fd(const pp_tun tun) {
     if (!tun) return -1;
     return tun->fd;
 }
@@ -118,7 +120,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     (void)uuid;
     (void)info_json;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_linux: ctrl_set_tunnel(%p)", ref);
-    return NULL;
+    return pp_tun_open(uuid);
 }
 
 bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -69,7 +69,7 @@ pp_tun pp_tun_retain(pp_tun other) {
     pp_tun tun = pp_alloc(sizeof(*tun));
     tun->name = pp_dup(other->name);
     tun->wname = _wcsdup(other->wname); // Can fail
-    // FIXME: ###, Are handles thread-safe?
+    // FIXME: ###, Sharing these is unsafe and prone to dangling pointers
     tun->adapter = other->adapter;
     tun->session = other->session;
     return tun;

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -17,7 +17,8 @@
 // FIXME: #188, convert debug messages to logs
 
 struct __pp_tun_struct {
-    LPWSTR name;
+    const char *name;
+    LPWSTR wname;
     WINTUN_ADAPTER_HANDLE adapter;
     WINTUN_SESSION_HANDLE session;
 };
@@ -63,12 +64,23 @@ GUID guid_from_wstring(const wchar_t *wstr) {
     return guid;
 }
 
+pp_tun pp_tun_retain(pp_tun other) {
+    pp_assert(other);
+    pp_tun tun = pp_alloc(sizeof(*tun));
+    tun->name = pp_dup(other->name);
+    tun->wname = _wcsdup(other->wname); // Can fail
+    // FIXME: ###, Are handles thread-safe?
+    tun->adapter = other->adapter;
+    tun->session = other->session;
+    return tun;
+}
+
 pp_tun pp_tun_open(const char *uuid) {
     if (!uuid) return NULL;
     WINTUN_ADAPTER_HANDLE adapter = NULL;
     WINTUN_SESSION_HANDLE session = NULL;
     LPCWSTR tun_type = NULL;
-    LPCWSTR dev_name = NULL;
+    LPWSTR dev_name = NULL;
 
     // Load DLL before anything (do it once)
     if (!wintun) {
@@ -118,7 +130,8 @@ pp_tun pp_tun_open(const char *uuid) {
 
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: Created wintun device %ls", dev_name);
     pp_tun tun = pp_alloc(sizeof(*tun));
-    tun->name = _wcsdup(dev_name);
+    tun->name = pp_dup(uuid);
+    tun->wname = dev_name;
     tun->adapter = adapter;
     tun->session = session;
     return tun;
@@ -127,7 +140,6 @@ failure:
     if (session) WintunEndSession(session);
     if (adapter) WintunCloseAdapter(adapter);
     if (dev_name) pp_free((LPWSTR)dev_name);
-    if (wintun) FreeLibrary(wintun);
     return NULL;
 }
 
@@ -135,15 +147,10 @@ void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
     if (and_close) {
         pp_tun_close(tun);
-        if (tun->adapter) {
-            WintunCloseAdapter(tun->adapter);
-        }
     }
-    pp_free(tun->name);
+    pp_free((char *)tun->name);
+    pp_free(tun->wname);
     pp_free(tun);
-
-    // XXX: Static library allocations are retained
-    // FreeLibrary(wintun);
 }
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
@@ -152,29 +159,24 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
         return -1;
     }
     DWORD packet_len;
-    BYTE *packet = NULL;
-    while (!packet) {
-        // printf(">>> tun_read looping, packet is %p, session is %p", packet, tun->session);
-        packet = WintunReceivePacket(tun->session, &packet_len);
-        // printf(">>> tun_read received: %p\n", packet);
-        if (packet) break;
+    BYTE *packet = WintunReceivePacket(tun->session, &packet_len);
+    if (!packet) {
         const DWORD err = GetLastError();
-        if (err != ERROR_NO_MORE_ITEMS) {
-            pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_windows: read(), %lu", err);
-            return -1;
+        if (err == ERROR_NO_MORE_ITEMS) {
+            return PPIOErrorWouldBlock;
         }
-        WaitForSingleObject(WintunGetReadWaitEvent(tun->session), INFINITE);
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_windows: read(), %lu", err);
+        return -1;
     }
-    // FIXME: #188, dst_len must accomodate max packet_len (can we know the MTU beforehand?)
-    // WINTUN_MAX_IP_PACKET_SIZE
-    // printf(">>> tun_read read %lu bytes\n", packet_len);
-    pp_assert(dst_len >= packet_len);
-    if (dst_len >= packet_len) {
-        memcpy(dst, packet, packet_len);
+
+    if (dst_len < packet_len) {
+        WintunReleaseReceivePacket(tun->session, packet);
+        SetLastError(ERROR_INSUFFICIENT_BUFFER);
+        return -1;
     }
+    memcpy(dst, packet, packet_len);
     WintunReleaseReceivePacket(tun->session, packet);
-    // printf(">>> tun_read released\n");
-    return packet_len;
+    return (int)packet_len;
 }
 
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
@@ -182,36 +184,38 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
         SetLastError(ERROR_INVALID_HANDLE);
         return -1;
     }
-    // printf(">>> tun_write write %llu bytes\n", src_len);
+
     BYTE *packet = WintunAllocateSendPacket(tun->session, src_len);
     if (!packet) {
         const DWORD err = GetLastError();
-        // Silently drop packets if the ring is full
-        if (err == ERROR_BUFFER_OVERFLOW) return 0;
+        if (err == ERROR_BUFFER_OVERFLOW) {
+            return PPIOErrorNoBufs;
+        }
         pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_windows: write(), %lu", err);
         return -1;
     }
-    // printf(">>> tun_write allocated\n");
+
     memcpy(packet, src, src_len);
     WintunSendPacket(tun->session, packet);
-    // printf(">>> tun_write written\n");
-    return src_len;
+    return (int)src_len;
 }
 
 void pp_tun_close(const pp_tun tun) {
     if (!tun || !tun->session) return;
     WintunEndSession(tun->session);
     tun->session = NULL;
+    WintunCloseAdapter(tun->adapter);
+    tun->adapter = NULL;
 }
 
-int pp_tun_get_fd(const pp_tun tun) {
-    (void)tun;
-    return -1;
+pp_fd pp_tun_get_watch_fd(const pp_tun tun) {
+    if (!tun || !tun->session) return INVALID_HANDLE_VALUE;
+    return WintunGetReadWaitEvent(tun->session);
 }
 
 const char *pp_tun_name(const pp_tun tun) {
-    (void)tun;
-    return NULL;
+    if (!tun) return NULL;
+    return tun->name;
 }
 
 void pp_tun_ctrl_set_delegate(void *ref, const pp_tun_ctrl_delegate *delegate) {
@@ -225,7 +229,7 @@ pp_tun pp_tun_ctrl_set_tunnel(void *ref, const char *uuid, const char *info_json
     (void)uuid;
     (void)info_json;
     pp_clog_v(PPLogCategoryCore, PPLogLevelInfo, "tun_windows: ctrl_set_tunnel(%p)", ref);
-    return NULL;
+    return pp_tun_open(uuid);
 }
 
 bool pp_tun_ctrl_configure_sockets(void *ref, const pp_reachability *info,

--- a/Sources/PartoutOS/AppleNE/Connection/NETunnelController.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NETunnelController.swift
@@ -49,7 +49,7 @@ public final class NETunnelController: TunnelController {
         tun = NETunnelInterface(.init(profile.id), impl: provider.packetFlow)
     }
 
-    public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> IOInterface {
+    public func setTunnelSettings(with info: TunnelRemoteInfo?) async throws -> TunInterface {
         guard let provider else {
             logReleasedProvider()
             throw PartoutError(.releasedObject)

--- a/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
@@ -6,7 +6,7 @@ internal import _PartoutCore_C
 import NetworkExtension
 
 /// A tunnel interface based on `NEPacketTunnelFlow`.
-public final class NETunnelInterface: IOInterface {
+public final class NETunnelInterface: TunInterface {
     private let ctx: PartoutLoggerContext
 
     nonisolated(unsafe)
@@ -17,9 +17,13 @@ public final class NETunnelInterface: IOInterface {
         self.impl = impl
     }
 
-    // MARK: TunnelInterface
+    // MARK: TunInterface
 
-    public var fileDescriptor: FileDescriptor? {
+    public var ioDescriptor: Any? {
+        Self.existingFileDescriptor
+    }
+
+    public var muxDescriptor: FileDescriptor? {
         Self.existingFileDescriptor
     }
 

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSession.swift
@@ -370,8 +370,7 @@ extension OpenVPNSession {
                 self,
                 remoteAddress: remoteAddress,
                 remoteProtocol: remoteProtocol,
-                remoteOptions: pushReplyOptions,
-                remoteFd: link?.fileDescriptor
+                remoteOptions: pushReplyOptions
             )
         }
         scheduleNextPing()

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionProtocol.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNSessionProtocol.swift
@@ -11,8 +11,7 @@ protocol OpenVPNSessionDelegate: AnyObject, Sendable {
     /// - Parameter remoteAddress: The address of the VPN server.
     /// - Parameter remoteProtocol: The endpoint protocol of the VPN server.
     /// - Parameter remoteOptions: The pulled tunnel settings.
-    /// - Parameter remoteFd: The file descriptor of the underlying connection.
-    func sessionDidStart(_ session: OpenVPNSessionProtocol, remoteAddress: String, remoteProtocol: EndpointProtocol, remoteOptions: OpenVPN.Configuration, remoteFd: FileDescriptor?) async
+    func sessionDidStart(_ session: OpenVPNSessionProtocol, remoteAddress: String, remoteProtocol: EndpointProtocol, remoteOptions: OpenVPN.Configuration) async
 
     /// Called after stopping a session.
     ///

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNTCPLink.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNTCPLink.swift
@@ -58,8 +58,8 @@ extension OpenVPNTCPLink: LinkInterface {
 // MARK: - IOInterface
 
 extension OpenVPNTCPLink {
-    var fileDescriptor: FileDescriptor? {
-        link.fileDescriptor
+    var muxDescriptor: FileDescriptor? {
+        link.muxDescriptor
     }
 
     func readPackets() async throws -> [Data] {

--- a/Sources/PartoutOpenVPNConnection/Internal/OpenVPNUDPLink.swift
+++ b/Sources/PartoutOpenVPNConnection/Internal/OpenVPNUDPLink.swift
@@ -53,8 +53,8 @@ extension OpenVPNUDPLink: LinkInterface {
 // MARK: - IOInterface
 
 extension OpenVPNUDPLink {
-    var fileDescriptor: FileDescriptor? {
-        link.fileDescriptor
+    var muxDescriptor: FileDescriptor? {
+        link.muxDescriptor
     }
 
     func readPackets() async throws -> [Data] {

--- a/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPNConnection/V2/_OpenVPNConnectionV2.swift
@@ -158,8 +158,7 @@ extension _OpenVPNConnectionV2: OpenVPNSessionDelegate {
         _ session: OpenVPNSessionProtocol,
         remoteAddress: String,
         remoteProtocol: EndpointProtocol,
-        remoteOptions: OpenVPN.Configuration,
-        remoteFd: FileDescriptor?
+        remoteOptions: OpenVPN.Configuration
     ) async {
         let addressObject = Address(rawValue: remoteAddress)
         if addressObject == nil {

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionProtocolV3.swift
@@ -47,9 +47,9 @@ protocol OpenVPNSessionProtocolV3: AnyObject, Sendable {
 
      - Precondition: `tunnel` is an active network interface.
      - Postcondition: The VPN data channel is open.
-     - Parameter tunnel: The `IOInterface` on which to exchange the VPN data traffic.
+     - Parameter tunnel: The `TunInterface` on which to exchange the VPN data traffic.
      */
-    func setTunnel(_ tunnel: IOInterface) async throws
+    func setTunnel(_ tunnel: TunInterface) async throws
 
     /**
      Shuts down the session with an optional `Error` reason. Does nothing if the session is already stopped or about to stop.

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -107,11 +107,8 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             pp_log(ctx, .openvpn, .error, "Link interface already set")
             return
         }
-        guard let fd = link.muxDescriptor else {
-            fatalError("Link has no file descriptor")
-        }
-        guard let socketFd = link.socketDescriptor else {
-            fatalError("Link has no socket descriptor")
+        guard let pair = link.descriptorPair else {
+            fatalError("Link lacks descriptors")
         }
 
         pp_log(ctx, .openvpn, .info, "Attach LINK")
@@ -122,7 +119,7 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         var didAttach = false
         do {
             try await looper.attach(.init(
-                pair: .link(fd, socketFd),
+                pair: pair,
                 closesOnEmptyRead: isTCP,
                 transformWrite: rw.beforeWrite,
                 onRead: { [weak self] packets in
@@ -157,16 +154,13 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             pp_log(ctx, .openvpn, .error, "Tunnel interface already set")
             return
         }
-        guard let fd = tunnel.muxDescriptor else {
-            fatalError("Tunnel has no file descriptor")
-        }
-        guard let ioFd = tunnel.ioDescriptor else {
-            fatalError("Tunnel has no I/O descriptor")
+        guard let pair = tunnel.descriptorPair else {
+            fatalError("Tunnel lacks descriptors")
         }
 
         pp_log(ctx, .openvpn, .info, "Attach TUN")
         try await looper.attach(.init(
-            pair: .tun(fd, ioFd),
+            pair: pair,
             closesOnEmptyRead: false,
             transformWrite: nil,
             onRead: { [weak self] packets in

--- a/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPNConnection/V3/Internal/OpenVPNSessionV3.swift
@@ -107,8 +107,11 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             pp_log(ctx, .openvpn, .error, "Link interface already set")
             return
         }
-        guard let fd = link.fileDescriptor else {
+        guard let fd = link.muxDescriptor else {
             fatalError("Link has no file descriptor")
+        }
+        guard let socketFd = link.socketDescriptor else {
+            fatalError("Link has no socket descriptor")
         }
 
         pp_log(ctx, .openvpn, .info, "Attach LINK")
@@ -119,8 +122,7 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         var didAttach = false
         do {
             try await looper.attach(.init(
-                side: .link,
-                fd: fd,
+                pair: .link(fd, socketFd),
                 closesOnEmptyRead: isTCP,
                 transformWrite: rw.beforeWrite,
                 onRead: { [weak self] packets in
@@ -146,7 +148,7 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
         }
     }
 
-    func setTunnel(_ tunnel: IOInterface) async throws {
+    func setTunnel(_ tunnel: TunInterface) async throws {
         guard looper.isLinkAttached else {
             pp_log(ctx, .openvpn, .error, "Set link interface first")
             return
@@ -155,14 +157,16 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
             pp_log(ctx, .openvpn, .error, "Tunnel interface already set")
             return
         }
-        guard let fd = tunnel.fileDescriptor else {
+        guard let fd = tunnel.muxDescriptor else {
             fatalError("Tunnel has no file descriptor")
+        }
+        guard let ioFd = tunnel.ioDescriptor else {
+            fatalError("Tunnel has no I/O descriptor")
         }
 
         pp_log(ctx, .openvpn, .info, "Attach TUN")
         try await looper.attach(.init(
-            side: .tun,
-            fd: fd,
+            pair: .tun(fd, ioFd),
             closesOnEmptyRead: false,
             transformWrite: nil,
             onRead: { [weak self] packets in

--- a/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
+++ b/Sources/PartoutWireGuardConnection/Internal/WireGuardBackend.swift
@@ -33,7 +33,7 @@ final class WireGuardBackend: @unchecked Sendable {
     }
 #endif
 
-    func socketDescriptors(_ handle: Int32) -> [Int32] {
+    func socketDescriptors(_ handle: Int32) -> [SocketDescriptor] {
 #if os(Android)
         [pp_wg_get_socket_v4(handle), pp_wg_get_socket_v6(handle)]
 #else

--- a/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V2/Internal/WireGuardAdapter.swift
@@ -8,7 +8,7 @@ protocol WireGuardAdapterDelegate: AnyObject, Sendable {
 
     func adapterShouldSetNetworkSettings(_ adapter: WireGuardAdapter, settings: TunnelRemoteInfo) async throws -> IOInterface
 
-    func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [FileDescriptor]) throws
+    func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [SocketDescriptor]) throws
 
     func adapterShouldClearNetworkSettings(_ adapter: WireGuardAdapter, tunnel: IOInterface) async
 }
@@ -233,7 +233,7 @@ actor WireGuardAdapter {
         guard let delegate else { return }
         tunnel = try await delegate.adapterShouldSetNetworkSettings(self, settings: networkSettings)
 #if !os(Windows)
-        guard let tunFd = tunnel?.fileDescriptor else {
+        guard let tunFd = tunnel?.muxDescriptor else {
             throw WireGuardAdapterError.cannotLocateTunnelFileDescriptor
         }
         tunnelFileDescriptor = tunFd
@@ -267,7 +267,7 @@ actor WireGuardAdapter {
     }
 
     @discardableResult
-    private func configureSockets(for handle: Int32) throws -> [FileDescriptor] {
+    private func configureSockets(for handle: Int32) throws -> [SocketDescriptor] {
         let descriptors = backend.socketDescriptors(handle)
             .filter { $0 >= 0 }
         pp_log(ctx, .wireguard, .info, "Socket descriptors: \(descriptors)")

--- a/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
+++ b/Sources/PartoutWireGuardConnection/V2/_WireGuardConnectionV2.swift
@@ -154,7 +154,7 @@ extension _WireGuardConnectionV2: WireGuardAdapterDelegate {
         }
     }
 
-    nonisolated func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [FileDescriptor]) throws {
+    nonisolated func adapterShouldConfigureSockets(_ adapter: WireGuardAdapter, descriptors: [SocketDescriptor]) throws {
         try controller.configureSockets(with: descriptors)
     }
 

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -70,6 +70,7 @@ set(PARTOUT_SOURCES
 ./PartoutCore/Connection/SimpleDNSResolver.swift
 ./PartoutCore/Connection/SocketConfigurator.swift
 ./PartoutCore/Connection/StaticTunnelEnvironment.swift
+./PartoutCore/Connection/TunInterface.swift
 ./PartoutCore/Connection/TunnelController.swift
 ./PartoutCore/Connection/TunnelEnvironment.swift
 ./PartoutCore/Connection/TunnelEnvironmentKeys+Connection.swift

--- a/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
+++ b/Tests/PartoutOpenVPNTests/OpenVPNConnectionTests.swift
@@ -386,8 +386,7 @@ private final class MockOpenVPNSession: OpenVPNSessionProtocol, @unchecked Senda
                 self,
                 remoteAddress: "100.200.100.200",
                 remoteProtocol: .init(.udp, 1234),
-                remoteOptions: options,
-                remoteFd: nil
+                remoteOptions: options
             )
             onConnected()
         } catch {

--- a/Tests/PartoutOpenVPNTests/OpenVPNConnectionV3Tests.swift
+++ b/Tests/PartoutOpenVPNTests/OpenVPNConnectionV3Tests.swift
@@ -424,7 +424,7 @@ private final class MockOpenVPNSession: OpenVPNSessionProtocolV3, @unchecked Sen
         mockHasLink
     }
 
-    func setTunnel(_ tunnel: IOInterface) async throws {
+    func setTunnel(_ tunnel: TunInterface) async throws {
         onSetTunnel()
     }
 


### PR DESCRIPTION
First, fix native pp_tun implementations:

- Use generic pp_fd type where applicable
- Retain other pp_tun, not pp_fd (FIXME: Still unsafe on Windows)
- Validate watch fd (-1 or INVALID_HANDLE_VALUE on error)
- Return pp_tun_open(uuid) in all ctrl_set_tunnel implementations

On Windows:

- Add a second tun name (vs wname) for use in Swift/C
- Create tun device in ctrl_set_tunnel
- Only close if necessary
- Never unload Wintun once loaded
- Fix leak in dev_name
- Fix wait for single object on read, mux will do
- Fix stale signatures

Then, make link and tun interfaces a descriptor pair:

- One for watching (pp_mux)
- One for reading and writing (pp_socket/pp_tun)

Because POSIX uses the same type for both, but Windows uses different types for:

- Watching: link = WSAEVENT (HANDLE), tun = HANDLE
- I/O: link = SOCKET, tun = WINTUN_SESSION_HANDLE

Refactor FdLooper to now receive descriptor pairs for link/tun.

Other fixes:

- FdLooper: Fix writability not initially signaled
- FdLooper: Fix tun not deleted on retain failure
- OpenVPN: Drop unused remoteFd in sessionDidStart
- WireGuard: Fix descriptor types