### PR TITLE
OpenVPN: Fix regression in OTPMethod encoding

### DIFF
--- a/Sources/PartoutCore/OpenAPI/OpenVPN/Credentials.swift
+++ b/Sources/PartoutCore/OpenAPI/OpenVPN/Credentials.swift
@@ -137,3 +137,48 @@ private extension OpenVPN.Credentials.OTPMethod {
         }
     }
 }
+
+// MARK: - Custom Codable
+
+extension OpenVPN.Credentials.OTPMethod {
+    private enum LegacyCodingKeys: String, CodingKey {
+        case none
+        case append
+        case encode
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let rawValue = try? container.decode(String.self) {
+            guard let method = Self(rawValue: rawValue) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Unknown OTP method '\(rawValue)'"
+                )
+            }
+            self = method
+            return
+        }
+
+        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
+        if legacyContainer.contains(.none) {
+            self = .none
+        } else if legacyContainer.contains(.append) {
+            self = .append
+        } else if legacyContainer.contains(.encode) {
+            self = .encode
+        } else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unknown legacy OTP method"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Tests/PartoutCoreTests/CodingRegistryTests.swift
+++ b/Tests/PartoutCoreTests/CodingRegistryTests.swift
@@ -37,6 +37,40 @@ struct CodingRegistryTests {
         #expect(profile == decoded)
     }
 
+    @Test
+    func givenCoder_whenDecodeV3ProfileWithLegacyOTPMethod_thenIsDecoded() throws {
+        let registry = Registry(withKnown: true)
+        let sut = registry.withLegacyEncoding(false)
+
+        var ovpnBuilder = OpenVPN.Configuration.Builder()
+        ovpnBuilder.ca = OpenVPN.CryptoContainer(pem: "ca is required")
+        ovpnBuilder.cipher = .aes128cbc
+        ovpnBuilder.remotes = [
+            try ExtendedEndpoint("host.name", EndpointProtocol(.tcp, 80))
+        ]
+        let credentials = OpenVPN.Credentials.Builder(
+            username: "user",
+            password: "password",
+            otpMethod: .append,
+            otp: "123456"
+        ).build()
+        let module = try OpenVPNModule.Builder(
+            configurationBuilder: ovpnBuilder,
+            credentials: credentials
+        ).build()
+        let profile = try Profile.Builder(modules: [module]).build()
+
+        let encoded = try sut.string(fromProfile: profile)
+        let legacyEncoded = encoded.replacingOccurrences(
+            of: "\"otpMethod\":\"append\"",
+            with: "\"otpMethod\":{\"append\":{}}"
+        )
+        #expect(legacyEncoded != encoded)
+
+        let decoded = try sut.profile(fromString: legacyEncoded)
+        #expect(decoded == profile)
+    }
+
     @Test(arguments: [true, false])
     func givenCoder_whenEncodeProfileWithRegisteredModule_thenIsDecoded(legacy: Bool) throws {
         let registry = Registry(allHandlers: [


### PR DESCRIPTION
A single `String` in the list of protocol implementations broke every-damn-thing, because non-raw enums in Swift encode as dictionaries.

Regression in 551f3cee917e412f95271c6ac6c07c420bca2161