### PR TITLE
CMake: Add install step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,39 @@ if(PP_BUILD_LIBRARY)
         target_link_libraries(partout_c PRIVATE "$<BUILD_LOCAL_INTERFACE:WireGuardGoInterface>")
     endif()
 
+    # Install
     set(PARTOUT_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/Partout")
+    if(PP_BUILD_USE_OPENSSL)
+        list(APPEND PARTOUT_VENDOR_BYPRODUCTS
+            "${OPENSSL_DIR}/${LIBSSL}"
+            "${OPENSSL_DIR}/${LIBCRYPTO}"
+        )
+        if(WIN32)
+            list(APPEND PARTOUT_VENDOR_BYPRODUCTS
+                "${OPENSSL_DIR}/${LIBSSL_IMP}"
+                "${OPENSSL_DIR}/${LIBCRYPTO_IMP}"
+            )
+        endif()
+    endif()
+    if(PP_BUILD_USE_MBEDTLS)
+        list(APPEND PARTOUT_VENDOR_BYPRODUCTS
+            "${MBEDTLS_DIR}/${LIBTLS}"
+            "${MBEDTLS_DIR}/${LIBX509}"
+            "${MBEDTLS_DIR}/${LIBCRYPTO}"
+        )
+    endif()
+    if(PP_BUILD_USE_WIREGUARD)
+        list(APPEND PARTOUT_VENDOR_BYPRODUCTS ${WGGO_BYPRODUCTS})
+    endif()
+    if(WIN32)
+        list(APPEND PARTOUT_VENDOR_BYPRODUCTS "${WINTUN_DIR}/wintun.dll")
+    endif()
+    foreach(vendor_byproduct ${PARTOUT_VENDOR_BYPRODUCTS})
+        file(RELATIVE_PATH vendor_byproduct_rel "${PP_BUILD_OUTPUT}" "${vendor_byproduct}")
+        get_filename_component(vendor_byproduct_dir "${vendor_byproduct_rel}" DIRECTORY)
+        install(FILES "${vendor_byproduct}" DESTINATION "${vendor_byproduct_dir}")
+    endforeach()
+    unset(PARTOUT_VENDOR_BYPRODUCTS)
     configure_package_config_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/PartoutConfig.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/PartoutConfig.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ endif()
 project(Partout LANGUAGES Swift C CXX)
 include(ExternalProject)
 include(FetchContent)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 # Command line options
 option(PP_BUILD_LIBRARY "Include main library" 0)
@@ -75,11 +77,27 @@ endif()
 if(PP_BUILD_LIBRARY)
     add_subdirectory(Sources)
     if(PP_BUILD_USE_OPENSSL)
-        target_link_libraries(partout_c PUBLIC OpenSSLInterface)
+        target_link_libraries(partout_c PRIVATE "$<BUILD_LOCAL_INTERFACE:OpenSSLInterface>")
     elseif(PP_BUILD_USE_MBEDTLS)
-        target_link_libraries(partout_c PUBLIC MbedTLSInterface)
+        target_link_libraries(partout_c PRIVATE "$<BUILD_LOCAL_INTERFACE:MbedTLSInterface>")
     endif()
     if(PP_BUILD_USE_WIREGUARD)
-        target_link_libraries(partout_c PUBLIC WireGuardGoInterface)
+        target_link_libraries(partout_c PRIVATE "$<BUILD_LOCAL_INTERFACE:WireGuardGoInterface>")
     endif()
+
+    set(PARTOUT_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/Partout")
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/PartoutConfig.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/PartoutConfig.cmake"
+        INSTALL_DESTINATION "${PARTOUT_INSTALL_CMAKEDIR}"
+    )
+    install(EXPORT PartoutTargets
+        FILE PartoutTargets.cmake
+        NAMESPACE Partout::
+        DESTINATION "${PARTOUT_INSTALL_CMAKEDIR}"
+    )
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/PartoutConfig.cmake"
+        DESTINATION "${PARTOUT_INSTALL_CMAKEDIR}"
+    )
 endif()

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -69,6 +69,22 @@ else()
     )
 endif()
 
