### PR TITLE
Windows: Support FdLooper with Win32 mux.c

### DIFF
--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -473,9 +473,12 @@ private extension FdLooper {
     }
 
     func process(mux: pp_mux, fdSet: FdSet) throws {
-        // Prepare link before processing
+        // Prepare fds before processing
         if let link, fdSet.readable.contains(link.fd) {
             try link.prepare?()
+        }
+        if let tun, fdSet.readable.contains(tun.fd) {
+            try tun.prepare?()
         }
 
         // Write link

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -473,6 +473,11 @@ private extension FdLooper {
     }
 
     func process(mux: pp_mux, fdSet: FdSet) throws {
+        // Prepare link before processing
+        if let link, fdSet.readable.contains(link.fd) {
+            try link.prepare?()
+        }
+
         // Write link
         if let link, fdSet.writable.contains(link.fd) {
             var watchWrites = false
@@ -902,6 +907,7 @@ private extension FdLooper {
         private let onRead: OnRead?
         private let onFailure: OnFailure?
 
+        let prepare: (() throws -> Void)?
         private let read: (inout [UInt8]) throws -> Data?
         private let write: (PendingWrite) throws -> Int
         private var cleanup: (() -> Void)?
@@ -915,6 +921,7 @@ private extension FdLooper {
             fd: FileDescriptor,
             readBufSize: Int,
             arguments: FdLooper.AttachArguments,
+            prepare: (() throws -> Void)? = nil,
             read: @escaping (inout [UInt8]) throws -> Data?,
             write: @escaping (PendingWrite) throws -> Int,
             cleanup: @escaping () -> Void,
@@ -924,6 +931,7 @@ private extension FdLooper {
             transformWrite = arguments.transformWrite
             onRead = arguments.onRead
             onFailure = arguments.onFailure
+            self.prepare = prepare
             self.read = read
             self.write = write
             self.cleanup = cleanup
@@ -1031,6 +1039,11 @@ private extension FdLooper.SideIO {
             fd: linkFd,
             readBufSize: readBufSize,
             arguments: arguments,
+            prepare: {
+                guard pp_socket_reset_event(socketFd, linkFd) else {
+                    throw FdLooper.IOError.libc(.link, pp_socket_last_error())
+                }
+            },
             read: { buf in
                 let count = ioFd.read(&buf)
                 guard count != PPIOErrorWouldBlock else {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -447,9 +447,9 @@ private extension FdLooper {
             case .detach(let side, let continuation):
                 handleDetach(side, continuation: continuation, results: &results)
             case .enableRead(let side, let id):
-                handleEnableRead(side, id: id)
+                try handleEnableRead(side, id: id)
             case .enableWrite(let side, let id):
-                handleEnableWrite(side, id: id, fdSet: fdSet)
+                try handleEnableWrite(side, id: id, fdSet: fdSet)
             case .custom(let body):
                 lock.unlock()
                 try body()
@@ -474,10 +474,10 @@ private extension FdLooper {
 
     func process(mux: pp_mux, fdSet: FdSet) throws {
         // Prepare fds before processing
-        if let link, fdSet.readable.contains(link.fd) {
+        if let link, fdSet.readable.contains(link.fd) || fdSet.writable.contains(link.fd) {
             try link.prepare?()
         }
-        if let tun, fdSet.readable.contains(tun.fd) {
+        if let tun, fdSet.readable.contains(tun.fd) || fdSet.writable.contains(tun.fd) {
             try tun.prepare?()
         }
 
@@ -493,7 +493,7 @@ private extension FdLooper {
                     break
                 } catch IOError.noBufSpace {
                     if let tun {
-                        suspendReadAndScheduleRetry(from: tun, fdSet: fdSet)
+                        try suspendReadAndScheduleRetry(from: tun, fdSet: fdSet)
                     }
                     scheduleWriteRetry(to: link)
                     watchWrites = false
@@ -501,7 +501,7 @@ private extension FdLooper {
                 }
             }
             // Stop watching if no blocks
-            pp_mux_set_write(mux, link.fd, watchWrites)
+            try link.setWrite(watchWrites, mux: mux)
             if !watchWrites {
                 fdSet.writable.remove(link.fd)
             }
@@ -519,7 +519,7 @@ private extension FdLooper {
                     break
                 } catch IOError.noBufSpace {
                     if let link {
-                        suspendReadAndScheduleRetry(from: link, fdSet: fdSet)
+                        try suspendReadAndScheduleRetry(from: link, fdSet: fdSet)
                     }
                     scheduleWriteRetry(to: tun)
                     watchWrites = false
@@ -527,7 +527,7 @@ private extension FdLooper {
                 }
             }
             // Stop watching if no blocks
-            pp_mux_set_write(mux, tun.fd, watchWrites)
+            try tun.setWrite(watchWrites, mux: mux)
             if !watchWrites {
                 fdSet.writable.remove(tun.fd)
             }
@@ -556,7 +556,7 @@ private extension FdLooper {
             if !inbox.isEmpty {
                 let action = try tun.processReadPackets(inbox)
                 if action == .pause {
-                    pp_mux_set_read(mux, tun.fd, false)
+                    try tun.setRead(false, mux: mux)
                 }
             }
         }
@@ -584,14 +584,14 @@ private extension FdLooper {
             if !inbox.isEmpty {
                 let action = try link.processReadPackets(inbox)
                 if action == .pause {
-                    pp_mux_set_read(mux, link.fd, false)
+                    try link.setRead(false, mux: mux)
                 }
             }
         }
     }
 
-    func suspendReadAndScheduleRetry(from io: SideIO, fdSet: FdSet) {
-        pp_mux_set_read(mux, io.fd, false)
+    func suspendReadAndScheduleRetry(from io: SideIO, fdSet: FdSet) throws {
+        try io.setRead(false, mux: mux)
         fdSet.readable.remove(io.fd)
 
         lock.lock()
@@ -718,14 +718,22 @@ private extension FdLooper {
             pp_log(ctx, .core, .info, "Attach link (fd=\(linkFd))")
 
             // Create new side
-            link = SideIO(
+            let newLink = SideIO(
                 mux: mux,
                 linkFd: linkFd,
                 ioFd: ioFd,
                 readBufSize: linkBufSize,
                 arguments: arguments
             )
-            results.append(.attach(continuation, .success(())))
+            do {
+                try newLink.syncEventMask()
+                link = newLink
+                results.append(.attach(continuation, .success(())))
+            } catch {
+                pp_log(ctx, .core, .fault, "Unable to retain link: \(error)")
+                pp_mux_delete(mux, linkFd)
+                results.append(.attach(continuation, .failure(MuxError(side: .link))))
+            }
         case .tun(let tunFd, let ioFd):
             // Cancel attach if stopping
             guard state != .stopping else {
@@ -745,14 +753,16 @@ private extension FdLooper {
             pp_log(ctx, .core, .info, "Attach tun (fd=\(tunFd))")
 
             // Create new side
+            let newTun = SideIO(
+                mux: mux,
+                tunFd: tunFd,
+                ioFd: ioFd,
+                readBufSize: tunBufSize,
+                arguments: arguments
+            )
             do {
-                tun = try SideIO(
-                    mux: mux,
-                    tunFd: tunFd,
-                    ioFd: ioFd,
-                    readBufSize: tunBufSize,
-                    arguments: arguments
-                )
+                try newTun.syncEventMask()
+                tun = newTun
                 results.append(.attach(continuation, .success(())))
             } catch {
                 pp_log(ctx, .core, .fault, "Unable to retain tun: \(error)")
@@ -783,7 +793,7 @@ private extension FdLooper {
         }
     }
 
-    func handleEnableRead(_ side: Side, id: UUID?) {
+    func handleEnableRead(_ side: Side, id: UUID?) throws {
         if let id {
             guard !isOutdated(id, side: side) else {
                 return
@@ -792,20 +802,20 @@ private extension FdLooper {
         switch side {
         case .link:
             if let link {
-                pp_mux_set_read(mux, link.fd, true)
+                try link.setRead(true, mux: mux)
             } else {
                 pp_log(ctx, .core, .error, "Ignoring enableRead(.link), not attached")
             }
         case .tun:
             if let tun {
-                pp_mux_set_read(mux, tun.fd, true)
+                try tun.setRead(true, mux: mux)
             } else {
                 pp_log(ctx, .core, .error, "Ignoring enableRead(.tun), not attached")
             }
         }
     }
 
-    func handleEnableWrite(_ side: Side, id: UUID?, fdSet: FdSet) {
+    func handleEnableWrite(_ side: Side, id: UUID?, fdSet: FdSet) throws {
         if let id {
             guard !isOutdated(id, side: side) else {
                 return
@@ -814,14 +824,14 @@ private extension FdLooper {
         switch side {
         case .link:
             if let link {
-                pp_mux_set_write(mux, link.fd, true)
+                try link.setWrite(true, mux: mux)
                 fdSet.writable.insert(link.fd)
             } else {
                 pp_log(ctx, .core, .error, "Ignoring enableWrite(.link), not attached")
             }
         case .tun:
             if let tun {
-                pp_mux_set_write(mux, tun.fd, true)
+                try tun.setWrite(true, mux: mux)
                 fdSet.writable.insert(tun.fd)
             } else {
                 pp_log(ctx, .core, .error, "Ignoring enableWrite(.tun), not attached")
@@ -911,6 +921,7 @@ private extension FdLooper {
         private let onFailure: OnFailure?
 
         let prepare: (() throws -> Void)?
+        private let setEventMask: (Bool, Bool) throws -> Void
         private let read: (inout [UInt8]) throws -> Data?
         private let write: (PendingWrite) throws -> Int
         private var cleanup: (() -> Void)?
@@ -918,6 +929,8 @@ private extension FdLooper {
         private var readBuf: [UInt8]
         private var writeQueue: RingQueue<Data>
         private var writeOffset: Int
+        private var isReading: Bool
+        private var isWriting: Bool
 
         init(
             side: Side,
@@ -925,6 +938,7 @@ private extension FdLooper {
             readBufSize: Int,
             arguments: FdLooper.AttachArguments,
             prepare: (() throws -> Void)? = nil,
+            setEventMask: @escaping (Bool, Bool) throws -> Void = { _, _ in },
             read: @escaping (inout [UInt8]) throws -> Data?,
             write: @escaping (PendingWrite) throws -> Int,
             cleanup: @escaping () -> Void,
@@ -935,16 +949,35 @@ private extension FdLooper {
             onRead = arguments.onRead
             onFailure = arguments.onFailure
             self.prepare = prepare
+            self.setEventMask = setEventMask
             self.read = read
             self.write = write
             self.cleanup = cleanup
             readBuf = Array(repeating: 0, count: readBufSize)
             writeQueue = RingQueue()
             writeOffset = 0
+            isReading = true
+            isWriting = false
         }
 
         func dequeueRead() throws -> Data? {
             try read(&readBuf)
+        }
+
+        func setRead(_ enabled: Bool, mux: pp_mux) throws {
+            pp_mux_set_read(mux, fd, enabled)
+            isReading = enabled
+            try setEventMask(isReading, isWriting)
+        }
+
+        func setWrite(_ enabled: Bool, mux: pp_mux) throws {
+            pp_mux_set_write(mux, fd, enabled)
+            isWriting = enabled
+            try setEventMask(isReading, isWriting)
+        }
+
+        func syncEventMask() throws {
+            try setEventMask(isReading, isWriting)
         }
 
         func processReadPackets(_ packets: [Data]) throws -> FdLooper.ReadAction {
@@ -1045,6 +1078,9 @@ private extension FdLooper.SideIO {
             prepare: {
                 try ioFd.resetEvents()
             },
+            setEventMask: { read, write in
+                try ioFd.setEventMask(read: read, write: write)
+            },
             read: { buf in
                 let count = ioFd.read(&buf)
                 guard count != PPIOErrorWouldBlock else {
@@ -1087,7 +1123,7 @@ private extension FdLooper.SideIO {
         ioFd: NativeIOInterface,
         readBufSize: Int,
         arguments: FdLooper.AttachArguments
-    ) throws {
+    ) {
         self.init(
             side: .tun,
             fd: tunFd,
@@ -1095,6 +1131,9 @@ private extension FdLooper.SideIO {
             arguments: arguments,
             prepare: {
                 try ioFd.resetEvents()
+            },
+            setEventMask: { read, write in
+                try ioFd.setEventMask(read: read, write: write)
             },
             read: { buf in
                 let count = ioFd.read(&buf)

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -1093,6 +1093,9 @@ private extension FdLooper.SideIO {
             fd: tunFd,
             readBufSize: readBufSize,
             arguments: arguments,
+            prepare: {
+                try ioFd.resetEvents()
+            },
             read: { buf in
                 let count = ioFd.read(&buf)
                 guard count != PPIOErrorWouldBlock else {

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -1043,9 +1043,7 @@ private extension FdLooper.SideIO {
             readBufSize: readBufSize,
             arguments: arguments,
             prepare: {
-                guard pp_socket_reset_event(socketFd, linkFd) else {
-                    throw FdLooper.IOError.libc(.link, pp_socket_last_error())
-                }
+                try ioFd.resetEvents()
             },
             read: { buf in
                 let count = ioFd.read(&buf)

--- a/Sources/PartoutCore/Connection/FdLooper.swift
+++ b/Sources/PartoutCore/Connection/FdLooper.swift
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-#if !os(Windows)
 internal import _PartoutCore_C
 
 /// Loops through a set of file descriptors.
@@ -1113,5 +1112,3 @@ private extension FdLooper.SideIO {
         )
     }
 }
-
-#endif

--- a/Sources/PartoutCore/Connection/NativeIOInterface.swift
+++ b/Sources/PartoutCore/Connection/NativeIOInterface.swift
@@ -4,6 +4,7 @@
 
 /// Provides an abstraction for the I/O of a native device.
 public protocol NativeIOInterface: Sendable {
+    func resetEvents() throws
     func read(_ buf: inout [UInt8]) -> Int32
     func write(_ data: Data, offset: Int) -> Int32
     func cleanup()

--- a/Sources/PartoutCore/Connection/NativeIOInterface.swift
+++ b/Sources/PartoutCore/Connection/NativeIOInterface.swift
@@ -4,6 +4,7 @@
 
 /// Provides an abstraction for the I/O of a native device.
 public protocol NativeIOInterface: Sendable {
+    func setEventMask(read: Bool, write: Bool) throws
     func resetEvents() throws
     func read(_ buf: inout [UInt8]) -> Int32
     func write(_ data: Data, offset: Int) -> Int32

--- a/Sources/PartoutCore/Connection/NativeSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/NativeSocketFactory.swift
@@ -149,6 +149,12 @@ final class SocketWrapper: NativeIOInterface, @unchecked Sendable {
         cleanup()
     }
 
+    func setEventMask(read: Bool, write: Bool) throws {
+        guard pp_socket_set_event_mask(socket, read, write) else {
+            throw PartoutError(.ioFailure)
+        }
+    }
+
     func resetEvents() throws {
         guard pp_socket_reset_events(socket) else {
             throw PartoutError(.ioFailure)

--- a/Sources/PartoutCore/Connection/NativeSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/NativeSocketFactory.swift
@@ -88,9 +88,6 @@ final class SocketWrapper: NativeIOInterface, @unchecked Sendable {
     private let ctx: PartoutLoggerContext
     let socket: pp_socket
     private let options: Options
-#if os(Windows)
-    private let handle: FileDescriptor
-#endif
     private var isClosed = false
 
     init(_ ctx: PartoutLoggerContext, options: Options) async throws {
@@ -142,28 +139,6 @@ final class SocketWrapper: NativeIOInterface, @unchecked Sendable {
                 continuation.resume(returning: newSock)
             }
         }
-#if os(Windows)
-        let handle = WSACreateEvent()
-        do {
-            guard let handle else {
-                throw PartoutError(.fdUnavailable)
-            }
-            guard WSAEventSelect(
-                pp_socket_get_fd(socket),
-                handle,
-                FD_READ | FD_WRITE | FD_CLOSE
-            ) == 0 else {
-                throw PartoutError(.linkNotActive)
-            }
-        } catch {
-            if let handle {
-                WSACloseEvent(handle)
-            }
-            pp_socket_free(socket)
-            throw error
-        }
-        self.handle = handle
-#endif
         self.ctx = ctx
         self.socket = socket
         self.options = options
@@ -171,18 +146,13 @@ final class SocketWrapper: NativeIOInterface, @unchecked Sendable {
 
     deinit {
         pp_log(ctx, .core, .debug, "Deinit SocketWrapper")
-#if os(Windows)
-        WSACloseEvent(handle)
-#endif
         cleanup()
     }
 
     func resetEvents() throws {
-#if os(Windows)
-        guard pp_socket_reset_event(socket, handle) else {
-            throw FdLooper.IOError.libc(.link, lastErrorCode)
+        guard pp_socket_reset_events(socket) else {
+            throw PartoutError(.ioFailure)
         }
-#endif
     }
 
     func read(_ buf: inout [UInt8]) -> Int32 {
@@ -213,11 +183,9 @@ final class SocketWrapper: NativeIOInterface, @unchecked Sendable {
 
 extension SocketWrapper: LinkInterface {
     var muxDescriptor: FileDescriptor? {
-#if os(Windows)
-        handle
-#else
-        pp_socket_get_fd(socket)
-#endif
+        let fd = pp_socket_get_watch_fd(socket)
+        guard pp_fd_is_valid(fd) else { return nil }
+        return fd
     }
 
     var nativeIO: NativeIOInterface? {

--- a/Sources/PartoutCore/Connection/NativeSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/NativeSocketFactory.swift
@@ -177,6 +177,14 @@ final class SocketWrapper: NativeIOInterface, @unchecked Sendable {
         cleanup()
     }
 
+    func resetEvents() throws {
+#if os(Windows)
+        guard pp_socket_reset_event(socket, handle) else {
+            throw FdLooper.IOError.libc(.link, lastErrorCode)
+        }
+#endif
+    }
+
     func read(_ buf: inout [UInt8]) -> Int32 {
         pp_socket_read(socket, &buf, buf.count)
     }

--- a/Sources/PartoutCore/Connection/TunWrapper.swift
+++ b/Sources/PartoutCore/Connection/TunWrapper.swift
@@ -21,6 +21,9 @@ public final class TunWrapper: NativeIOInterface, @unchecked Sendable {
         cleanup()
     }
 
+    public func resetEvents() throws {
+    }
+
     public func read(_ buf: inout [UInt8]) -> Int32 {
         pp_tun_read(tun, &buf, buf.count)
     }

--- a/Sources/PartoutCore/Connection/TunWrapper.swift
+++ b/Sources/PartoutCore/Connection/TunWrapper.swift
@@ -21,6 +21,9 @@ public final class TunWrapper: NativeIOInterface, @unchecked Sendable {
         cleanup()
     }
 
+    public func setEventMask(read: Bool, write: Bool) throws {
+    }
+
     public func resetEvents() throws {
     }
 

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -68,7 +68,8 @@ pp_fd pp_socket_get_watch_fd(pp_socket sock);
 int pp_socket_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
 int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags);
 
-/* Call this before any event loop. */
+/* Configure and reset the socket events associated with the watch fd. */
+bool pp_socket_set_event_mask(pp_socket sock, bool read, bool write);
 bool pp_socket_reset_events(pp_socket sock);
 
 #if PARTOUT_WINDOWS

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -58,15 +58,18 @@ bool pp_socket_set_buffers(pp_socket sock,
                            int recvbuf_len,
                            int sendbuf_len);
 
-/* Universal file descriptor. */
+/* Native socket descriptor. */
 pp_socket_fd pp_socket_get_fd(pp_socket sock);
+
+/* Return the file descriptor to watch. Check result with pp_fd_is_valid(). */
+pp_fd pp_socket_get_watch_fd(pp_socket sock);
 
 /* These are tied to sockets on Windows. */
 int pp_socket_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
 int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags);
 
 /* Call this before any event loop. */
-bool pp_socket_reset_event(pp_socket_fd fd, pp_fd event);
+bool pp_socket_reset_events(pp_socket sock);
 
 #if PARTOUT_WINDOWS
 static inline int pp_socket_last_error(void) {

--- a/Sources/PartoutCore_C/include/portable/socket.h
+++ b/Sources/PartoutCore_C/include/portable/socket.h
@@ -61,9 +61,12 @@ bool pp_socket_set_buffers(pp_socket sock,
 /* Universal file descriptor. */
 pp_socket_fd pp_socket_get_fd(pp_socket sock);
 
-/* Tied to sockets on Windows. */
+/* These are tied to sockets on Windows. */
 int pp_socket_set_nonblocking(pp_socket_fd fd, int *_Nullable original_flags);
 int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags);
+
+/* Call this before any event loop. */
+bool pp_socket_reset_event(pp_socket_fd fd, pp_fd event);
 
 #if PARTOUT_WINDOWS
 static inline int pp_socket_last_error(void) {

--- a/Sources/PartoutCore_C/include/portable/socket_posix.h
+++ b/Sources/PartoutCore_C/include/portable/socket_posix.h
@@ -85,9 +85,23 @@ static inline bool local_is_nobufs(void) {
 // pp_socket_fd == pp_fd in POSIX
 
 int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
-    return pp_fd_set_nonblocking(fd, original_flags);
+    const int ret = pp_fd_set_nonblocking(fd, original_flags);
+    if (ret < 0) {
+        local_print_error("pp_fd_set_nonblocking()");
+    }
+    return ret;
 }
 
 int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
-    return pp_fd_restore_blocking(fd, original_flags);
+    const int ret = pp_fd_restore_blocking(fd, original_flags);
+    if (ret < 0) {
+        local_print_error("pp_socket_restore_blocking()");
+    }
+    return ret;
+}
+
+bool pp_socket_reset_event(pp_socket_fd fd, pp_fd event) {
+    (void)fd;
+    (void)event;
+    return true;
 }

--- a/Sources/PartoutCore_C/include/portable/socket_posix.h
+++ b/Sources/PartoutCore_C/include/portable/socket_posix.h
@@ -12,6 +12,11 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
+/* POSIX systems use int for both I/O and watching.  */
+struct __pp_socket_struct {
+    pp_socket_fd fd;
+};
+
 typedef socklen_t os_socklen_t;
 
 static inline void local_print_error(const char *msg) {
@@ -27,7 +32,15 @@ static inline pp_socket_fd local_invalid_fd(void) {
 }
 
 static inline bool local_is_invalid_fd(pp_socket_fd fd) {
-    return fd == -1;
+    return fd == local_invalid_fd();
+}
+
+static inline pp_fd local_invalid_watch_fd(void) {
+    return -1;
+}
+
+static inline pp_fd local_socket_watch_fd(const pp_socket sock) {
+    return sock->fd;
 }
 
 static inline void local_set_not_socket_error(void) {
@@ -70,6 +83,15 @@ static inline int local_select_nfds(pp_socket_fd fd) {
     return fd + 1;
 }
 
+static inline bool local_init_socket(pp_socket sock) {
+    (void)sock;
+    return true;
+}
+
+static inline void local_cleanup_socket(pp_socket sock) {
+    (void)sock;
+}
+
 static inline bool local_is_interrupted(void) {
     return errno == EINTR;
 }
@@ -100,8 +122,10 @@ int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
     return ret;
 }
 
-bool pp_socket_reset_event(pp_socket_fd fd, pp_fd event) {
-    (void)fd;
-    (void)event;
+bool pp_socket_reset_events(pp_socket sock) {
+    if (!sock || local_is_invalid_fd(sock->fd)) {
+        local_set_not_socket_error();
+        return false;
+    }
     return true;
 }

--- a/Sources/PartoutCore_C/include/portable/socket_posix.h
+++ b/Sources/PartoutCore_C/include/portable/socket_posix.h
@@ -122,6 +122,16 @@ int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
     return ret;
 }
 
+bool pp_socket_set_event_mask(pp_socket sock, bool read, bool write) {
+    if (!sock || local_is_invalid_fd(sock->fd)) {
+        local_set_not_socket_error();
+        return false;
+    }
+    (void)read;
+    (void)write;
+    return true;
+}
+
 bool pp_socket_reset_events(pp_socket sock) {
     if (!sock || local_is_invalid_fd(sock->fd)) {
         local_set_not_socket_error();

--- a/Sources/PartoutCore_C/include/portable/socket_posix.h
+++ b/Sources/PartoutCore_C/include/portable/socket_posix.h
@@ -31,10 +31,6 @@ static inline pp_socket_fd local_invalid_fd(void) {
     return -1;
 }
 
-static inline bool local_is_invalid_fd(pp_socket_fd fd) {
-    return fd == local_invalid_fd();
-}
-
 static inline pp_fd local_invalid_watch_fd(void) {
     return -1;
 }
@@ -123,7 +119,7 @@ int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
 }
 
 bool pp_socket_set_event_mask(pp_socket sock, bool read, bool write) {
-    if (!sock || local_is_invalid_fd(sock->fd)) {
+    if (!local_is_valid_socket(sock)) {
         local_set_not_socket_error();
         return false;
     }
@@ -133,7 +129,7 @@ bool pp_socket_set_event_mask(pp_socket sock, bool read, bool write) {
 }
 
 bool pp_socket_reset_events(pp_socket sock) {
-    if (!sock || local_is_invalid_fd(sock->fd)) {
+    if (!local_is_valid_socket(sock)) {
         local_set_not_socket_error();
         return false;
     }

--- a/Sources/PartoutCore_C/include/portable/socket_posix.h
+++ b/Sources/PartoutCore_C/include/portable/socket_posix.h
@@ -14,12 +14,12 @@
 
 typedef socklen_t os_socklen_t;
 
-static inline bool local_platform_init(void) {
-    return true;
-}
-
 static inline void local_print_error(const char *msg) {
     pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed: %s", msg, strerror(errno));
+}
+
+static inline bool local_platform_init(void) {
+    return true;
 }
 
 static inline pp_socket_fd local_invalid_fd(void) {

--- a/Sources/PartoutCore_C/include/portable/socket_windows.h
+++ b/Sources/PartoutCore_C/include/portable/socket_windows.h
@@ -9,6 +9,10 @@
 
 typedef int os_socklen_t;
 
+static inline void local_print_error(const char *msg) {
+    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed with error %d", msg, WSAGetLastError());
+}
+
 static inline bool local_platform_init(void) {
     static int wsa_initialized = 0;
     if (!wsa_initialized) {
@@ -20,10 +24,6 @@ static inline bool local_platform_init(void) {
         wsa_initialized = 1;
     }
     return true;
-}
-
-static inline void local_print_error(const char *msg) {
-    pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "%s failed with error %d", msg, WSAGetLastError());
 }
 
 static inline pp_socket_fd local_invalid_fd(void) {

--- a/Sources/PartoutCore_C/include/portable/socket_windows.h
+++ b/Sources/PartoutCore_C/include/portable/socket_windows.h
@@ -36,17 +36,6 @@ static inline pp_socket_fd local_invalid_fd(void) {
     return INVALID_SOCKET;
 }
 
-static inline bool local_is_invalid_fd(pp_socket_fd fd) {
-    return fd == local_invalid_fd();
-}
-
-static inline bool local_is_valid_socket(pp_socket sock) {
-    return (sock &&
-            !local_is_invalid_fd(sock->fd) &&
-            sock->handle != WSA_INVALID_EVENT &&
-            pp_fd_is_valid(sock->handle));
-}
-
 static inline pp_fd local_invalid_watch_fd(void) {
     return INVALID_HANDLE_VALUE;
 }

--- a/Sources/PartoutCore_C/include/portable/socket_windows.h
+++ b/Sources/PartoutCore_C/include/portable/socket_windows.h
@@ -7,6 +7,12 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+/* Windows uses SOCKET for I/O and HANDLE for watching.  */
+struct __pp_socket_struct {
+    pp_socket_fd fd;
+    pp_fd handle;
+};
+
 typedef int os_socklen_t;
 
 static inline void local_print_error(const char *msg) {
@@ -31,7 +37,18 @@ static inline pp_socket_fd local_invalid_fd(void) {
 }
 
 static inline bool local_is_invalid_fd(pp_socket_fd fd) {
-    return fd == INVALID_SOCKET;
+    return fd == local_invalid_fd();
+}
+
+static inline pp_fd local_invalid_watch_fd(void) {
+    return INVALID_HANDLE_VALUE;
+}
+
+static inline pp_fd local_socket_watch_fd(const pp_socket sock) {
+    if (sock->handle == WSA_INVALID_EVENT || !pp_fd_is_valid(sock->handle)) {
+        return local_invalid_watch_fd();
+    }
+    return sock->handle;
 }
 
 static inline void local_set_not_socket_error(void) {
@@ -76,6 +93,34 @@ static inline int local_select_nfds(pp_socket_fd fd) {
     return 0;
 }
 
+static inline bool local_init_socket(pp_socket sock) {
+    if (!sock || local_is_invalid_fd(sock->fd)) {
+        local_set_not_socket_error();
+        return false;
+    }
+    sock->handle = WSACreateEvent();
+    if (sock->handle == WSA_INVALID_EVENT) {
+        local_print_error("WSACreateEvent()");
+        return false;
+    }
+    if (WSAEventSelect(sock->fd, sock->handle, FD_READ | FD_WRITE | FD_CLOSE) == SOCKET_ERROR) {
+        local_print_error("WSAEventSelect()");
+        WSACloseEvent(sock->handle);
+        sock->handle = WSA_INVALID_EVENT;
+        return false;
+    }
+    return true;
+}
+
+static inline void local_cleanup_socket(pp_socket sock) {
+    if (!sock || sock->handle == WSA_INVALID_EVENT || !pp_fd_is_valid(sock->handle)) return;
+    if (!local_is_invalid_fd(sock->fd)) {
+        (void)WSAEventSelect(sock->fd, WSA_INVALID_EVENT, 0);
+    }
+    WSACloseEvent(sock->handle);
+    sock->handle = WSA_INVALID_EVENT;
+}
+
 static inline bool local_is_interrupted(void) {
     return WSAGetLastError() == WSAEINTR;
 }
@@ -108,13 +153,16 @@ int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
     return 0;
 }
 
-bool pp_socket_reset_event(pp_socket_fd fd, pp_fd event) {
-    if (local_is_invalid_fd(fd) || !event || !pp_fd_is_valid(event)) {
+bool pp_socket_reset_events(pp_socket sock) {
+    if (!sock ||
+        local_is_invalid_fd(sock->fd) ||
+        sock->handle == WSA_INVALID_EVENT ||
+        !pp_fd_is_valid(sock->handle)) {
         local_set_not_socket_error();
         return false;
     }
     WSANETWORKEVENTS events;
-    if (WSAEnumNetworkEvents(fd, event, &events) == SOCKET_ERROR) {
+    if (WSAEnumNetworkEvents(sock->fd, sock->handle, &events) == SOCKET_ERROR) {
         local_print_error("WSAEnumNetworkEvents()");
         return false;
     }

--- a/Sources/PartoutCore_C/include/portable/socket_windows.h
+++ b/Sources/PartoutCore_C/include/portable/socket_windows.h
@@ -92,7 +92,7 @@ int pp_socket_set_nonblocking(pp_socket_fd fd, int *original_flags) {
     (void)original_flags;
     u_long mode = 1;
     if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
-        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): set");
+        local_print_error("ioctlsocket(): set");
         return -1;
     }
     return 0;
@@ -102,8 +102,21 @@ int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
     (void)original_flags;
     u_long mode = 0;
     if (ioctlsocket(fd, FIONBIO, &mode) == SOCKET_ERROR) {
-        pp_clog(PPLogCategoryCore, PPLogLevelFault, "ioctlsocket(): restore");
+        local_print_error("ioctlsocket(): restore");
         return -1;
     }
     return 0;
+}
+
+bool pp_socket_reset_event(pp_socket_fd fd, pp_fd event) {
+    if (local_is_invalid_fd(fd) || !event || !pp_fd_is_valid(event)) {
+        local_set_not_socket_error();
+        return false;
+    }
+    WSANETWORKEVENTS events;
+    if (WSAEnumNetworkEvents(fd, event, &events) == SOCKET_ERROR) {
+        local_print_error("WSAEnumNetworkEvents()");
+        return false;
+    }
+    return true;
 }

--- a/Sources/PartoutCore_C/include/portable/socket_windows.h
+++ b/Sources/PartoutCore_C/include/portable/socket_windows.h
@@ -153,6 +153,24 @@ int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
     return 0;
 }
 
+bool pp_socket_set_event_mask(pp_socket sock, bool read, bool write) {
+    if (!sock ||
+        local_is_invalid_fd(sock->fd) ||
+        sock->handle == WSA_INVALID_EVENT ||
+        !pp_fd_is_valid(sock->handle)) {
+        local_set_not_socket_error();
+        return false;
+    }
+    long events = FD_CLOSE;
+    if (read) events |= FD_READ;
+    if (write) events |= FD_WRITE;
+    if (WSAEventSelect(sock->fd, sock->handle, events) == SOCKET_ERROR) {
+        local_print_error("WSAEventSelect()");
+        return false;
+    }
+    return true;
+}
+
 bool pp_socket_reset_events(pp_socket sock) {
     if (!sock ||
         local_is_invalid_fd(sock->fd) ||

--- a/Sources/PartoutCore_C/include/portable/socket_windows.h
+++ b/Sources/PartoutCore_C/include/portable/socket_windows.h
@@ -40,6 +40,13 @@ static inline bool local_is_invalid_fd(pp_socket_fd fd) {
     return fd == local_invalid_fd();
 }
 
+static inline bool local_is_valid_socket(pp_socket sock) {
+    return (sock &&
+            !local_is_invalid_fd(sock->fd) &&
+            sock->handle != WSA_INVALID_EVENT &&
+            pp_fd_is_valid(sock->handle));
+}
+
 static inline pp_fd local_invalid_watch_fd(void) {
     return INVALID_HANDLE_VALUE;
 }
@@ -154,10 +161,7 @@ int pp_socket_restore_blocking(pp_socket_fd fd, int original_flags) {
 }
 
 bool pp_socket_set_event_mask(pp_socket sock, bool read, bool write) {
-    if (!sock ||
-        local_is_invalid_fd(sock->fd) ||
-        sock->handle == WSA_INVALID_EVENT ||
-        !pp_fd_is_valid(sock->handle)) {
+    if (!local_is_valid_socket(sock)) {
         local_set_not_socket_error();
         return false;
     }
@@ -172,10 +176,7 @@ bool pp_socket_set_event_mask(pp_socket sock, bool read, bool write) {
 }
 
 bool pp_socket_reset_events(pp_socket sock) {
-    if (!sock ||
-        local_is_invalid_fd(sock->fd) ||
-        sock->handle == WSA_INVALID_EVENT ||
-        !pp_fd_is_valid(sock->handle)) {
+    if (!local_is_valid_socket(sock)) {
         local_set_not_socket_error();
         return false;
     }

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -10,7 +10,189 @@
 const int PPMuxErrorNull = -2;
 
 #if PARTOUT_WINDOWS
-// FIXME: ###, Implement mux.c on Windows
+#include <windows.h>
+
+struct pp_mux_entry {
+    pp_fd fd;
+    bool read;
+    bool write;
+};
+
+struct __pp_mux {
+    struct pp_mux_entry *entries;
+    int entries_len;
+    pp_fd wake_event;
+    pp_fd *handles;
+    int num_tracked;
+    void (*on_readable)(void *ctx, pp_fd fd);
+    void (*on_writable)(void *ctx, pp_fd fd);
+    void *read_ctx;
+    void *write_ctx;
+};
+
+static bool pp_mux_is_valid_handle(pp_fd fd) {
+    return fd && fd != INVALID_HANDLE_VALUE;
+}
+
+static struct pp_mux_entry *pp_mux_entry_find(pp_mux mux, pp_fd fd) {
+    for (int i = 0; i < mux->num_tracked; ++i) {
+        if (mux->entries[i].fd == fd) return mux->entries + i;
+    }
+    return NULL;
+}
+
+static struct pp_mux_entry *pp_mux_track_fd(pp_mux mux, pp_fd fd) {
+    struct pp_mux_entry *tracked = pp_mux_entry_find(mux, fd);
+    if (tracked) return tracked;
+    /* Do not track more than fds_len. */
+    if (mux->num_tracked >= mux->entries_len) return NULL;
+    tracked = mux->entries + mux->num_tracked;
+    tracked->fd = fd;
+    tracked->read = false;
+    tracked->write = false;
+    ++mux->num_tracked;
+    return tracked;
+}
+
+static void pp_mux_untrack_fd(pp_mux mux, struct pp_mux_entry *entry) {
+    const int index = (int)(entry - mux->entries);
+    --mux->num_tracked;
+    if (index != mux->num_tracked) {
+        mux->entries[index] = mux->entries[mux->num_tracked];
+    }
+}
+
+static bool pp_mux_is_enabled(const struct pp_mux_entry *entry) {
+    return entry->read || entry->write;
+}
+
+static int pp_mux_build_handles(pp_mux mux) {
+    int count = 0;
+    mux->handles[count] = mux->wake_event;
+    ++count;
+
+    for (int i = 0; i < mux->num_tracked; ++i) {
+        const struct pp_mux_entry *tracked = mux->entries + i;
+        if (!pp_mux_is_enabled(tracked)) continue;
+        mux->handles[count] = tracked->fd;
+        ++count;
+    }
+    return count;
+}
+
+pp_mux pp_mux_create(int num) {
+    if (num <= 0) return NULL;
+    /* Adds 1 to account for wake_event. */
+    if (num > MAXIMUM_WAIT_OBJECTS - 1) return NULL;
+
+    pp_fd wake_event = CreateEventW(NULL, FALSE, FALSE, NULL);
+    if (!wake_event) return NULL;
+
+    pp_mux mux = pp_alloc(sizeof(*mux));
+    mux->entries = pp_alloc(num * sizeof(struct pp_mux_entry));
+    mux->entries_len = num;
+    mux->wake_event = wake_event;
+    mux->handles = pp_alloc((1 + num) * sizeof(pp_fd));
+
+    return mux;
+}
+
+void pp_mux_free(pp_mux mux) {
+    if (!mux) return;
+    CloseHandle(mux->wake_event);
+    pp_free(mux->handles);
+    pp_free(mux->entries);
+    pp_free(mux);
+}
+
+bool pp_mux_add(pp_mux mux, pp_fd fd) {
+    if (!mux || !pp_mux_is_valid_handle(fd)) return false;
+    struct pp_mux_entry *tracked = pp_mux_track_fd(mux, fd);
+    if (!tracked) return false;
+    tracked->read = true;
+    tracked->write = false;
+    return true;
+}
+
+bool pp_mux_delete(pp_mux mux, pp_fd fd) {
+    if (!mux) return false;
+    struct pp_mux_entry *tracked = pp_mux_entry_find(mux, fd);
+    if (!tracked) return true;
+    pp_mux_untrack_fd(mux, tracked);
+    return true;
+}
+
+bool pp_mux_set_read(pp_mux mux, pp_fd fd, bool enable) {
+    if (!mux) return false;
+    struct pp_mux_entry *tracked = pp_mux_entry_find(mux, fd);
+    if (!tracked && !enable) return true;
+    if (!tracked) return false;
+    tracked->read = enable;
+    return true;
+}
+
+bool pp_mux_set_write(pp_mux mux, pp_fd fd, bool enable) {
+    if (!mux) return false;
+    struct pp_mux_entry *tracked = pp_mux_entry_find(mux, fd);
+    if (!tracked && !enable) return true;
+    if (!tracked) return false;
+    tracked->write = enable;
+    return true;
+}
+
+void pp_mux_set_on_readable(pp_mux mux, void (*callback)(void *ctx, pp_fd fd), void *ctx) {
+    if (!mux) return;
+    mux->on_readable = callback;
+    mux->read_ctx = ctx;
+}
+
+void pp_mux_set_on_writable(pp_mux mux, void (*callback)(void *ctx, pp_fd fd), void *ctx) {
+    if (!mux) return;
+    mux->on_writable = callback;
+    mux->write_ctx = ctx;
+}
+
+int pp_mux_wait(pp_mux mux, int *error_code) {
+    if (!mux) return PPMuxErrorNull;
+
+    const int handles_count = pp_mux_build_handles(mux);
+    const DWORD ret = WaitForMultipleObjects((DWORD)handles_count, mux->handles, FALSE, INFINITE);
+    if (ret == WAIT_FAILED) {
+        const DWORD error = GetLastError();
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "pp_mux_wait WaitForMultipleObjects() failed: error=%lu", error);
+        if (error_code) *error_code = (int)error;
+        return -1;
+    }
+
+    const DWORD first = WAIT_OBJECT_0;
+    const DWORD last = WAIT_OBJECT_0 + (DWORD)handles_count;
+    if (ret < first || ret >= last) {
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "pp_mux_wait WaitForMultipleObjects() unexpected status: %lu", ret);
+        if (error_code) *error_code = (int)ret;
+        return -1;
+    }
+
+    const int index = (int)(ret - WAIT_OBJECT_0);
+    const pp_fd fd = mux->handles[index];
+    if (fd == mux->wake_event) {
+        return 1;
+    }
+
+    const struct pp_mux_entry *tracked = pp_mux_entry_find(mux, fd);
+    if (!tracked) return 1;
+    if (tracked->read && mux->on_readable) {
+        mux->on_readable(mux->read_ctx, fd);
+    }
+    if (tracked->write && mux->on_writable) {
+        mux->on_writable(mux->write_ctx, fd);
+    }
+    return 1;
+}
+
+bool pp_mux_wake(pp_mux mux) {
+    if (!mux) return false;
+    return SetEvent(mux->wake_event);
+}
 #else
 #include <fcntl.h>
 #include <poll.h>

--- a/Sources/PartoutCore_C/mux.c
+++ b/Sources/PartoutCore_C/mux.c
@@ -5,7 +5,7 @@
  */
 
 #include "portable/mux.h"
-#include <errno.h>
+#include "portable/common.h"
 
 const int PPMuxErrorNull = -2;
 
@@ -45,7 +45,10 @@ static struct pp_mux_entry *pp_mux_track_fd(pp_mux mux, pp_fd fd) {
     struct pp_mux_entry *tracked = pp_mux_entry_find(mux, fd);
     if (tracked) return tracked;
     /* Do not track more than fds_len. */
-    if (mux->num_tracked >= mux->entries_len) return NULL;
+    if (mux->num_tracked >= mux->entries_len) {
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "Too many tracked fds");
+        return NULL;
+    }
     tracked = mux->entries + mux->num_tracked;
     tracked->fd = fd;
     tracked->read = false;
@@ -198,6 +201,7 @@ bool pp_mux_wake(pp_mux mux) {
 #include <poll.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <errno.h>
 
 #define PP_MUX_ERROR_EVENTS (POLLERR | POLLHUP | POLLNVAL)
 
@@ -230,7 +234,10 @@ static struct pp_mux_entry *pp_mux_track_fd(pp_mux mux, pp_fd fd) {
     struct pp_mux_entry *tracked = pp_mux_entry_find(mux, fd);
     if (tracked) return tracked;
     /* Do not track more than fds_len. */
-    if (mux->num_tracked >= mux->entries_len) return NULL;
+    if (mux->num_tracked >= mux->entries_len) {
+        pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "Too many tracked fds");
+        return NULL;
+    }
     tracked = mux->entries + mux->num_tracked;
     tracked->fd = fd;
     tracked->read = false;

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -11,6 +11,10 @@
 #include "portable/common.h"
 #include "portable/socket.h"
 
+static pp_socket_fd local_invalid_fd(void);
+static bool local_is_invalid_fd(pp_socket_fd fd);
+static bool local_is_valid_socket(pp_socket sock);
+
 #if PARTOUT_WINDOWS
 #include "portable/socket_windows.h"
 #else
@@ -18,8 +22,6 @@
 #endif
 
 static bool local_platform_init(void);
-static pp_socket_fd local_invalid_fd(void);
-static bool local_is_invalid_fd(pp_socket_fd fd);
 static void local_print_error(const char *msg);
 static void local_set_not_socket_error(void);
 static void local_set_timeout_error(void);
@@ -46,6 +48,16 @@ static bool local_parse_numeric_addr(const char *ip_addr,
                                      struct sockaddr_storage *addr,
                                      os_socklen_t *addrlen);
 static void local_close_impl(pp_socket sock);
+
+static bool local_is_invalid_fd(pp_socket_fd fd) {
+    return fd == local_invalid_fd();
+}
+
+static bool local_is_valid_socket(pp_socket sock) {
+    return sock &&
+           !local_is_invalid_fd(sock->fd) &&
+           pp_fd_is_valid(local_socket_watch_fd(sock));
+}
 
 /* Create a socket from a formerly opened file descriptor. */
 static pp_socket pp_socket_create(pp_socket_fd fd) {
@@ -194,7 +206,7 @@ failure:
 
 /* Close the native file descriptor without freeing the wrapper. */
 void pp_socket_shutdown(pp_socket sock) {
-    if (!sock || local_is_invalid_fd(sock->fd)) return;
+    if (!local_is_valid_socket(sock)) return;
     (void)local_shutdown_fd(sock->fd);
 }
 
@@ -218,7 +230,7 @@ void pp_socket_free_and_close(pp_socket sock, bool and_close) {
 /* Read up to dst_len bytes, and return the amount of the actually read
  * bytes. Returns < 0 on failure. */
 int pp_socket_read(pp_socket sock, uint8_t *dst, size_t dst_len) {
-    if (!sock || local_is_invalid_fd(sock->fd)) {
+    if (!local_is_valid_socket(sock)) {
         local_set_not_socket_error();
         return -1;
     }
@@ -245,7 +257,7 @@ int pp_socket_read(pp_socket sock, uint8_t *dst, size_t dst_len) {
 /* Write src_len bytes, and repeat until fully written. Returns the amount
  * of written bytes, expected to always be src_len. Returns < 0 on failure. */
 int pp_socket_write(pp_socket sock, const uint8_t *src, size_t src_len) {
-    if (!sock || local_is_invalid_fd(sock->fd)) {
+    if (!local_is_valid_socket(sock)) {
         local_set_not_socket_error();
         return -1;
     }
@@ -280,7 +292,7 @@ int pp_socket_write(pp_socket sock, const uint8_t *src, size_t src_len) {
 }
 
 bool pp_socket_set_buffers(pp_socket sock, int recvbuf_len, int sendbuf_len) {
-    if (!sock || local_is_invalid_fd(sock->fd)) {
+    if (!local_is_valid_socket(sock)) {
         local_set_not_socket_error();
         return false;
     }
@@ -303,13 +315,13 @@ bool pp_socket_set_buffers(pp_socket sock, int recvbuf_len, int sendbuf_len) {
 
 /* Return the native file descriptor. */
 pp_socket_fd pp_socket_get_fd(const pp_socket sock) {
-    pp_assert(sock && !local_is_invalid_fd(sock->fd));
+    pp_assert(local_is_valid_socket(sock));
     return sock->fd;
 }
 
 /* Return the native watch file descriptor. */
 pp_fd pp_socket_get_watch_fd(const pp_socket sock) {
-    if (!sock || local_is_invalid_fd(sock->fd)) {
+    if (!local_is_valid_socket(sock)) {
         return local_invalid_watch_fd();
     }
     return local_socket_watch_fd(sock);

--- a/Sources/PartoutCore_C/socket.c
+++ b/Sources/PartoutCore_C/socket.c
@@ -31,6 +31,10 @@ static int local_shutdown_fd(pp_socket_fd fd);
 static int local_recv_fd(pp_socket_fd fd, void *dst, size_t dst_len);
 static int local_send_fd(pp_socket_fd fd, const void *src, size_t src_len);
 static int local_select_nfds(pp_socket_fd fd);
+static bool local_init_socket(pp_socket sock);
+static void local_cleanup_socket(pp_socket sock);
+static pp_fd local_invalid_watch_fd(void);
+static pp_fd local_socket_watch_fd(const pp_socket sock);
 
 static int local_connect_with_timeout(pp_socket_fd fd,
                                       const struct sockaddr *addr,
@@ -43,16 +47,14 @@ static bool local_parse_numeric_addr(const char *ip_addr,
                                      os_socklen_t *addrlen);
 static void local_close_impl(pp_socket sock);
 
-/* Host a file descriptor with the specific platform type. POSIX systems
- * use int, whereas Windows uses SOCKET.  */
-struct __pp_socket_struct {
-    pp_socket_fd fd;
-};
-
 /* Create a socket from a formerly opened file descriptor. */
 static pp_socket pp_socket_create(pp_socket_fd fd) {
     pp_socket sock = pp_alloc(sizeof(*sock));
     sock->fd = (pp_socket_fd)fd;
+    if (!local_init_socket(sock)) {
+        pp_free(sock);
+        return NULL;
+    }
     return sock;
 }
 
@@ -107,7 +109,11 @@ pp_socket pp_socket_open(const char *ip_addr,
             local_print_error("connect()");
             goto failure;
         }
-        return pp_socket_create(new_fd);
+        pp_socket sock = pp_socket_create(new_fd);
+        if (!sock) {
+            goto failure;
+        }
+        return sock;
     }
 
     pp_zero(&hints, sizeof(hints));
@@ -168,14 +174,20 @@ pp_socket pp_socket_open(const char *ip_addr,
         break;
     }
     freeaddrinfo(resolved);
+    resolved = NULL;
     if (local_is_invalid_fd(new_fd)) {
         goto failure;
     }
 
     // Success
-    return pp_socket_create(new_fd);
+    pp_socket sock = pp_socket_create(new_fd);
+    if (!sock) {
+        goto failure;
+    }
+    return sock;
 
 failure:
+    if (resolved) freeaddrinfo(resolved);
     if (!local_is_invalid_fd(new_fd)) local_close_fd(new_fd);
     return NULL;
 }
@@ -197,6 +209,8 @@ void pp_socket_free_and_close(pp_socket sock, bool and_close) {
     if (!sock) return;
     if (and_close) {
         local_close_impl(sock);
+    } else {
+        local_cleanup_socket(sock);
     }
     pp_free(sock);
 }
@@ -293,6 +307,14 @@ pp_socket_fd pp_socket_get_fd(const pp_socket sock) {
     return sock->fd;
 }
 
+/* Return the native watch file descriptor. */
+pp_fd pp_socket_get_watch_fd(const pp_socket sock) {
+    if (!sock || local_is_invalid_fd(sock->fd)) {
+        return local_invalid_watch_fd();
+    }
+    return local_socket_watch_fd(sock);
+}
+
 /* Cross-platform helpers. */
 
 bool local_parse_numeric_addr(const char *ip_addr,
@@ -324,11 +346,14 @@ bool local_parse_numeric_addr(const char *ip_addr,
 }
 
 void local_close_impl(pp_socket sock) {
-    if (!sock || local_is_invalid_fd(sock->fd)) {
+    if (!sock) {
         return;
     }
-    local_close_fd(sock->fd);
-    sock->fd = local_invalid_fd();
+    local_cleanup_socket(sock);
+    if (!local_is_invalid_fd(sock->fd)) {
+        local_close_fd(sock->fd);
+        sock->fd = local_invalid_fd();
+    }
 }
 
 int local_connect_with_timeout(pp_socket_fd fd,


### PR DESCRIPTION
Implement the Windows side of mux.c based on:

- Winsock for the link (socket.c)
- Wintun for the tun device (tun_windows.c)

The difference with POSIX is that Windows uses different handles for watching events and doing I/O:

- Winsock
  - I/O is done on SOCKET
  - Events are watched with a linked WSAEVENT
- Wintun
  - I/O is done with specific Wintun DLL read/write calls
  - Events are watched with an object returned by the Wintun API (WintunGetReadWaitEvent)

The great news is that both WSAEVENT and WintunGetReadWaitEvent() return a HANDLE that is compatible with WaitForMultipleObjects(), which is the exact counterpart of POSIX poll() for our case. With the Winsock/Wintun disparities hidden behind pp_socket and pp_tun, there's no additional change to make to FdLooper to work on Windows.

The only annoyance is that Winsock requires us to reset the event mask on each call to process() with WSAEnumNetworkEvents(). Failing to do so on each iteration literally leads Wintun to starvation because Winsock keeps reporting readable events forever and ever.

We wrap the reset in a NativeIOInterface.resetEvents() call, which does nothing on the tun channel.