### PR TITLE
WireGuard: Fix CMake vendor build

### DIFF
--- a/vendors/wg-go.cmake
+++ b/vendors/wg-go.cmake
@@ -22,22 +22,26 @@ endif()
 
 if(APPLE)
     set(WGGO_INSTALL_COMMAND
+        INSTALL_COMMAND
         install_name_tool -id "@rpath/libwg-go.dylib" "${WGGO_DIR}/lib/libwg-go.dylib"
     )
 elseif(WIN32)
     set(WGGO_INSTALL_COMMAND
+        INSTALL_COMMAND
         gendef "${WGGO_DIR}/lib/wg-go.dll"
         COMMAND dlltool -d wg-go.def -l "${WGGO_DIR}/lib/wg-go.lib"
     )
 else()
-    set(WGGO_INSTALL_COMMAND "")
+    set(WGGO_INSTALL_COMMAND
+        INSTALL_COMMAND ""
+    )
 endif()
 
 ExternalProject_Add(WireGuardGoProject
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vendors/wg-go
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${VENDOR_ENV} ${WGGO_CMD}
-    INSTALL_COMMAND ${WGGO_INSTALL_COMMAND}
+    ${WGGO_INSTALL_COMMAND}
     BUILD_IN_SOURCE 1
     BUILD_BYPRODUCTS ${WGGO_BYPRODUCTS}
 )

--- a/vendors/wg-go/Makefile
+++ b/vendors/wg-go/Makefile
@@ -67,7 +67,7 @@ $(DESTDIR)/wireguard-go-version.h: go.mod $(GOROOT)/.prepared
 	sed -E -n 's/.*golang\.zx2c4\.com\/wireguard +v[0-9.]+-[0-9]+-([0-9a-f]{8})[0-9a-f]{4}.*/#define WIREGUARD_GO_VERSION "\1"/p' "$<" > "$@"
 
 clean:
-	rm -rf "$(BUILDDIR)" "$(DESTDIR)"
+	rm -rf "$(BUILDDIR)" "$(DESTDIR)" "$(TMPROOTDIR)"
 
 install: build
 	mkdir -p "$(DESTDIR)/lib"


### PR DESCRIPTION
Clean up stale goroot on clean. Prepend install command.