+# Exclude legacy connections
+list(APPEND EXCLUDED_PATTERNS
+    [=[PartoutOpenVPN/OpenVPNConnection[+]Alias[.]swift$]=]
+    PartoutOpenVPN\/V2
+    [=[PartoutWireGuard/WireGuardConnection[+]Alias[.]swift$]=]
+    PartoutWireGuard\/V1
+)
+
+# Use Foundation on Apple, compatible otherwise
+if(NOT APPLE)
+    set(USE_COMPAT ON)
+    list(APPEND EXCLUDED_PATTERNS
+        PartoutOS\/Apple.*
+    )
+endif()
+
 # Partout_C ############################################
 
 # Base configuration
@@ -77,7 +93,7 @@ target_compile_options(partout_c PRIVATE
     -DUSE_CMAKE
 )
 
-# Account for exclusions in source files
+# Apply exclusions
 foreach(pattern ${EXCLUDED_PATTERNS})
     list(FILTER PARTOUT_C_SOURCES EXCLUDE REGEX ${pattern})
 endforeach()
@@ -104,14 +120,6 @@ target_compile_options(partout PRIVATE
     -DUSE_CMAKE
 )
 
-# Use Foundation on Apple, compatible otherwise
-if(NOT APPLE)
-    set(USE_COMPAT ON)
-    list(APPEND EXCLUDED_PATTERNS
-        PartoutOS\/Apple.*
-    )
-endif()
-
 # Exclude Foundation if compatibility is on
 if(USE_COMPAT)
     target_compile_options(partout PRIVATE
@@ -119,20 +127,17 @@ if(USE_COMPAT)
     )
 endif()
 
-# Exclude legacy connections
-list(APPEND EXCLUDED_PATTERNS
-    PartoutOpenVPN\/V1
-    PartoutWireGuard\/V1
-)
-
+# Apply exclusions
 foreach(pattern ${EXCLUDED_PATTERNS})
     list(FILTER PARTOUT_SOURCES EXCLUDE REGEX ${pattern})
 endforeach()
 
-# Look for modulemaps in C "include" dirs while building Partout.
+# Look up internal partout_c modulemaps while building
 foreach(dir ${PARTOUT_C_INCLUDE_DIRS})
     target_include_directories(partout PRIVATE ${dir})
 endforeach()
+
+# Look up public headers
 target_include_directories(partout PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Partout_C/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -177,17 +182,41 @@ set_target_properties(partout_c PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_DIR}
 )
 
+# Platform specifics
 if(WIN32)
     set_target_properties(partout_c PROPERTIES PREFIX "lib")
     set_target_properties(partout PROPERTIES PREFIX "lib")
-elseif(LINUX)
+else()
+    if(APPLE)
+        set(RPATH_ORIGIN "@loader_path")
+    else()
+        set(RPATH_ORIGIN "\$ORIGIN")
+    endif()
+    set(PARTOUT_RPATH "${RPATH_ORIGIN}")
+    if(PP_BUILD_USE_OPENSSL)
+        list(APPEND PARTOUT_RPATH "${RPATH_ORIGIN}/../openssl/lib")
+    endif()
+    if(PP_BUILD_USE_WIREGUARD)
+        list(APPEND PARTOUT_RPATH "${RPATH_ORIGIN}/../wg-go/lib")
+    endif()
     set_target_properties(partout PROPERTIES
-        BUILD_RPATH "\$ORIGIN"
-        INSTALL_RPATH "\$ORIGIN"
+        BUILD_WITH_INSTALL_RPATH ON
+        INSTALL_RPATH "${PARTOUT_RPATH}"
         SKIP_BUILD_RPATH OFF
+    )
+    unset(PARTOUT_RPATH)
+    unset(RPATH_ORIGIN)
+endif()
+
+# Strip after build
+if((LINUX OR ANDROID) AND NOT PP_BUILD_STATIC)
+    add_custom_command(TARGET partout POST_BUILD
+        COMMAND ${CMAKE_STRIP} $<TARGET_FILE:partout>
+        COMMENT "Stripping $<TARGET_FILE_NAME:partout>"
     )
 endif()
 
