### PR TITLE
Linux: Add matrix variant to test build workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           swift-version: ${{ env.SWIFT_VERSION }}
           swift-build: ${{ env.SWIFT_BUILD }}
+          cache: true
       - name: Build with CMake (no vendors)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 10
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - name: Windows x64
@@ -42,7 +42,9 @@ jobs:
       - name: Build with CMake (no vendors)
         if: runner.os == 'Linux'
         shell: bash
-        run: ./scripts/build.sh -gen -l -install "$INSTALL_DIR"
+        run: |
+          git submodule update --init cmake/swift
+          ./scripts/build.sh -gen -l -install "$INSTALL_DIR"
       - name: Verify output
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,28 +7,43 @@ env:
   INSTALL_DIR: dist
   SWIFT_VERSION: swift-6.3.2-release
   SWIFT_BUILD: 6.3.2-RELEASE
-  ARCH_WINDOWS: x64
 
 jobs:
-  build_windows:
-    name: Build for Windows x64
-    runs-on: windows-latest
+  build:
+    name: Build for ${{ matrix.name }}
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows x64
+            runs_on: windows-latest
+            arch: x64
+            shell: pwsh
+            build_command: ./scripts/build.ps1 -gen -l -install $env:INSTALL_DIR
+            verify_command: ./ci/verify-windows.ps1 $env:INSTALL_DIR
+          - name: Linux x64
+            runs_on: ubuntu-latest
+            arch: x64
+            shell: bash
+            build_command: ./scripts/build.sh -gen -l -install "$INSTALL_DIR"
+            verify_command: ./ci/verify-linux.sh "$INSTALL_DIR"
     steps:
       - uses: actions/checkout@v7
       - name: Set up Visual Studio
+        if: runner.os == 'Windows'
         uses: egor-tensin/vs-shell@v2
         with:
-          arch: ${{ env.ARCH_WINDOWS }}
+          arch: ${{ matrix.arch }}
       - name: Set up Swift
         uses: compnerd/gha-setup-swift@main
         with:
           swift-version: ${{ env.SWIFT_VERSION }}
           swift-build: ${{ env.SWIFT_BUILD }}
       - name: Build with CMake (no vendors)
-        shell: pwsh
-        run: |
-          ./scripts/build.ps1 -gen -l -install $env:INSTALL_DIR
+        shell: ${{ matrix.shell }}
+        run: ${{ matrix.build_command }}
       - name: Verify output
-        shell: pwsh
-        run: ./ci/verify-windows.ps1 $env:INSTALL_DIR
+        shell: ${{ matrix.shell }}
+        run: ${{ matrix.verify_command }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,15 +20,9 @@ jobs:
           - name: Windows x64
             runs_on: windows-latest
             arch: x64
-            shell: pwsh
-            build_command: ./scripts/build.ps1 -gen -l -install $env:INSTALL_DIR
-            verify_command: ./ci/verify-windows.ps1 $env:INSTALL_DIR
           - name: Linux x64
             runs_on: ubuntu-latest
             arch: x64
-            shell: bash
-            build_command: ./scripts/build.sh -gen -l -install "$INSTALL_DIR"
-            verify_command: ./ci/verify-linux.sh "$INSTALL_DIR"
     steps:
       - uses: actions/checkout@v7
       - name: Set up Visual Studio
@@ -42,8 +36,18 @@ jobs:
           swift-version: ${{ env.SWIFT_VERSION }}
           swift-build: ${{ env.SWIFT_BUILD }}
       - name: Build with CMake (no vendors)
-        shell: ${{ matrix.shell }}
-        run: ${{ matrix.build_command }}
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/build.ps1 -gen -l -install $env:INSTALL_DIR
+      - name: Build with CMake (no vendors)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: ./scripts/build.sh -gen -l -install "$INSTALL_DIR"
       - name: Verify output
-        shell: ${{ matrix.shell }}
-        run: ${{ matrix.verify_command }}
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./ci/verify-windows.ps1 $env:INSTALL_DIR
+      - name: Verify output
+        if: runner.os == 'Linux'
+        shell: bash
+        run: ./ci/verify-linux.sh "$INSTALL_DIR"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,6 +43,10 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          # Swift action sets a wrong path, maybe the toolchain
+          # has changed its layout since the action was last updated
+          SWIFT_PATHS=("$HOME"/swift-*/usr/bin)
+          PATH="${SWIFT_PATHS[0]}:$PATH"
           git submodule update --init cmake/swift
           ./scripts/build.sh -gen -l -install "$INSTALL_DIR"
       - name: Verify output

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/openssl/openssl
 [submodule "swift-cmake-toolchains"]
 	path = cmake/swift
-	url = git@github.com:keeshux/swift-cmake-toolchains.git
+	url = https://github.com/keeshux/swift-cmake-toolchains

--- a/ci/verify-linux.sh
+++ b/ci/verify-linux.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: ci/verify-linux.sh <install-dir>"
+    exit 1
+fi
+
+get_required_command_path() {
+    local name=$1
+
+    if ! command -v "$name" >/dev/null 2>&1; then
+        echo "$name not found on PATH" >&2
+        exit 1
+    fi
+}
+
+get_required_artifact() {
+    local result_var=$1
+    local root=$2
+    local relative_path=$3
+    local path="$root/$relative_path"
+
+    if [[ ! -f $path ]]; then
+        echo "Missing artifact: $path" >&2
+        exit 1
+    fi
+    if [[ ! -s $path ]]; then
+        echo "Empty artifact: $path" >&2
+        exit 1
+    fi
+
+    local size
+    size=$(wc -c < "$path")
+    size=${size//[[:space:]]/}
+    echo "$relative_path : $size bytes"
+    printf -v "$result_var" "%s" "$path"
+}
+
+assert_x64_artifact() {
+    local path=$1
+    local headers
+
+    headers=$(readelf -h "$path")
+    if [[ ! $headers =~ Class:[[:space:]]+ELF64 ]]; then
+        echo "Artifact is not ELF64: $path" >&2
+        exit 1
+    fi
+    if [[ ! $headers =~ Machine:[[:space:]]+Advanced[[:space:]]Micro[[:space:]]Devices[[:space:]]X86-64 ]]; then
+        echo "Artifact is not x64: $path" >&2
+        exit 1
+    fi
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+cd "$repo_root"
+
+install_dir=$1
+install_root="$(cd "$install_dir" && pwd -P)"
+get_required_command_path readelf
+echo "Using readelf: $(command -v readelf)"
+echo "Verifying install directory: $install_root"
+
+get_required_artifact partout_library "$install_root" "lib/libpartout.so"
+assert_x64_artifact "$partout_library"


### PR DESCRIPTION
Similarly to #349, make it a matrix to add a Linux build.