### PR TITLE
Core: Fix async stream races

### DIFF
--- a/Sources/MiniFoundation/Streams/AsyncStream+Extensions.swift
+++ b/Sources/MiniFoundation/Streams/AsyncStream+Extensions.swift
@@ -21,7 +21,7 @@ extension AsyncThrowingStream {
 extension AsyncStream where Element: Equatable & Sendable {
     public func removeDuplicates() -> AsyncStream<Element> {
         AsyncStream { continuation in
-            Task {
+            let task = Task {
                 var previous: Element?
                 for await value in self {
                     guard !Task.isCancelled else {
@@ -35,6 +35,9 @@ extension AsyncStream where Element: Equatable & Sendable {
                 }
                 continuation.finish()
             }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
         }
     }
 }
@@ -42,7 +45,7 @@ extension AsyncStream where Element: Equatable & Sendable {
 extension AsyncThrowingStream where Element: Equatable & Sendable {
     public func removeDuplicates() -> AsyncThrowingStream<Element, Error> where Error == Failure {
         AsyncThrowingStream { continuation in
-            Task {
+            let task = Task {
                 do {
                     var previous: Element?
                     for try await value in self {
@@ -60,6 +63,9 @@ extension AsyncThrowingStream where Element: Equatable & Sendable {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
         }
     }
 }
@@ -67,7 +73,7 @@ extension AsyncThrowingStream where Element: Equatable & Sendable {
 extension AsyncStream where Element: Sendable {
     public func map<Other>(_ block: @escaping @Sendable (Element) -> Other) -> AsyncStream<Other> where Other: Sendable {
         AsyncStream<Other> { continuation in
-            Task {
+            let task = Task {
                 for await value in self {
                     guard !Task.isCancelled else {
                         break
@@ -76,12 +82,15 @@ extension AsyncStream where Element: Sendable {
                 }
                 continuation.finish()
             }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
         }
     }
 
     public func compactMap<Other>(_ block: @escaping @Sendable (Element) -> Other?) -> AsyncStream<Other> where Other: Sendable {
         AsyncStream<Other> { continuation in
-            Task {
+            let task = Task {
                 for await value in self {
                     guard !Task.isCancelled else {
                         break
@@ -91,6 +100,9 @@ extension AsyncStream where Element: Sendable {
                     }
                 }
                 continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }
@@ -103,7 +115,7 @@ extension AsyncThrowingStream where Element: Sendable {
 
     public func replaceError(with element: @autoclosure @escaping @Sendable () -> Element?) -> AsyncStream<Element> {
         AsyncStream { continuation in
-            Task {
+            let task = Task {
                 do {
                     for try await value in self {
                         guard !Task.isCancelled else {
@@ -118,6 +130,9 @@ extension AsyncThrowingStream where Element: Sendable {
                     }
                     continuation.finish()
                 }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }

--- a/Sources/PartoutCore/Tunnel/Tunnel.swift
+++ b/Sources/PartoutCore/Tunnel/Tunnel.swift
@@ -173,11 +173,11 @@ private extension Tunnel {
         // Subscribe once
         guard subscriptions.isEmpty else { return }
 #endif
+        let ctx = self.ctx
+        let strategyStream = strategy.didUpdateActiveProfiles
         var subscriptions: [Task<Void, Never>] = []
-        subscriptions.append(Task { [weak self] in
-            guard let ctx = self?.ctx else { return }
-            guard let stream = self?.strategy.didUpdateActiveProfiles else { return }
-            for await snapshots in stream {
+        subscriptions.append(Task { [weak self, ctx] in
+            for await snapshots in strategyStream {
                 guard !Task.isCancelled else { break }
                 await self?.handleStrategySnapshots(snapshots)
             }

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -123,12 +123,9 @@ extension NETunnelStrategy: TunnelObservableStrategy {
     }
 
     public nonisolated var didUpdateActiveProfiles: AsyncStream<[Profile.ID: TunnelSnapshot]> {
-        AsyncStream { [weak self] continuation in
-            Task { [weak self] in
-                guard let stream = self?.activeProfilesStream.dropFirst() else {
-                    continuation.finish()
-                    return
-                }
+        let stream = activeProfilesStream.dropFirst()
+        return AsyncStream { [weak self] continuation in
+            let task = Task { [weak self] in
                 for await activeProfiles in stream {
                     guard let self else {
                         continuation.finish()
@@ -142,6 +139,9 @@ extension NETunnelStrategy: TunnelObservableStrategy {
                     continuation.yield(activeProfiles)
                 }
                 continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }
@@ -223,12 +223,9 @@ extension NETunnelStrategy: NETunnelManagerRepository {
     }
 
     public nonisolated var managersStream: AsyncStream<[Profile.ID: NETunnelProviderManager]> {
-        AsyncStream { [weak self] continuation in
-            Task { [weak self] in
-                guard let stream = self?.managersSubject.subscribe().dropFirst() else {
-                    continuation.finish()
-                    return
-                }
+        let stream = managersSubject.subscribe().dropFirst()
+        return AsyncStream { [weak self] continuation in
+            let task = Task { [weak self] in
                 for await value in stream {
                     guard let self else {
                         continuation.finish()
@@ -241,6 +238,9 @@ extension NETunnelStrategy: NETunnelManagerRepository {
                     continuation.yield(value)
                 }
                 continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
     }


### PR DESCRIPTION
Some streams are initialized inside Task. Do that immediately. Also handle cancellation.