### PR TITLE
Android: Fix service behavior on revoke

### DIFF
--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -89,7 +89,7 @@ class PartoutVpnServiceRuntime(
 
     fun onRevoke() {
         Log.d(logTag, "PartoutVpnServiceRuntime.onRevoke()")
-        disconnect(null)
+        disconnect(null, wasRevoked = true)
     }
     //endregion
 
@@ -198,7 +198,7 @@ class PartoutVpnServiceRuntime(
         snapshotEmitter.emitFinal()
     }
 
-    private fun disconnect(intent: Intent?) = launchCommand {
+    private fun disconnect(intent: Intent?, wasRevoked: Boolean = false) = launchCommand {
         val forgetId = intent?.getStringExtra(EXTRA_FORGET_ID)
         if (forgetId != null) {
             engine.deleteLastProfile(forgetId)
@@ -211,12 +211,12 @@ class PartoutVpnServiceRuntime(
             }
         }
         stopTunnel()
-        stopService()
+        stopService(wasRevoked)
     }
 
-    private fun stopService() {
+    private fun stopService(wasRevoked: Boolean = false) {
         service.stopSelf()
-        engine.onServiceStopped()
+        engine.onServiceStopped(wasRevoked)
     }
 
     private fun close() {
@@ -393,7 +393,7 @@ class PartoutVpnServiceRuntime(
         suspend fun writeLastProfile(json: String)
         suspend fun deleteLastProfile(id: String)
         fun onSnapshot(snapshot: TunnelSnapshot)
-        fun onServiceStopped() {}
+        fun onServiceStopped(wasRevoked: Boolean) {}
     }
     //endregion
 

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -146,8 +146,9 @@ class PartoutVpnServiceRuntime(
     }
 
     override fun onSnapshot(snapshot: TunnelSnapshot) {
-        snapshotEmitter.emit(snapshot)
-        engine.onSnapshot(snapshot)
+        if (snapshotEmitter.emit(snapshot)) {
+            engine.onSnapshot(snapshot)
+        }
     }
 
     override fun shouldDisconnect(controller: NativeTunnelControllerJNI) = launchCommand {
@@ -250,19 +251,21 @@ class PartoutVpnServiceRuntime(
             }
         }
 
-        fun emit(snapshot: TunnelSnapshot) = synchronized(lock) {
-            if (!isAccepting) { return }
+        fun emit(snapshot: TunnelSnapshot): Boolean = synchronized(lock) {
+            if (!isAccepting) { return@synchronized false }
             if (snapshot.id != activeProfileId) {
                 logIfNeeded("Drop stale daemon snapshot: $snapshot")
-                return
+                return@synchronized false
             }
             broadcast(snapshot)
+            return@synchronized true
         }
 
         fun emitFinal() = synchronized(lock) {
             logIfNeeded("Emit final daemon snapshot")
-            latestSnapshot?.let {
-                emit(it.disabled())
+            val finalSnapshot = if (isAccepting) latestSnapshot?.disabled() else null
+            if (finalSnapshot != null) {
+                broadcast(finalSnapshot)
             }
             isAccepting = false
             activeProfileId = null

--- a/cross/android/io/partout/abi/PartoutResult.kt
+++ b/cross/android/io/partout/abi/PartoutResult.kt
@@ -4,9 +4,10 @@
 
 package io.partout.abi
 
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
 
 data class PartoutResult(
     val code: Int,
@@ -16,11 +17,11 @@ data class PartoutResult(
         suspend fun await(
             block: (PartoutCompletionCallback) -> Unit
         ): PartoutResult = withContext(Dispatchers.IO) {
-            val future = CompletableDeferred<PartoutResult>()
-            block { code, json ->
-                future.complete(PartoutResult(code, json))
+            val result = suspendCancellableCoroutine { continuation ->
+                block { code, json ->
+                    continuation.resume(PartoutResult(code, json))
+                }
             }
-            val result = future.await()
             if (result.code != 0) {
                 throw PartoutException(result.code, result.json)
             }


### PR DESCRIPTION
Give the engine a way to tell if the service was stopped intentionally or due to external revocation.

Other than that:

- Do not forward unemitted snapshots
- Replace CompletableDeferred with suspendCancellableCoroutine() in PartoutResult for library consistency