### PR TITLE
NE: Move tun logic to C layer

### DIFF
--- a/Sources/PartoutCore/Connection/TunWrapper.swift
+++ b/Sources/PartoutCore/Connection/TunWrapper.swift
@@ -76,12 +76,8 @@ extension TunWrapper: TunInterface {
 #if canImport(Darwin)
 extension TunWrapper {
     public static func forNetworkExtension(_ ctx: PartoutLoggerContext) throws -> TunWrapper {
-        var tun: pp_tun?
-
         // Look up Network Extension fd first
-        if let networkExtensionFd {
-            tun = pp_tun_dup(networkExtensionFd)
-        }
+        var tun = pp_tun_lookup()
 #if os(macOS)
         // Otherwise, open new device
         if tun == nil {
@@ -96,40 +92,5 @@ extension TunWrapper {
         }
         return TunWrapper(ctx, tun: tun)
     }
-
-    // FIXME: ###, This is better done in C to also omit the manual structs from tun.h
-    public static var networkExtensionFd: Int32? {
-        var ctlInfo = ctl_info()
-        withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
-            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
-                _ = strcpy($0, "com.apple.net.utun_control")
-            }
-        }
-        for fd: Int32 in 0...1024 {
-            var addr = sockaddr_ctl()
-            var len = socklen_t(MemoryLayout.size(ofValue: addr))
-            let ret = withUnsafeMutablePointer(to: &addr) {
-                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                    getpeername(fd, $0, &len)
-                }
-            }
-            guard ret == 0 && addr.sc_family == AF_SYSTEM else {
-                continue
-            }
-            if ctlInfo.ctl_id == 0 {
-                let ret = ioctl(fd, Self.CTLIOCGINFO, &ctlInfo)
-                guard ret == 0 else {
-                    continue
-                }
-            }
-            guard addr.sc_id == ctlInfo.ctl_id else {
-                continue
-            }
-            return fd
-        }
-        return nil
-    }
-
-    private static let CTLIOCGINFO: UInt = 0xc0644e03
 }
 #endif

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -17,31 +17,12 @@
 /* Opaque tun device. */
 typedef struct __pp_tun_struct *pp_tun;
 
-#if PARTOUT_APPLE
-/* Duplicate Network Extension fd. */
-pp_tun _Nullable pp_tun_dup(pp_fd fd);
-
-#if !PARTOUT_MACOS
-/* Redefine these manually because the <sys/kern_control.h>
- * header is not exposed to iOS/tvOS */
-struct ctl_info {
-    u_int32_t   ctl_id;
-    char        ctl_name[96];
-};
-struct sockaddr_ctl {
-    u_char      sc_len;
-    u_char      sc_family;
-    u_int16_t   ss_sysaddr;
-    u_int32_t   sc_id;
-    u_int32_t   sc_unit;
-    u_int32_t   sc_reserved[5];
-};
-#endif
-#endif
-
-#if PARTOUT_MACOS || PARTOUT_LINUX || PARTOUT_WINDOWS
-/* On desktop, we can request a new device. */
+/* Request a new device. */
 pp_tun _Nullable pp_tun_open(const char *uuid);
+#if PARTOUT_APPLE
+/* Look up Network Extension fd. */
+pp_tun _Nullable pp_tun_lookup(void);
+pp_fd pp_tun_network_extension_fd(void);
 #endif
 
 /* Platform-specific implementations. */

--- a/Sources/PartoutCore_C/include/portable/tun.h
+++ b/Sources/PartoutCore_C/include/portable/tun.h
@@ -17,8 +17,11 @@
 /* Opaque tun device. */
 typedef struct __pp_tun_struct *pp_tun;
 
+#if PARTOUT_MACOS || PARTOUT_LINUX || PARTOUT_WINDOWS
 /* Request a new device. */
 pp_tun _Nullable pp_tun_open(const char *uuid);
+#endif
+
 #if PARTOUT_APPLE
 /* Look up Network Extension fd. */
 pp_tun _Nullable pp_tun_lookup(void);

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -19,6 +19,20 @@
 #include <string.h>
 #include "portable/endian.h"
 
+#if defined(UTUN_CONTROL_NAME)
+#define PP_UTUN_CONTROL_NAME UTUN_CONTROL_NAME
+#else
+#define PP_UTUN_CONTROL_NAME "com.apple.net.utun_control"
+#endif
+
+#if defined(CTLIOCGINFO)
+#define PP_CTLIOCGINFO CTLIOCGINFO
+#else
+#define PP_CTLIOCGINFO 0xc0644e03UL
+#endif
+
+#define PP_TUN_NE_FD_MAX 1024
+
 struct __pp_tun_struct {
     pp_fd fd;
     const char *dev_name;
@@ -79,17 +93,22 @@ failure:
     if (fd != -1) close(fd);
     return NULL;
 }
+#else
+/* Redefine these manually because the <sys/kern_control.h>
+ * header is not exposed to iOS/tvOS */
+struct ctl_info {
+    u_int32_t   ctl_id;
+    char        ctl_name[96];
+};
+struct sockaddr_ctl {
+    u_char      sc_len;
+    u_char      sc_family;
+    u_int16_t   ss_sysaddr;
+    u_int32_t   sc_id;
+    u_int32_t   sc_unit;
+    u_int32_t   sc_reserved[5];
+};
 #endif
