### PR TITLE
Core: Validate src/dst input in tun I/O

### DIFF
--- a/Sources/PartoutCore_C/tun_android.c
+++ b/Sources/PartoutCore_C/tun_android.c
@@ -31,6 +31,7 @@ void pp_tun_free_and_close(pp_tun tun, bool and_close) {
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
     if (!tun || tun->fd < 0) return -1;
+    if (!dst || dst_len == 0) return -1;
     int ret;
     PP_IO_RETRY(ret, read(tun->fd, dst, dst_len));
     return pp_tun_handle_result(ret);
@@ -38,6 +39,7 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
 
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     if (!tun || tun->fd < 0) return -1;
+    if (!src || src_len == 0) return -1;
     int ret;
     PP_IO_RETRY(ret, write(tun->fd, src, src_len));
     return pp_tun_handle_result(ret);

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -160,13 +160,14 @@ pp_fd pp_tun_network_extension_fd(void) {
 /* The first 4 bits of a local packet identify the IP family. */
 static inline
 uint32_t pp_tun_proto_for(uint8_t byte) {
-    switch ((byte & 0xf0) >> 4) {
+    const uint8_t header = (byte & 0xf0) >> 4;
+    switch (header) {
         case 4:
             return AF_INET;
         case 6:
             return AF_INET6;
         default:
-            pp_assert(false);
+            pp_clog_v(PPLogCategoryCore, PPLogLevelError, "tun_darwin: Unexpected utun packet header (%u)", header);
             return 0;
     }
 }
@@ -188,7 +189,7 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
         return pp_tun_handle_result(read_len);
     }
     if (read_len < (int)sizeof(pi)) {
-        pp_clog(PPLogCategoryCore, PPLogLevelFault, "tun_darwin: Missing 4-byte utun packet header");
+        pp_clog(PPLogCategoryCore, PPLogLevelError, "tun_darwin: Missing 4-byte utun packet header");
         return -1;
     }
     return read_len - (int)sizeof(pi);
@@ -197,7 +198,9 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     if (!tun || tun->fd < 0) return -1;
     if (!src || src_len == 0) return -1;
-    const uint32_t pi = pp_endian_htonl(pp_tun_proto_for(*src));
+    const uint32_t proto_byte = pp_tun_proto_for(*src);
+    if (proto_byte == 0) return -1;
+    const uint32_t pi = pp_endian_htonl(proto_byte);
     const size_t pi_len = sizeof(pi);
 
     struct iovec iov[2];

--- a/Sources/PartoutCore_C/tun_darwin.c
+++ b/Sources/PartoutCore_C/tun_darwin.c
@@ -173,6 +173,7 @@ uint32_t pp_tun_proto_for(uint8_t byte) {
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
     if (!tun || tun->fd < 0) return -1;
+    if (!dst || dst_len == 0) return -1;
     uint32_t pi = 0; // 4-byte utun protocol header
 
     struct iovec iov[2];
@@ -195,6 +196,7 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
 
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     if (!tun || tun->fd < 0) return -1;
+    if (!src || src_len == 0) return -1;
     const uint32_t pi = pp_endian_htonl(pp_tun_proto_for(*src));
     const size_t pi_len = sizeof(pi);
 

--- a/Sources/PartoutCore_C/tun_linux.c
+++ b/Sources/PartoutCore_C/tun_linux.c
@@ -74,6 +74,7 @@ void pp_tun_free_and_close(pp_tun tun, bool and_close) {
 
 int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
     if (!tun || tun->fd < 0) return -1;
+    if (!dst || dst_len == 0) return -1;
     int ret;
     PP_IO_RETRY(ret, read(tun->fd, dst, dst_len));
     return pp_tun_handle_result(ret);
@@ -81,6 +82,7 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
 
 int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
     if (!tun || tun->fd < 0) return -1;
+    if (!src || src_len == 0) return -1;
     int ret;
     PP_IO_RETRY(ret, write(tun->fd, src, src_len));
     return pp_tun_handle_result(ret);

--- a/Sources/PartoutCore_C/tun_windows.c
+++ b/Sources/PartoutCore_C/tun_windows.c
@@ -147,6 +147,7 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
         SetLastError(ERROR_INVALID_HANDLE);
         return -1;
     }
+    if (!dst || dst_len == 0) return -1;
     DWORD packet_len;
     BYTE *packet = WintunReceivePacket(tun->session, &packet_len);
     if (!packet) {
@@ -157,7 +158,6 @@ int pp_tun_read(const pp_tun tun, uint8_t *dst, size_t dst_len) {
         pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_windows: read(), %lu", err);
         return -1;
     }
-
     if (dst_len < packet_len) {
         WintunReleaseReceivePacket(tun->session, packet);
         SetLastError(ERROR_INSUFFICIENT_BUFFER);
@@ -173,7 +173,7 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
         SetLastError(ERROR_INVALID_HANDLE);
         return -1;
     }
-
+    if (!src || src_len == 0) return -1;
     BYTE *packet = WintunAllocateSendPacket(tun->session, src_len);
     if (!packet) {
         const DWORD err = GetLastError();
@@ -183,7 +183,6 @@ int pp_tun_write(const pp_tun tun, const uint8_t *src, size_t src_len) {
         pp_clog_v(PPLogCategoryCore, PPLogLevelFault, "tun_windows: write(), %lu", err);
         return -1;
     }
-
     memcpy(packet, src, src_len);
     WintunSendPacket(tun->session, packet);
     return (int)src_len;


### PR DESCRIPTION
On Darwin in particular, non-IP header bytes were asserting.