### PR TITLE
OpenVPN: Share reachability snapshot between DNS and socket creation

### DIFF
--- a/Sources/PartoutCore/Connection/DNSResolver.swift
+++ b/Sources/PartoutCore/Connection/DNSResolver.swift
@@ -40,7 +40,7 @@ public protocol DNSResolver: AnyObject, Sendable {
 }
 
 extension DNSResolver {
-    public func resolve(_ hostname: String, flags: Set<DNSResolverFlag> = [], timeout: Int) async throws -> [DNSRecord] {
-        try await resolve(hostname, flags: flags, reachability: nil, timeout: timeout)
+    public func resolve(_ hostname: String, flags: Set<DNSResolverFlag> = [], reachability: ReachabilityInfo?, timeout: Int) async throws -> [DNSRecord] {
+        try await resolve(hostname, flags: flags, reachability: reachability, timeout: timeout)
     }
 }

--- a/Sources/PartoutCore/Connection/EndpointResolver+Resolvable.swift
+++ b/Sources/PartoutCore/Connection/EndpointResolver+Resolvable.swift
@@ -40,9 +40,10 @@ extension EndpointResolver {
             self.isResolved = isResolved
         }
 
-        func resolved(with dns: DNSResolver, timeout: Int) async throws -> Self {
+        func resolved(with dns: DNSResolver, reachability: ReachabilityInfo?, timeout: Int) async throws -> Self {
             let records = try await dns.resolve(
                 originalEndpoint.address.rawValue,
+                reachability: reachability,
                 timeout: timeout
             )
             pp_log(ctx, .core, .notice, "DNS resolved addresses: \(records.map { $0.address.asSensitiveAddress(ctx) })")

--- a/Sources/PartoutCore/Connection/EndpointResolver.swift
+++ b/Sources/PartoutCore/Connection/EndpointResolver.swift
@@ -32,6 +32,7 @@ public struct EndpointResolver: Sendable {
 
     public func withNextEndpoint(
         dns: DNSResolver,
+        reachability: ReachabilityInfo?,
         timeout: Int
     ) async throws -> (nextResolver: Self, endpoint: ExtendedEndpoint) {
         var copy = self
@@ -52,7 +53,11 @@ public struct EndpointResolver: Sendable {
                 pp_log(ctx, .core, .info, "Try DNS resolution: \(currentResolvable.asSensitiveAddress(ctx))")
                 let newResolvable: EndpointResolver.Resolvable
                 do {
-                    newResolvable = try await currentResolvable.resolved(with: dns, timeout: timeout)
+                    newResolvable = try await currentResolvable.resolved(
+                        with: dns,
+                        reachability: reachability,
+                        timeout: timeout
+                    )
                 } catch {
                     pp_log(ctx, .core, .fault, "DNS resolution failed: \(error)")
                     newResolvable = currentResolvable.with(newResolvedEndpoints: [])

--- a/Sources/PartoutCore/Connection/LinkObserver.swift
+++ b/Sources/PartoutCore/Connection/LinkObserver.swift
@@ -4,7 +4,6 @@
 
 /// Observes activity to eventually return a ``LinkInterface``.
 public protocol LinkObserver {
-
     /// Waits until the link is active.
     ///
     /// - Parameter timeout: The timeout for link activity.

--- a/Sources/PartoutCore/Connection/NativeSocketFactory.swift
+++ b/Sources/PartoutCore/Connection/NativeSocketFactory.swift
@@ -39,33 +39,34 @@ public final class NativeSocketFactory: NetworkInterfaceFactory {
     }
 
     private let ctx: PartoutLoggerContext
+    private let currentReachabilityBlock: (@Sendable () -> ReachabilityInfo?)?
     private let betterPathFactory: BetterPathStreamFactory
-    private let currentReachability: (@Sendable () -> ReachabilityInfo?)?
     private let configureSocket: ConfigureSocket?
     private let bufSize: Int
 
     public init(
         _ ctx: PartoutLoggerContext,
+        currentReachabilityBlock: (@Sendable () -> ReachabilityInfo?)?,
         betterPathFactory: BetterPathStreamFactory,
         bufSize: Int = 1 * 1024 * 1024, // 1MB
     ) {
         self.ctx = ctx
+        self.currentReachabilityBlock = currentReachabilityBlock
         self.betterPathFactory = betterPathFactory
-        currentReachability = nil
         configureSocket = nil
         self.bufSize = bufSize
     }
 
     init(
         _ ctx: PartoutLoggerContext,
+        currentReachabilityBlock: (@Sendable () -> ReachabilityInfo?)?,
         betterPathFactory: BetterPathStreamFactory,
-        currentReachability: (@Sendable () -> ReachabilityInfo?)?,
         configureSocket: ConfigureSocket?,
         bufSize: Int = 1 * 1024 * 1024, // 1MB
     ) {
         self.ctx = ctx
+        self.currentReachabilityBlock = currentReachabilityBlock
         self.betterPathFactory = betterPathFactory
-        self.currentReachability = currentReachability
         self.configureSocket = configureSocket
         self.bufSize = bufSize
     }
@@ -74,8 +75,14 @@ public final class NativeSocketFactory: NetworkInterfaceFactory {
         pp_log(ctx, .core, .debug, "Deinit NativeSocketFactory")
     }
 
-    public func linkObserver(to endpoint: ExtendedEndpoint) -> LinkObserver {
-        let reachability = currentReachability?()
+    public func currentReachability() -> ReachabilityInfo? {
+        currentReachabilityBlock?()
+    }
+
+    public func linkObserver(
+        to endpoint: ExtendedEndpoint,
+        reachability: ReachabilityInfo?
+    ) -> LinkObserver {
         return Observer(factory: self, endpoint: endpoint, reachability: reachability)
     }
 }

--- a/Sources/PartoutCore/Connection/NativeTunnelController.swift
+++ b/Sources/PartoutCore/Connection/NativeTunnelController.swift
@@ -177,10 +177,10 @@ extension NativeTunnelController {
     public func newSocketFactory() -> NativeSocketFactory {
         NativeSocketFactory(
             ctx,
-            betterPathFactory: betterPathFactory,
-            currentReachability: { [weak self] in
+            currentReachabilityBlock: { [weak self] in
                 self?.currentReachability
             },
+            betterPathFactory: betterPathFactory,
             configureSocket: { [weak self] fd, reachability in
                 guard let self else {
                     let msg = "Configuring sockets, but NativeTunnelController was released"

--- a/Sources/PartoutCore/Connection/NetworkInterfaceFactory.swift
+++ b/Sources/PartoutCore/Connection/NetworkInterfaceFactory.swift
@@ -4,9 +4,10 @@
 
 /// Generalizes the creation of network interfaces.
 public protocol NetworkInterfaceFactory: Sendable {
+    func currentReachability() -> ReachabilityInfo?
 
     /// Returns a `LinkObserver` to establish a link to the specified endpoint.
     ///
     /// - Parameter endpoint: The endpoint to connect to.
-    func linkObserver(to endpoint: ExtendedEndpoint) throws -> LinkObserver
+    func linkObserver(to endpoint: ExtendedEndpoint, reachability: ReachabilityInfo?) throws -> LinkObserver
 }

--- a/Sources/PartoutCore/Testing/MockNetworkInterfaceFactory.swift
+++ b/Sources/PartoutCore/Testing/MockNetworkInterfaceFactory.swift
@@ -10,7 +10,14 @@ public final class MockNetworkInterfaceFactory: NetworkInterfaceFactory, @unchec
     public init() {
     }
 
-    public func linkObserver(to endpoint: ExtendedEndpoint) -> LinkObserver {
+    public func currentReachability() -> ReachabilityInfo? {
+        nil
+    }
+
+    public func linkObserver(
+        to endpoint: ExtendedEndpoint,
+        reachability: ReachabilityInfo?,
+    ) -> LinkObserver {
         let newObserver = MockLinkObserver(to: endpoint, linkBlock: linkBlock)
         observerBlock(newObserver)
         return newObserver

--- a/Sources/PartoutOS/AppleNE/Connection/NEInterfaceFactory.swift
+++ b/Sources/PartoutOS/AppleNE/Connection/NEInterfaceFactory.swift
@@ -35,7 +35,14 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
         self.options = options
     }
 
-    public func linkObserver(to endpoint: ExtendedEndpoint) throws -> LinkObserver {
+    public func currentReachability() -> ReachabilityInfo? {
+        nil
+    }
+
+    public func linkObserver(
+        to endpoint: ExtendedEndpoint,
+        reachability: ReachabilityInfo?
+    ) throws -> LinkObserver {
         guard let provider else {
             pp_log(ctx, .os, .info, "NEInterfaceFactory: NEPacketTunnelProvider released")
             throw PartoutError(.releasedObject)

--- a/Sources/PartoutOpenVPN/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPN/V2/_OpenVPNConnectionV2.swift
@@ -352,6 +352,7 @@ private extension _OpenVPNConnectionV2 {
     func setupLink(upgradingCurrent: Bool) async throws -> LinkInterface {
         do {
             pp_log(ctx, .core, .notice, "Create new link")
+            let reachability = factory.currentReachability()
             var newLink: LinkInterface
 
             // upgrade current link if possible
@@ -364,14 +365,14 @@ private extension _OpenVPNConnectionV2 {
                 pp_log(ctx, .core, .notice, "Cycle to next endpoint")
                 let result = try await endpointResolver.withNextEndpoint(
                     dns: dns,
-                    reachability: nil,
+                    reachability: reachability,
                     timeout: options.dnsTimeout
                 )
                 endpointResolver = result.nextResolver
 
                 let linkObserver = try factory.linkObserver(
                     to: result.endpoint,
-                    reachability: nil
+                    reachability: reachability
                 )
                 pp_log(ctx, .core, .notice, "Connect to \(result.endpoint.asSensitiveAddress(ctx))")
                 newLink = try await linkObserver.waitForActivity(timeout: options.linkActivityTimeout)

--- a/Sources/PartoutOpenVPN/V2/_OpenVPNConnectionV2.swift
+++ b/Sources/PartoutOpenVPN/V2/_OpenVPNConnectionV2.swift
@@ -364,11 +364,15 @@ private extension _OpenVPNConnectionV2 {
                 pp_log(ctx, .core, .notice, "Cycle to next endpoint")
                 let result = try await endpointResolver.withNextEndpoint(
                     dns: dns,
+                    reachability: nil,
                     timeout: options.dnsTimeout
                 )
                 endpointResolver = result.nextResolver
 
-                let linkObserver = try factory.linkObserver(to: result.endpoint)
+                let linkObserver = try factory.linkObserver(
+                    to: result.endpoint,
+                    reachability: nil
+                )
                 pp_log(ctx, .core, .notice, "Connect to \(result.endpoint.asSensitiveAddress(ctx))")
                 newLink = try await linkObserver.waitForActivity(timeout: options.linkActivityTimeout)
 

--- a/Sources/PartoutOpenVPN/V3/_OpenVPNConnectionV3.swift
+++ b/Sources/PartoutOpenVPN/V3/_OpenVPNConnectionV3.swift
@@ -408,12 +408,13 @@ private extension _OpenVPNConnectionV3 {
     func setupLink(upgradingCurrent: Bool) async throws -> LinkInterface {
         do {
             pp_log(ctx, .openvpn, .notice, "Create new link")
+            let reachability = factory.currentReachability()
             var newLink: LinkInterface
 
             // Upgrade current link if possible
             if upgradingCurrent, let currentEndpoint {
                 pp_log(ctx, .openvpn, .notice, "Will reconnect to current link")
-                let linkObserver = try factory.linkObserver(to: currentEndpoint)
+                let linkObserver = try factory.linkObserver(to: currentEndpoint, reachability: reachability)
                 newLink = try await linkObserver.waitForActivity(timeout: options.linkActivityTimeout)
             }
             // Create new link
@@ -421,11 +422,12 @@ private extension _OpenVPNConnectionV3 {
                 pp_log(ctx, .openvpn, .notice, "Cycle to next endpoint")
                 let result = try await endpointResolver.withNextEndpoint(
                     dns: dns,
+                    reachability: reachability,
                     timeout: options.dnsTimeout
                 )
                 endpointResolver = result.nextResolver
 
-                let linkObserver = try factory.linkObserver(to: result.endpoint)
+                let linkObserver = try factory.linkObserver(to: result.endpoint, reachability: reachability)
                 pp_log(ctx, .openvpn, .notice, "Connect to \(result.endpoint.asSensitiveAddress(ctx))")
                 newLink = try await linkObserver.waitForActivity(timeout: options.linkActivityTimeout)
                 currentEndpoint = result.endpoint

--- a/Sources/PartoutWireGuard/V2/Internal/Configuration+Resolve.swift
+++ b/Sources/PartoutWireGuard/V2/Internal/Configuration+Resolve.swift
@@ -82,6 +82,7 @@ extension WireGuard.Configuration {
                         let resolvedRecords = try await resolver.resolve(
                             endpoint.address.rawValue,
                             flags: flags,
+                            reachability: nil, // Relies on default
                             timeout: timeout
                         )
                         var currentResolved: [Endpoint] = []

--- a/Tests/PartoutCoreTests/DNSResolverTests.swift
+++ b/Tests/PartoutCoreTests/DNSResolverTests.swift
@@ -12,7 +12,7 @@ struct DNSResolverTests {
 
         let sut = MockDNSResolver()
         sut.resolvedRecords = ["www.google.com": expRecords]
-        let records = try await sut.resolve("www.google.com", timeout: 1000)
+        let records = try await sut.resolve("www.google.com", reachability: nil,timeout: 1000)
         #expect(records == expRecords)
     }
 
@@ -21,7 +21,7 @@ struct DNSResolverTests {
         let sut = MockDNSResolver()
         sut.error = PartoutError(.dnsFailure)
         do {
-            _ = try await sut.resolve("www.google.com", timeout: 1000)
+            _ = try await sut.resolve("www.google.com", reachability: nil,timeout: 1000)
         } catch let error as PartoutError {
             #expect(error.code == .dnsFailure)
         } catch {
@@ -34,7 +34,7 @@ struct DNSResolverTests {
         let sut = MockDNSResolver()
         sut.error = PartoutError(.timeout)
         do {
-            _ = try await sut.resolve("www.google.com", timeout: 1000)
+            _ = try await sut.resolve("www.google.com", reachability: nil,timeout: 1000)
         } catch let error as PartoutError {
             #expect(error.code == .timeout)
         } catch {

--- a/Tests/PartoutCoreTests/EndpointResolverResolvableTests.swift
+++ b/Tests/PartoutCoreTests/EndpointResolverResolvableTests.swift
@@ -21,7 +21,7 @@ struct EndpointResolverResolvableTests {
         dns.resolvedRecords = [hostname: resolvedRecords]
         var sut = EndpointResolver.Resolvable(.global, endpoint)
 
-        sut = try await sut.resolved(with: dns, timeout: 1000)
+        sut = try await sut.resolved(with: dns, reachability: nil,timeout: 1000)
         #expect(sut.isResolved)
 
         for (i, record) in resolvedRecords.enumerated() {
@@ -45,7 +45,7 @@ struct EndpointResolverResolvableTests {
         var sut = EndpointResolver.Resolvable(.global, endpoint)
 
         do {
-            sut = try await sut.resolved(with: dns, timeout: 1000)
+            sut = try await sut.resolved(with: dns, reachability: nil,timeout: 1000)
         } catch {
             sut = sut.with(newResolvedEndpoints: [])
         }

--- a/Tests/PartoutCoreTests/EndpointResolverTests.swift
+++ b/Tests/PartoutCoreTests/EndpointResolverTests.swift
@@ -34,7 +34,7 @@ struct EndpointResolverTests {
         var i = 0
         do {
             while true {
-                let result = try await sut.withNextEndpoint(dns: dns, timeout: 1000)
+                let result = try await sut.withNextEndpoint(dns: dns, reachability: nil,timeout: 1000)
                 sut = result.nextResolver
                 #expect(result.endpoint.description == expected[i])
                 i += 1
@@ -67,7 +67,7 @@ struct EndpointResolverTests {
         var i = 0
         do {
             while true {
-                let result = try await sut.withNextEndpoint(dns: dns, timeout: 1000)
+                let result = try await sut.withNextEndpoint(dns: dns, reachability: nil,timeout: 1000)
                 sut = result.nextResolver
                 #expect(result.endpoint.description == expected[i])
                 i += 1
@@ -100,7 +100,7 @@ struct EndpointResolverTests {
         var i = 0
         do {
             while true {
-                let result = try await sut.withNextEndpoint(dns: dns, timeout: 1000)
+                let result = try await sut.withNextEndpoint(dns: dns, reachability: nil,timeout: 1000)
                 sut = result.nextResolver
                 #expect(result.endpoint.description == expected[i])
                 i += 1
@@ -150,7 +150,7 @@ struct EndpointResolverTests {
         var i = 0
         do {
             while true {
-                let result = try await sut.withNextEndpoint(dns: dns, timeout: 1000)
+                let result = try await sut.withNextEndpoint(dns: dns, reachability: nil,timeout: 1000)
                 sut = result.nextResolver
                 #expect(result.endpoint == expected[i])
                 i += 1

--- a/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
+++ b/Tests/PartoutCoreTests/SimpleDNSResolverTests.swift
@@ -12,7 +12,7 @@ struct SimpleDNSResolverTests {
         let sut = SimpleDNSResolver { _, _ in
             MockStrategy(records: records, delay: 100)
         }
-        let result = try await sut.resolve("foobar.com", timeout: 500)
+        let result = try await sut.resolve("foobar.com", reachability: nil, timeout: 500)
         #expect(result == records)
     }
 
@@ -23,7 +23,7 @@ struct SimpleDNSResolverTests {
             MockStrategy(records: records, delay: 500)
         }
         do {
-            _ = try await sut.resolve("foobar.com", timeout: 100)
+            _ = try await sut.resolve("foobar.com", reachability: nil,timeout: 100)
             #expect(Bool(false), ".resolve must fail")
         } catch let error as PartoutError {
             #expect(error.code == .timeout)
@@ -38,7 +38,7 @@ struct SimpleDNSResolverTests {
             CancellationIgnoringStrategy()
         }
         do {
-            _ = try await sut.resolve("foobar.com", timeout: 100)
+            _ = try await sut.resolve("foobar.com", reachability: nil,timeout: 100)
             #expect(Bool(false), ".resolve must fail")
         } catch let error as PartoutError {
             #expect(error.code == .timeout)


### PR DESCRIPTION
Capture the current reachability snapshot once during OpenVPN link setup, then pass it through hostname resolution and LinkObserver/socket creation. This keeps DNS resolution and socket configuration aligned to the same reachability state when a snapshot is available.

Requires a small refactoring of NetworkInterfaceFactory to add a reachability argument in LinkObserver.