### PR TITLE
Core: Reexport C symbols from Swift

### DIFF
--- a/Sources/Partout/CommonABI_C.swift
+++ b/Sources/Partout/CommonABI_C.swift
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+internal import _PartoutCore_C
 import Partout_C
 
 #if canImport(Darwin)
@@ -99,4 +100,13 @@ extension ABI {
             completion.callback?(completion.ctx, code, payloadJSON)
         }
     }
+}
+
+@c(partout_readfile)
+public func __partout_readfile(
+    relPath: UnsafePointer<CChar>?,
+    parent: UnsafePointer<CChar>?
+) -> UnsafeMutablePointer<CChar>? {
+    guard let relPath else { return nil }
+    return pp_file_read(relPath, parent)
 }

--- a/Sources/PartoutCore/Connection/NativeTunnelController.swift
+++ b/Sources/PartoutCore/Connection/NativeTunnelController.swift
@@ -44,7 +44,7 @@ public final class NativeTunnelController: TunnelController, Sendable {
         self.betterPathFactory = betterPathFactory ?? BetterPathProxy()
         self.bufSize = bufSize
 
-        onReachableStream = CurrentValueStream(false)
+        onReachableStream = CurrentValueStream(true)
         reachabilityHolder = ReachabilityHolder()
 
         // Native resolver requires network handle on Android

--- a/Sources/PartoutCore/Connection/NativeTunnelController.swift
+++ b/Sources/PartoutCore/Connection/NativeTunnelController.swift
@@ -44,7 +44,7 @@ public final class NativeTunnelController: TunnelController, Sendable {
         self.betterPathFactory = betterPathFactory ?? BetterPathProxy()
         self.bufSize = bufSize
 
-        onReachableStream = CurrentValueStream(true)
+        onReachableStream = CurrentValueStream(false)
         reachabilityHolder = ReachabilityHolder()
 
         // Native resolver requires network handle on Android

--- a/Sources/PartoutCore_C/file.c
+++ b/Sources/PartoutCore_C/file.c
@@ -8,17 +8,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "partout.h"
+#include "portable/common.h"
 
-static char *partout_strdup(const char *value) {
-#ifdef _WIN32
-    return _strdup(value);
-#else
-    return strdup(value);
-#endif
-}
-
-static FILE *partout_fopen_read(const char *path) {
+static FILE *pp_file_open_read(const char *path) {
 #ifdef _WIN32
     FILE *file = NULL;
     return (fopen_s(&file, path, "rb") == 0) ? file : NULL;
@@ -27,7 +19,7 @@ static FILE *partout_fopen_read(const char *path) {
 #endif
 }
 
-char *partout_readfile(const char *rel_path, const char *parent) {
+char *pp_file_read(const char *rel_path, const char *parent) {
     char *abs_path = NULL;
     FILE *file = NULL;
     char *buffer = NULL;
@@ -40,12 +32,12 @@ char *partout_readfile(const char *rel_path, const char *parent) {
         if (!abs_path) goto failure;
         snprintf(abs_path, path_len + 1, "%s/%s", parent, rel_path);
     } else {
-        abs_path = partout_strdup(rel_path);
+        abs_path = pp_dup(rel_path);
         if (!abs_path) goto failure;
     }
 
     /* Open file at absolute path. */
-    file = partout_fopen_read(abs_path);
+    file = pp_file_open_read(abs_path);
     if (!file) goto failure;
     free(abs_path);
     abs_path = NULL;

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -102,6 +102,8 @@ FILE *_Nullable pp_fopen(const char *filename, const char *mode) {
 #define pp_sscanf sscanf
 #endif
 
+char *pp_file_read(const char *rel_path, const char *parent);
+
 #pragma clang assume_nonnull end
 
 /* Syscalls. */

--- a/Sources/PartoutCore_C/include/portable/common.h
+++ b/Sources/PartoutCore_C/include/portable/common.h
@@ -102,7 +102,8 @@ FILE *_Nullable pp_fopen(const char *filename, const char *mode) {
 #define pp_sscanf sscanf
 #endif
 
-char *pp_file_read(const char *rel_path, const char *parent);
+/* Read a whole file into a string. */
+char *pp_file_read(const char *rel_path, const char *_Nullable parent);
 
 #pragma clang assume_nonnull end
 

--- a/Sources/partout.cmake
+++ b/Sources/partout.cmake
@@ -349,6 +349,7 @@ set(PARTOUT_C_SOURCES
 ./MiniFoundation_C/rx.cc
 ./MiniFoundation_C/std.c
 ./PartoutCore_C/common.c
+./PartoutCore_C/file.c
 ./PartoutCore_C/lib.c
 ./PartoutCore_C/mux.c
 ./PartoutCore_C/network.c
@@ -388,5 +389,4 @@ set(PARTOUT_C_SOURCES
 ./PartoutWireGuard_C/key.c
 ./PartoutWireGuard_C/logging.c
 ./PartoutWireGuard_C/x25519.c
-./Partout_C/partout.c
 )


### PR DESCRIPTION
Do not export C symbols from top Partout_C. Instead:

- Define them in PartouCore_C or below
- Bridge them from Swift with `@c` to enforce their inclusion in the final library

Otherwise, the static C library would also have to be linked as a whole archive, and it's annoying. This PR fixes `partout_read()` in particular.