### PR TITLE
Core: Unify build scripts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,11 +71,11 @@ let package = Package(
                 // These are always included
                 var list: [Target.Dependency] = [
                     "Partout_C",
+                    "PartoutCrypto_C",
                     "PartoutCore",
                     "PartoutOS"
                 ]
                 if !cryptoLibraries.isEmpty {
-                    list.append("PartoutCrypto_C")
                     if areas.contains(.openVPN) {
                         list.append("PartoutOpenVPN")
                     }
@@ -85,16 +85,18 @@ let package = Package(
                 }
                 return list
             }(),
-            swiftSettings: areas.swiftSettings + useFoundationCompatibility.swiftSettings
+            swiftSettings: areas.compactMap {
+                $0.define(cryptoLibraries)
+            } + useFoundationCompatibility.swiftSettings
         ),
         .target(
             name: "Partout_C",
             dependencies: {
                 var list: [Target.Dependency] = [
+                    "PartoutCrypto_C",
                     "PartoutCore_C"
                 ]
                 if !cryptoLibraries.isEmpty {
-                    list.append("PartoutCrypto_C")
                     if areas.contains(.openVPN) {
                         list.append("PartoutOpenVPN_C")
                     }
@@ -348,45 +350,45 @@ for mode in cryptoLibraries {
 }
 
 // Include concrete crypto targets if supported
+package.targets.append(
+    .target(
+        name: "PartoutCrypto_C",
+        dependencies: cryptoDependencies,
+        exclude: {
+            // Pick current OS by removing it from exclusions
+            var list: [String] = []
+            if !cryptoLibraries.contains(.openSSL) {
+                list.append("openssl")
+            }
+            if !cryptoLibraries.contains(.mbedTLS) {
+                list.append("mbed")
+                list.append("native")
+            } else {
+                var native = Set(OS.nativeCryptoSources)
+                native.remove(OS.current.nativeCryptoSource)
+                let nativeSrc = native.map { "native/\($0.rawValue)" }
+                list.append(contentsOf: nativeSrc)
+            }
+            return list
+        }(),
+        cSettings: globalCSettings,
+        linkerSettings: {
+            var list: [LinkerSetting] = []
+            if cryptoLibraries.contains(.mbedTLS) {
+                list.append(.linkedLibrary("mbedx509"))
+                list.append(.linkedLibrary("mbedcrypto"))
+            }
+            return list
+        }()
+    )
+)
+package.products.append(
+    .library(
+        name: "PartoutCrypto",
+        targets: ["PartoutCrypto_C"]
+    )
+)
 if !cryptoLibraries.isEmpty {
-    package.targets.append(
-        .target(
-            name: "PartoutCrypto_C",
-            dependencies: cryptoDependencies,
-            exclude: {
-                // Pick current OS by removing it from exclusions
-                var list: [String] = []
-                if !cryptoLibraries.contains(.openSSL) {
-                    list.append("openssl")
-                }
-                if !cryptoLibraries.contains(.mbedTLS) {
-                    list.append("mbed")
-                    list.append("native")
-                } else {
-                    var native = Set(OS.nativeCryptoSources)
-                    native.remove(OS.current.nativeCryptoSource)
-                    let nativeSrc = native.map { "native/\($0.rawValue)" }
-                    list.append(contentsOf: nativeSrc)
-                }
-                return list
-            }(),
-            cSettings: globalCSettings,
-            linkerSettings: {
-                var list: [LinkerSetting] = []
-                if cryptoLibraries.contains(.mbedTLS) {
-                    list.append(.linkedLibrary("mbedx509"))
-                    list.append(.linkedLibrary("mbedcrypto"))
-                }
-                return list
-            }()
-        )
-    )
-    package.products.append(
-        .library(
-            name: "PartoutCrypto",
-            targets: ["PartoutCrypto_C"]
-        )
-    )
     package.targets.append(contentsOf: [
         .testTarget(
             name: "PartoutCryptoTests",
@@ -436,14 +438,14 @@ protocol Definable {
     var define: String { get }
 }
 
-enum Area: Definable, CaseIterable {
+enum Area: CaseIterable {
     case openVPN
     case wireGuard
 
-    var define: String {
+    func define(_ cryptoLibraries: [CryptoLibrary]) -> SwiftSetting? {
         switch self {
-        case .openVPN: "PARTOUT_OPENVPN"
-        case .wireGuard: "PARTOUT_WIREGUARD"
+        case .openVPN: !cryptoLibraries.isEmpty ? .define("PARTOUT_OPENVPN") : nil
+        case .wireGuard: .define("PARTOUT_WIREGUARD")
         }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -105,7 +105,7 @@ let package = Package(
                 }
                 return list
             }(),
-            cSettings: globalCSettings + {
+            cSettings: globalCSettings + cryptoLibraries.cSettings + {
                 var list: [CSetting] = []
                 if areas.contains(.openVPN), !cryptoLibraries.isEmpty {
                     list.append(.define("PARTOUT_OPENVPN"))
@@ -507,6 +507,12 @@ enum CryptoLibrary: Definable {
 }
 
 extension Collection where Element: Definable {
+    var cSettings: [CSetting] {
+        map {
+            .define($0.define)
+        }
+    }
+
     var swiftSettings: [SwiftSetting] {
         map {
             .define($0.define)

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let envDocs = env["PP_BUILD_DOCS"] == "1"
 
 // MARK: Configuration
 
-let areas = Area.allCases
 let cryptoLibraries: [CryptoLibrary] = [.openSSL]
 let openSSLVersion: Version = "3.6.300" // 3.6.2
 let wgGoVersion: Version = "0.0.20260530"
@@ -23,6 +22,10 @@ let wgGoVersion: Version = "0.0.20260530"
 let cmakeOutput = envCMakeOutput ?? "bin/darwin-arm64"
 let useFoundationCompatibility: FoundationCompatibility = .off
 // let useFoundationCompatibility: FoundationCompatibility = OS.current != .apple ? .on : .off
+
+let areas = Area.allCases.filter {
+    $0 != .openVPN || !cryptoLibraries.isEmpty
+}
 
 // MARK: - Package
 
@@ -75,19 +78,15 @@ let package = Package(
                     "PartoutCore",
                     "PartoutOS"
                 ]
-                if !cryptoLibraries.isEmpty {
-                    if areas.contains(.openVPN) {
-                        list.append("PartoutOpenVPN")
-                    }
+                if areas.contains(.openVPN) {
+                    list.append("PartoutOpenVPN")
                 }
                 if areas.contains(.wireGuard) {
                     list.append("PartoutWireGuard")
                 }
                 return list
             }(),
-            swiftSettings: areas.compactMap {
-                $0.define(cryptoLibraries)
-            } + useFoundationCompatibility.swiftSettings
+            swiftSettings: areas.swiftSettings + useFoundationCompatibility.swiftSettings
         ),
         .target(
             name: "Partout_C",
@@ -96,10 +95,8 @@ let package = Package(
                     "PartoutCrypto_C",
                     "PartoutCore_C"
                 ]
-                if !cryptoLibraries.isEmpty {
-                    if areas.contains(.openVPN) {
-                        list.append("PartoutOpenVPN_C")
-                    }
+                if areas.contains(.openVPN) {
+                    list.append("PartoutOpenVPN_C")
                 }
                 if areas.contains(.wireGuard) {
                     list.append("PartoutWireGuard_C")
@@ -109,7 +106,7 @@ let package = Package(
             }(),
             cSettings: globalCSettings + cryptoLibraries.cSettings + {
                 var list: [CSetting] = []
-                if areas.contains(.openVPN), !cryptoLibraries.isEmpty {
+                if areas.contains(.openVPN) {
                     list.append(.define("PARTOUT_OPENVPN"))
                 }
                 if areas.contains(.wireGuard) {
@@ -210,7 +207,7 @@ package.targets.append(contentsOf: [
 // MARK: OpenVPN
 
 // OpenVPN requires Crypto/TLS wrappers
-if areas.contains(.openVPN), !cryptoLibraries.isEmpty {
+if areas.contains(.openVPN) {
     package.products.append(
         .library(
             name: "PartoutOpenVPN",
@@ -438,14 +435,14 @@ protocol Definable {
     var define: String { get }
 }
 
-enum Area: CaseIterable {
+enum Area: Definable, CaseIterable {
     case openVPN
     case wireGuard
 
-    func define(_ cryptoLibraries: [CryptoLibrary]) -> SwiftSetting? {
+    var define: String {
         switch self {
-        case .openVPN: !cryptoLibraries.isEmpty ? .define("PARTOUT_OPENVPN") : nil
-        case .wireGuard: .define("PARTOUT_WIREGUARD")
+        case .openVPN: "PARTOUT_OPENVPN"
+        case .wireGuard: "PARTOUT_WIREGUARD"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The script builds the vendors as static libraries and accepts a few options:
 - `-gen`: Generate CMake metadata
 - `-config (Debug|Release)`: The CMake build type (`build.sh` only)
 - `-l`: Build the Partout library (opt-in)
-- `-crypto (openssl|native[,openssl|native...])`: Pick one or more crypto subsystems between OpenSSL and Native/MbedTLS (WIP)
+- `-crypto (openssl|native[,openssl|native...])`: Pick one or more crypto subsystems between OpenSSL and Native/MbedTLS
 - `-wireguard`: Enable support for WireGuard (requires Go)
 - `-android`: Build for Android
 - `-vendors [bundled|<url>]`: Build bundled vendors (requires submodules), or provide the prebuilt vendor URL for Android/Windows

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Use one of the `scripts/build.*` variants based on the host platform:
 The script builds the vendors as static libraries and accepts a few options: 
 
 - `-gen`: Generate CMake metadata
-- `-config (Debug|Release)`: The CMake build type
+- `-config (Debug|Release)`: The CMake build type (`build.sh` only)
 - `-l`: Build the Partout library (opt-in)
-- `-crypto (openssl|native)`: Pick a crypto subsystem between OpenSSL and Native/MbedTLS (WIP)
+- `-crypto (openssl|native[,openssl|native...])`: Pick one or more crypto subsystems between OpenSSL and Native/MbedTLS (WIP)
 - `-wireguard`: Enable support for WireGuard (requires Go)
 - `-android`: Build for Android
 - `-vendors [bundled|<url>]`: Build bundled vendors (requires submodules), or provide the prebuilt vendor URL for Android/Windows

--- a/Sources/PartoutCore_C/include/portable/conditionals.h
+++ b/Sources/PartoutCore_C/include/portable/conditionals.h
@@ -46,3 +46,9 @@
 #include <WS2tcpip.h>
 #include <Windows.h>
 #endif
+
+#if defined(PARTOUT_CRYPTO_OPENSSL) || defined(PARTOUT_CRYPTO_MBEDTLS)
+#define PARTOUT_HAS_CRYPTO 1
+#else
+#define PARTOUT_HAS_CRYPTO 0
+#endif

--- a/Sources/Partout_C/partout.c
+++ b/Sources/Partout_C/partout.c
@@ -5,9 +5,11 @@
  */
 
 #include "partout.h"
-#include "crypto/crypto.h"
 #include "portable/portable.h"
-#include "crypto/tls.h"
+
+#if PARTOUT_HAS_CRYPTO
+#include "crypto/crypto.h"
+#endif
 
 #if PARTOUT_OPENVPN
 #include "openvpn/openvpn.h"

--- a/scripts/build-help.txt
+++ b/scripts/build-help.txt
@@ -1,0 +1,9 @@
+  -clean                         Remove build output directories
+  -gen                           Generate CMake metadata and configure
+  -install <dir>                 Install after building
+  -crypto <openssl|native>[,...] Enable one or more crypto backends
+  -openvpn                       Enable OpenVPN support
+  -wireguard                     Enable WireGuard support
+  -l                             Build the Partout library
+  -android                       Configure an Android build
+  -vendors [auto|bundled|<url>]  Select vendor source or prebuilt vendor URL

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,91 +1,212 @@
-$cwd = Get-Location
-$build_dir = ".cmake"
-$bin_dir = "bin"
-$configuration = "Debug"
-$generator = "Ninja Multi-Config"
-$vendor_source = $null
-$vendor_prebuilt_url = $null
+$ErrorActionPreference = "Stop"
 
-$index = 0
-while ($index -lt $args.Count) {
-    switch ($args[$index]) {
-        "-config" {
-            if (($index + 1) -ge $args.Count -or $args[$index + 1].StartsWith("-")) {
-                Write-Error "-config requires a value"
-                exit 1
-            }
-            $configuration = $args[$index + 1]
-            $index += 2
-        }
-        "-generator" {
-            if (($index + 1) -ge $args.Count -or $args[$index + 1].StartsWith("-")) {
-                Write-Error "-generator requires a value"
-                exit 1
-            }
-            $generator = $args[$index + 1]
-            $index += 2
-        }
-        "-vendors" {
-            if (($index + 1) -ge $args.Count -or $args[$index + 1].StartsWith("-")) {
-                $index += 1
-            } else {
-                $vendor_value = $args[$index + 1]
-                switch ($vendor_value) {
-                    "auto" {
-                        $vendor_source = $null
-                    }
-                    "bundled" {
-                        $vendor_source = "bundled"
-                    }
-                    default {
-                        $vendor_prebuilt_url = $vendor_value
-                    }
-                }
-                $index += 2
-            }
-        }
-        default {
-            Write-Error "Unknown option $($args[$index])"
+$script_dir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+$root_dir = Resolve-Path (Join-Path $script_dir "..")
+
+Push-Location $root_dir
+try {
+    $build_dir = ".cmake"
+    $bin_dir = "bin"
+    $swift_version = "6.3.1"
+    $vendor_source = $null
+    $vendor_prebuilt_url = $null
+    $crypto_selected = $false
+    $crypto_openssl = $false
+    $crypto_mbedtls = $false
+    $do_build = $false
+    $gen_build = $false
+    $install_dir = $null
+    $positional_args = @()
+    $cmake_opts = @()
+
+    function ConvertTo-CMakeBool($value) {
+        if ($value) { "ON" } else { "OFF" }
+    }
+
+    function Require-Value($option, $index, $all_args) {
+        if (($index + 1) -ge $all_args.Count -or $all_args[$index + 1].StartsWith("-")) {
+            Write-Error "$option requires a value"
             exit 1
         }
-    }
-}
-$is_multi_config = $generator -match "Multi-Config|Visual Studio|Xcode"
-
-try {
-    # Create build folder if it doesn't exist
-    if (-not (Test-Path -Path "$build_dir")) {
-        New-Item -ItemType Directory -Path "$build_dir" | Out-Null
+        $all_args[$index + 1]
     }
 
-    # Change directory to build
-    Set-Location -Path "$build_dir"
-
-    # Run CMake
-    $cmake_opts = @(
-        "-G", $generator,
-        "-DPP_BUILD_USE_OPENSSL=ON",
-        "-DPP_BUILD_USE_OPENVPN=ON",
-        "-DPP_BUILD_USE_WIREGUARD=ON",
-        "-DPP_BUILD_LIBRARY=ON"
-    )
-    if ($is_multi_config) {
-        $cmake_opts += "-DCMAKE_CONFIGURATION_TYPES=$configuration"
-    } else {
-        $cmake_opts += "-DCMAKE_BUILD_TYPE=$configuration"
+    function Add-Crypto($value) {
+        $script:crypto_selected = $true
+        $script:do_build = $true
+        foreach ($crypto in $value.Split(",")) {
+            $crypto = $crypto.Trim()
+            switch ($crypto) {
+                "openssl" {
+                    $script:crypto_openssl = $true
+                }
+                "native" {
+                    $script:crypto_mbedtls = $true
+                }
+                "" {
+                    Write-Error "Empty crypto in '$value'"
+                    exit 1
+                }
+                default {
+                    Write-Error "Unknown crypto '$crypto'"
+                    exit 1
+                }
+            }
+        }
     }
+
+    function Get-SourceRelativePath($base_dir, $file) {
+        $relative = $file.FullName.Substring($base_dir.Length).TrimStart([char[]]@("\", "/"))
+        "./" + ($relative -replace "\\", "/")
+    }
+
+    function Update-CMakeFileList {
+        $sources_dir = (Resolve-Path "Sources").Path
+        $swift_files = Get-ChildItem -Path $sources_dir -Recurse -File |
+            Where-Object { $_.Extension -eq ".swift" } |
+            ForEach-Object { Get-SourceRelativePath $sources_dir $_ } |
+            Sort-Object
+        $c_files = Get-ChildItem -Path $sources_dir -Recurse -File |
+            Where-Object { $_.Extension -eq ".c" -or $_.Extension -eq ".cc" } |
+            ForEach-Object { Get-SourceRelativePath $sources_dir $_ } |
+            Sort-Object
+
+        $lines = @("set(PARTOUT_SOURCES")
+        $lines += $swift_files
+        $lines += ")"
+        $lines += "set(PARTOUT_C_SOURCES"
+        $lines += $c_files
+        $lines += ")"
+        Set-Content -Path (Join-Path $sources_dir "files.cmake") -Value $lines -Encoding ASCII
+    }
+
+    $index = 0
+    while ($index -lt $args.Count) {
+        switch ($args[$index]) {
+            "-clean" {
+                Remove-Item -Path $build_dir, $bin_dir -Recurse -Force -ErrorAction SilentlyContinue
+                $index += 1
+            }
+            "-gen" {
+                $do_build = $true
+                $gen_build = $true
+                $index += 1
+            }
+            "-install" {
+                $install_dir = Require-Value "-install" $index $args
+                New-Item -ItemType Directory -Path $install_dir -Force | Out-Null
+                $cmake_opts += "-DCMAKE_INSTALL_PREFIX=$install_dir"
+                $do_build = $true
+                $index += 2
+            }
+            "-crypto" {
+                Add-Crypto (Require-Value "-crypto" $index $args)
+                $index += 2
+            }
+            "-openvpn" {
+                $cmake_opts += "-DPP_BUILD_USE_OPENVPN=ON"
+                $do_build = $true
+                $index += 1
+            }
+            "-wireguard" {
+                $cmake_opts += "-DPP_BUILD_USE_WIREGUARD=ON"
+                $do_build = $true
+                $index += 1
+            }
+            "-l" {
+                $cmake_opts += "-DPP_BUILD_LIBRARY=ON"
+                $do_build = $true
+                $index += 1
+            }
+            "-android" {
+                $build_dir = ".cmake-android"
+                $cmake_opts += "-DCMAKE_ANDROID_NDK=$env:ANDROID_NDK_HOME"
+                $cmake_opts += "-DANDROID_ABI=arm64-v8a"
+                $cmake_opts += "-DANDROID_STL=c++_shared"
+                $cmake_opts += "-DSWIFT_VERSION=$swift_version"
+                $cmake_opts += "-DCMAKE_TOOLCHAIN_FILE=cmake/swift/swift-android.toolchain.cmake"
+                $index += 1
+            }
+            "-vendors" {
+                if (($index + 1) -ge $args.Count -or $args[$index + 1].StartsWith("-")) {
+                    $index += 1
+                } else {
+                    switch ($args[$index + 1]) {
+                        "auto" {
+                            $vendor_source = $null
+                            $vendor_prebuilt_url = $null
+                        }
+                        "bundled" {
+                            $vendor_source = "bundled"
+                            $vendor_prebuilt_url = $null
+                        }
+                        default {
+                            $vendor_source = $null
+                            $vendor_prebuilt_url = $args[$index + 1]
+                        }
+                    }
+                    $index += 2
+                }
+            }
+            "-gen-models" {
+                Write-Error "-gen-models is not supported by build.ps1"
+                exit 1
+            }
+            "-config" {
+                Write-Error "-config is not supported by build.ps1"
+                exit 1
+            }
+            "-a" {
+                Write-Error "-a has been removed"
+                exit 1
+            }
+            default {
+                if ($args[$index].StartsWith("-")) {
+                    Write-Error "Unknown option $($args[$index])"
+                    exit 1
+                }
+                $positional_args += $args[$index]
+                $index += 1
+            }
+        }
+    }
+
+    if ($crypto_selected) {
+        $cmake_opts += "-DPP_BUILD_USE_OPENSSL=$(ConvertTo-CMakeBool $crypto_openssl)"
+        $cmake_opts += "-DPP_BUILD_USE_MBEDTLS=$(ConvertTo-CMakeBool $crypto_mbedtls)"
+    }
+
     if ($vendor_source) {
         $cmake_opts += "-DPP_BUILD_VENDOR_SOURCE=$vendor_source"
     }
     if ($vendor_prebuilt_url) {
         $cmake_opts += "-DPP_BUILD_VENDOR_PREBUILT_URL=$vendor_prebuilt_url"
+    } elseif ($env:PP_BUILD_VENDOR_PREBUILT_URL) {
+        $cmake_opts += "-DPP_BUILD_VENDOR_PREBUILT_URL=$env:PP_BUILD_VENDOR_PREBUILT_URL"
     }
-    cmake @cmake_opts ..
 
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    if (-not (Test-Path -Path $build_dir)) {
+        New-Item -ItemType Directory -Path $build_dir | Out-Null
+    }
+    if (-not (Test-Path -Path $bin_dir)) {
+        New-Item -ItemType Directory -Path $bin_dir | Out-Null
+    }
 
-    cmake --build . --config $configuration
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    if ($gen_build) {
+        Update-CMakeFileList
+        $configure_args = @("-G", "Ninja", "-S", ".", "-B", $build_dir) + $cmake_opts
+        & cmake @configure_args
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    }
+
+    if ($do_build) {
+        & cmake --build $build_dir
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        if ($install_dir) {
+            & cmake --install $build_dir
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        }
+    }
 } finally {
-    Set-Location -Path $cwd
+    Pop-Location
 }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -181,8 +181,6 @@ try {
     }
     if ($vendor_prebuilt_url) {
         $cmake_opts += "-DPP_BUILD_VENDOR_PREBUILT_URL=$vendor_prebuilt_url"
-    } elseif ($env:PP_BUILD_VENDOR_PREBUILT_URL) {
-        $cmake_opts += "-DPP_BUILD_VENDOR_PREBUILT_URL=$env:PP_BUILD_VENDOR_PREBUILT_URL"
     }
 
     if (-not (Test-Path -Path $build_dir)) {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -27,6 +27,8 @@ Push-Location $root_dir
 try {
     $build_dir = ".cmake"
     $bin_dir = "bin"
+    $configuration = "Debug"
+    $generator = "Ninja Multi-Config"
     $swift_version = "6.3.1"
     $vendor_source = $null
     $vendor_prebuilt_url = $null
@@ -212,16 +214,16 @@ try {
 
     if ($gen_build) {
         Update-CMakeFileList
-        $configure_args = @("-G", "Ninja", "-S", ".", "-B", $build_dir) + $cmake_opts
+        $configure_args = @("-G", $generator, "-S", ".", "-B", $build_dir) + $cmake_opts
         & cmake @configure_args
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     }
 
     if ($do_build) {
-        & cmake --build $build_dir
+        & cmake --build $build_dir --config $configuration
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         if ($install_dir) {
-            & cmake --install $build_dir
+            & cmake --install $build_dir --config $configuration
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         }
     }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -3,6 +3,26 @@ $ErrorActionPreference = "Stop"
 $script_dir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
 $root_dir = Resolve-Path (Join-Path $script_dir "..")
 
+function Show-CommonHelp {
+    foreach ($line in Get-Content -Path (Join-Path $script_dir "build-help.txt")) {
+        Write-Host $line
+    }
+}
+
+function Show-Help {
+    @"
+Usage: scripts/build.ps1 [options]
+
+Options:
+"@ | Write-Host
+    Show-CommonHelp
+}
+
+if ($args.Count -eq 0) {
+    Show-Help
+    exit 0
+}
+
 Push-Location $root_dir
 try {
     $build_dir = ".cmake"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -e
-opt_configuration=Debug
 build_dir=.cmake
 bin_dir=bin
 swift_version=6.3.1
 vendor_source=
 vendor_prebuilt_url=
+crypto_selected=
+crypto_openssl=
+crypto_mbedtls=
 
 root_dir="$(dirname "$0")"/..
 pushd $root_dir
@@ -87,36 +89,59 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -install)
+            if [[ -z ${2:-} || $2 == -* ]]; then
+                echo "-install requires a value"
+                exit 1
+            fi
             install_dir=$2
-            mkdir $install_dir || true
+            mkdir -p "$install_dir"
             cmake_opts+=("-DCMAKE_INSTALL_PREFIX=$install_dir")
+            do_build=1
             shift
             shift
             ;;
         -crypto)
-            # openssl|native
-            case $2 in
-                openssl)
-                    cmake_opts+=("-DPP_BUILD_USE_OPENSSL=ON")
-                    cmake_opts+=("-DPP_BUILD_USE_MBEDTLS=OFF")
-                    ;;
-                native)
-                    cmake_opts+=("-DPP_BUILD_USE_OPENSSL=OFF")
-                    cmake_opts+=("-DPP_BUILD_USE_MBEDTLS=ON")
-                    ;;
-                *)
-                    echo "Unknown crypto '$2'"
-                    exit 1
-                    ;;
-            esac
+            # openssl|native, comma-separated
+            if [[ -z ${2:-} || $2 == -* ]]; then
+                echo "-crypto requires a value"
+                exit 1
+            fi
+            if [[ $2 == ,* || $2 == *, || $2 == *,,* ]]; then
+                echo "Empty crypto in '$2'"
+                exit 1
+            fi
+            crypto_selected=1
+            do_build=1
+            IFS=',' read -ra crypto_args <<< "$2"
+            for crypto in "${crypto_args[@]}"; do
+                crypto="${crypto//[[:space:]]/}"
+                case $crypto in
+                    openssl)
+                        crypto_openssl=1
+                        ;;
+                    native)
+                        crypto_mbedtls=1
+                        ;;
+                    "")
+                        echo "Empty crypto in '$2'"
+                        exit 1
+                        ;;
+                    *)
+                        echo "Unknown crypto '$crypto'"
+                        exit 1
+                        ;;
+                esac
+            done
             shift
             shift
             ;;
         -openvpn)
+            do_build=1
             cmake_opts+=("-DPP_BUILD_USE_OPENVPN=ON")
             shift
             ;;
         -wireguard)
+            do_build=1
             cmake_opts+=("-DPP_BUILD_USE_WIREGUARD=ON")
             shift
             ;;
@@ -165,6 +190,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 set -- "${positional_args[@]}"
+
+# Crypto
+if [[ $crypto_selected == 1 ]]; then
+    if [[ $crypto_openssl == 1 ]]; then
+        cmake_opts+=("-DPP_BUILD_USE_OPENSSL=ON")
+    else
+        cmake_opts+=("-DPP_BUILD_USE_OPENSSL=OFF")
+    fi
+    if [[ $crypto_mbedtls == 1 ]]; then
+        cmake_opts+=("-DPP_BUILD_USE_MBEDTLS=ON")
+    else
+        cmake_opts+=("-DPP_BUILD_USE_MBEDTLS=OFF")
+    fi
+fi
 
 # Vendor overrides
 if [[ -n $vendor_source ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,34 @@ vendor_prebuilt_url=
 crypto_selected=
 crypto_openssl=
 crypto_mbedtls=
+script_dir="$(dirname "$0")"
 
-root_dir="$(dirname "$0")"/..
+print_common_help() {
+    cat "$script_dir/build-help.txt"
+}
+
+print_help() {
+    cat <<EOF
+Usage: scripts/build.sh [options]
+
+Options:
+EOF
+    print_common_help
+    cat <<EOF
+
+build.sh only:
+  -gen-models [all|swift|kotlin|cpp]
+                                  Generate OpenAPI models
+  -config Debug|Release          Set the CMake build type
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+    print_help
+    exit 0
+fi
+
+root_dir="$script_dir"/..
 pushd $root_dir
 
 generate_swift_models() {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -211,8 +211,6 @@ if [[ -n $vendor_source ]]; then
 fi
 if [[ -n $vendor_prebuilt_url ]]; then
     cmake_opts+=("-DPP_BUILD_VENDOR_PREBUILT_URL=$vendor_prebuilt_url")
-elif [[ -n ${PP_BUILD_VENDOR_PREBUILT_URL:-} ]]; then
-    cmake_opts+=("-DPP_BUILD_VENDOR_PREBUILT_URL=$PP_BUILD_VENDOR_PREBUILT_URL")
 fi
 
 # On Linux, use custom toolchain

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,8 +22,6 @@ Options:
 EOF
     print_common_help
     cat <<EOF
-
-build.sh only:
   -gen-models [all|swift|kotlin|cpp]
                                   Generate OpenAPI models
   -config Debug|Release          Set the CMake build type

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,13 +93,6 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
-        -a)
-            do_build=1
-            cmake_opts+=("-DPP_BUILD_LIBRARY=ON")
-            cmake_opts+=("-DPP_BUILD_USE_OPENVPN=ON")
-            cmake_opts+=("-DPP_BUILD_USE_WIREGUARD=ON")
-            shift
-            ;;
         -crypto)
             # openssl|native
             case $2 in

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ EOF
     print_common_help
     cat <<EOF
   -gen-models [all|swift|kotlin|cpp]
-                                  Generate OpenAPI models
+                                 Generate OpenAPI models (requires java)
   -config Debug|Release          Set the CMake build type
 EOF
 }


### PR DESCRIPTION
The UNIX script had a few issues, and the Windows script was fairly limited. In short:

- Support multiple crypto backends in CMake after #514 
- Use Ninja multiconfig on Windows
- Pick prebuilt URL from command line
- Show help when called without arguments

Other than that, fix a few build issues with different combinations of crypto libs:

- Add PARTOUT_HAS_CRYPTO macro
- Define PartoutCrypto_C target unconditionally
- Simplify Package.swift