-
-/* iOS/tvOS requires the file descriptor to be duplicated. */
-pp_tun pp_tun_dup(pp_fd fd) {
-    pp_assert(fd >= 0);
-    const int dup_fd = dup(fd);
-    if (dup_fd < 0) return NULL;
-    pp_tun tun = pp_alloc(sizeof(*tun));
-    tun->fd = dup_fd;
-    return tun;
-}
 
 void pp_tun_free_and_close(pp_tun tun, bool and_close) {
     if (!tun) return;
@@ -100,6 +119,43 @@ void pp_tun_free_and_close(pp_tun tun, bool and_close) {
         pp_free((void *)tun->dev_name);
     }
     pp_free(tun);
+}
+
+pp_tun pp_tun_lookup(void) {
+    const int fd = pp_tun_network_extension_fd();
+    pp_assert(fd >= 0);
+    /* iOS/tvOS requires the file descriptor to be duplicated. */
+    // FIXME: ###, and macOS NE?
+    const int dup_fd = dup(fd);
+    if (dup_fd < 0) return NULL;
+    pp_tun tun = pp_alloc(sizeof(*tun));
+    tun->fd = dup_fd;
+    tun->dev_name = NULL;
+    return tun;
+}
+
+pp_fd pp_tun_network_extension_fd(void) {
+    struct ctl_info ctl_info = { 0 };
+    snprintf(ctl_info.ctl_name, sizeof(ctl_info.ctl_name), "%s", PP_UTUN_CONTROL_NAME);
+    for (pp_fd fd = 0; fd <= PP_TUN_NE_FD_MAX; ++fd) {
+        struct sockaddr_ctl addr = { 0 };
+        socklen_t len = sizeof(addr);
+        int ret;
+        PP_IO_RETRY(ret, getpeername(fd, (struct sockaddr *)&addr, &len));
+        if (ret != 0 || addr.sc_family != AF_SYSTEM) {
+            continue;
+        }
+        if (ctl_info.ctl_id == 0) {
+            PP_IO_RETRY(ret, ioctl(fd, PP_CTLIOCGINFO, &ctl_info));
+            if (ret != 0) {
+                continue;
+            }
+        }
+        if (addr.sc_id == ctl_info.ctl_id) {
+            return fd;
+        }
+    }
+    return -1;
 }
 
 /* The first 4 bits of a local packet identify the IP family. */

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -123,7 +123,7 @@ void pp_tun_free_and_close(pp_tun tun, bool and_close) {
 
 pp_tun pp_tun_lookup(void) {
     const int fd = pp_tun_network_extension_fd();
-    pp_assert(fd >= 0);
+    if (fd < 0) return NULL;
     /* iOS/tvOS requires the file descriptor to be duplicated. */
     // FIXME: ###, and macOS NE?
     const int dup_fd = dup(fd);

--- a/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NETunnelInterface.swift
@@ -29,7 +29,9 @@ public final class NETunnelInterface: TunInterface {
     }
 
     public var muxDescriptor: FileDescriptor? {
-        TunWrapper.networkExtensionFd
+        let fd = pp_tun_network_extension_fd()
+        guard pp_fd_is_valid(fd) else { return nil }
+        return fd
     }
 
     public func readPackets() async throws -> [Data] {

--- a/Sources/PartoutWireGuardConnection/V1/Internal/LegacyWireGuardAdapter.swift
+++ b/Sources/PartoutWireGuardConnection/V1/Internal/LegacyWireGuardAdapter.swift
@@ -46,7 +46,7 @@ class LegacyWireGuardAdapter: @unchecked Sendable {
 
     /// Tunnel device file descriptor.
     private var tunnelFileDescriptor: Int32? {
-        TunWrapper.networkExtensionFd
+        Self.networkExtensionFd
     }
 
     /// Returns a WireGuard version.
@@ -385,4 +385,40 @@ private extension Network.NWPath.Status {
             return true
         }
     }
+}
+
+private extension LegacyWireGuardAdapter {
+    static var networkExtensionFd: Int32? {
+        var ctlInfo = ctl_info()
+        withUnsafeMutablePointer(to: &ctlInfo.ctl_name) {
+            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: $0.pointee)) {
+                _ = strcpy($0, "com.apple.net.utun_control")
+            }
+        }
+        for fd: Int32 in 0...1024 {
+            var addr = sockaddr_ctl()
+            var len = socklen_t(MemoryLayout.size(ofValue: addr))
+            let ret = withUnsafeMutablePointer(to: &addr) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    getpeername(fd, $0, &len)
+                }
+            }
+            guard ret == 0 && addr.sc_family == AF_SYSTEM else {
+                continue
+            }
+            if ctlInfo.ctl_id == 0 {
+                let ret = ioctl(fd, Self.CTLIOCGINFO, &ctlInfo)
+                guard ret == 0 else {
+                    continue
+                }
+            }
+            guard addr.sc_id == ctlInfo.ctl_id else {
+                continue
+            }
+            return fd
+        }
+        return nil
+    }
+
+    private static let CTLIOCGINFO: UInt = 0xc0644e03
 }

--- a/Sources/PartoutWireGuard_C/include/wireguard/sys.h
+++ b/Sources/PartoutWireGuard_C/include/wireguard/sys.h
@@ -12,4 +12,22 @@
 #include "wireguard/key.h"
 #include "wireguard/x25519.h"
 
+// FIXME: ###, Delete after using pp_tun_network_extension_fd()
+/* Redefine these manually because the <sys/kern_control.h>
+ * header is not exposed to iOS/tvOS */
+#if PARTOUT_APPLE && !PARTOUT_MACOS
+struct ctl_info {
+    u_int32_t   ctl_id;
+    char        ctl_name[96];
+};
+struct sockaddr_ctl {
+    u_char      sc_len;
+    u_char      sc_family;
+    u_int16_t   ss_sysaddr;
+    u_int32_t   sc_id;
+    u_int32_t   sc_unit;
+    u_int32_t   sc_reserved[5];
+};
+#endif
+
 #endif


### PR DESCRIPTION
Keep the Swift code for tun fd like it was before #449 in legacy WireGuard. Going forward, though, move the tun lookup to C code because it feels more natural.