+# Configure install
 install(TARGETS partout
     EXPORT PartoutTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -199,6 +228,8 @@ install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Partout_C/include/module.modulemap
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+# Include partout_c if building statically (cannot embed)
 if(PP_BUILD_STATIC)
     install(TARGETS partout_c
         EXPORT PartoutTargets

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -84,7 +84,7 @@ endforeach()
 
 # Add computed files
 target_sources(partout_c PRIVATE ${PARTOUT_C_SOURCES})
-target_include_directories(partout_c PUBLIC ${PARTOUT_C_INCLUDE_DIRS})
+target_include_directories(partout_c PRIVATE ${PARTOUT_C_INCLUDE_DIRS})
 if(LINUX OR ANDROID)
     target_compile_options(partout_c PRIVATE -fPIC)
 endif()
@@ -97,6 +97,7 @@ if(PP_BUILD_STATIC)
 else()
     add_library(partout SHARED "")
 endif()
+add_library(Partout::partout ALIAS partout)
 
 # Define symbols to skip Swift imports and legacy code
 target_compile_options(partout PRIVATE
@@ -128,14 +129,25 @@ foreach(pattern ${EXCLUDED_PATTERNS})
     list(FILTER PARTOUT_SOURCES EXCLUDE REGEX ${pattern})
 endforeach()
 
-# Look for modulemaps in C "include" dirs
+# Look for modulemaps in C "include" dirs while building Partout.
 foreach(dir ${PARTOUT_C_INCLUDE_DIRS})
-    target_include_directories(partout PUBLIC ${dir})
+    target_include_directories(partout PRIVATE ${dir})
 endforeach()
+target_include_directories(partout PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Partout_C/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 # Depend on C target (include before)
 add_dependencies(partout partout_c)
-target_sources(partout PRIVATE ${PARTOUT_SOURCES})
+target_sources(partout
+    PRIVATE ${PARTOUT_SOURCES}
+    PUBLIC
+        FILE_SET api_headers
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/Partout_C/include
+        FILES ${CMAKE_CURRENT_SOURCE_DIR}/Partout_C/include/partout.h
+)
 target_link_libraries(partout PRIVATE partout_c)
 
 # Apple still requires Swift 5 for NE
@@ -173,5 +185,23 @@ elseif(LINUX)
         BUILD_RPATH "\$ORIGIN"
         INSTALL_RPATH "\$ORIGIN"
         SKIP_BUILD_RPATH OFF
+    )
+endif()
+
+install(TARGETS partout
+    EXPORT PartoutTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    FILE_SET api_headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Partout_C/include/module.modulemap
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+if(PP_BUILD_STATIC)
+    install(TARGETS partout_c
+        EXPORT PartoutTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()

--- a/Sources/Partout/DaemonABI.swift
+++ b/Sources/Partout/DaemonABI.swift
@@ -37,37 +37,12 @@ public final class DaemonABI {
         let profile = options.profile
         let ctx = PartoutLoggerContext(profile.id)
         let environment = SharedTunnelEnvironment(profileId: profile.id)
-        let registry = Registry(withKnown: true, allImplementations: [
-            OpenVPNModule.Implementation(
-                importerBlock: {
-                    StandardOpenVPNParser()
-                },
-                connectionBlock: { parameters, module in
-                    try _OpenVPNConnectionV3(
-                        ctx,
-                        parameters: parameters,
-                        module: module,
-                        cachesURL: options.cachesURL
-                    )
-                }
-            ),
-            WireGuardModule.Implementation(
-                keyGenerator: StandardWireGuardKeyGenerator(),
-                importerBlock: {
-                    StandardWireGuardParser()
-                },
-                validatorBlock: {
-                    StandardWireGuardParser()
-                },
-                connectionBlock: { parameters, module in
-                    try _WireGuardConnectionV2(
-                        ctx,
-                        parameters: parameters,
-                        module: module
-                    )
-                }
-            )
-        ])
+
+        // Compute known implementations
+        let registry = Registry(
+            withKnown: true,
+            allImplementations: Self.moduleImplementations(ctx, options: options)
+        )
 
         // Create platform-specific objects
         let betterPathFactory: BetterPathStreamFactory?
@@ -118,5 +93,51 @@ public final class DaemonABI {
 
     func stop() async {
         await daemon.stop()
+    }
+}
+
+private extension DaemonABI {
+    typealias OpenVPNConnection = _OpenVPNConnectionV3
+    typealias WireGuardConnection = _WireGuardConnectionV2
+
+    static func moduleImplementations(
+        _ ctx: PartoutLoggerContext,
+        options: Options
+    ) -> [ModuleImplementation] {
+        var list: [ModuleImplementation] = []
+#if PARTOUT_OPENVPN
+        list.append(OpenVPNModule.Implementation(
+            importerBlock: {
+                StandardOpenVPNParser()
+            },
+            connectionBlock: { parameters, module in
+                try OpenVPNConnection(
+                    ctx,
+                    parameters: parameters,
+                    module: module,
+                    cachesURL: options.cachesURL
+                )
+            }
+        ))
+#endif
+#if PARTOUT_WIREGUARD
+        list.append(WireGuardModule.Implementation(
+            keyGenerator: StandardWireGuardKeyGenerator(),
+            importerBlock: {
+                StandardWireGuardParser()
+            },
+            validatorBlock: {
+                StandardWireGuardParser()
+            },
+            connectionBlock: { parameters, module in
+                try WireGuardConnection(
+                    ctx,
+                    parameters: parameters,
+                    module: module
+                )
+            }
+        ))
+#endif
+        return list
     }
 }

--- a/Sources/PartoutOpenVPN/OpenVPNConnection+Alias.swift
+++ b/Sources/PartoutOpenVPN/OpenVPNConnection+Alias.swift
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2026 Davide De Rosa
-//
-// SPDX-License-Identifier: GPL-3.0
-
-public typealias OpenVPNConnection = _OpenVPNConnectionV2

--- a/Sources/PartoutWireGuard/WireGuardConnectionError.swift
+++ b/Sources/PartoutWireGuard/WireGuardConnectionError.swift
@@ -8,12 +8,6 @@
 //  SPDX-License-Identifier: MIT
 //  Copyright © 2018-2024 WireGuard LLC. All Rights Reserved.
 
-#if !USE_CMAKE
-public typealias WireGuardConnection = _WireGuardConnectionV1
-#else
-public typealias WireGuardConnection = _WireGuardConnectionV2
-#endif
-
 enum WireGuardConnectionError: Error {
     case dnsResolutionFailure
 

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -285,7 +285,6 @@ set(PARTOUT_SOURCES
 ./PartoutOpenVPN/KeyDecrypter.swift
 ./PartoutOpenVPN/OpenVPN+Extensions.swift
 ./PartoutOpenVPN/OpenVPN+Serialization.swift
-./PartoutOpenVPN/OpenVPNConnection+Alias.swift
 ./PartoutOpenVPN/OpenVPNConnectionOptions.swift
 ./PartoutOpenVPN/OpenVPNModule+Implementation.swift
 ./PartoutOpenVPN/OpenVPNOption.swift
@@ -341,7 +340,7 @@ set(PARTOUT_SOURCES
 ./PartoutWireGuard/V2/Internal/WireGuardAdapterError.swift
 ./PartoutWireGuard/V2/_WireGuardConnectionV2.swift
 ./PartoutWireGuard/WireGuard+Extensions.swift
-./PartoutWireGuard/WireGuardConnection+Alias.swift
+./PartoutWireGuard/WireGuardConnectionError.swift
 ./PartoutWireGuard/WireGuardKeyGenerator.swift
 ./PartoutWireGuard/WireGuardModule+Implementation.swift
 ./PartoutWireGuard/WireGuardParseError.swift

--- a/cmake/PartoutConfig.cmake.in
+++ b/cmake/PartoutConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/PartoutTargets.cmake")
+check_required_components(Partout)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,6 +29,13 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
+        -install)
+            install_dir=$2
+            mkdir $install_dir || true
+            cmake_opts+=("-DCMAKE_INSTALL_PREFIX=$install_dir")
+            shift
+            shift
+            ;;
         -a)
             cmake_opts+=("-DPP_BUILD_LIBRARY=ON")
             cmake_opts+=("-DPP_BUILD_USE_OPENSSL=ON")
@@ -96,13 +103,14 @@ if [[ ! -d $bin_dir ]]; then
 fi
 if [[ $gen_build == 1 ]]; then
     scripts/gen-cmake-files.sh
-    pushd $build_dir
-    cmake -G Ninja "${cmake_opts[@]}" ..
-else
-    pushd $build_dir
+    cmake -G Ninja -S . -B $build_dir "${cmake_opts[@]}"
 fi
-cmake --build .
-popd
+
+# Execute
+cmake --build $build_dir
+if [[ -n $install_dir ]]; then
+    cmake --install $build_dir
+fi
 
 # Generate foreign models
 if [[ $gen_models == 1 ]]; then


### PR DESCRIPTION
- Only export partout.h and modulemap, not all C headers
- Fix `@rpath/RPATH` post build
- Perform dead code stripping (unless static)

Fix VPN implementation availability not checked by ABI before adding to registry.