### PR TITLE
OpenVPN: Make I/O failures recoverable

### DIFF
--- a/Sources/PartoutOpenVPN/V3/Internal/OpenVPNSessionV3.swift
+++ b/Sources/PartoutOpenVPN/V3/Internal/OpenVPNSessionV3.swift
@@ -135,7 +135,7 @@ extension OpenVPNSessionV3: OpenVPNSessionProtocolV3 {
                 },
                 onFailure: { [weak self] error in
                     Task {
-                        await self?.shutdown(error)
+                        await self?.shutdown(PartoutError(.ioFailure, error))
                     }
                 }
             ))

--- a/zig/src/openvpn/internal/session.zig
+++ b/zig/src/openvpn/internal/session.zig
@@ -302,7 +302,7 @@ pub const Session = struct {
         try self.looper.attach(.{
             .pair = .{ .link = descriptor },
             .on_read = .{ .context = self, .callback = onLinkRead },
-            .on_failure = .{ .context = self, .callback = onSideFailure },
+            .on_failure = .{ .context = self, .callback = onLinkFailure },
         });
         attached = true;
         var request = SetLinkRequest{
@@ -486,6 +486,12 @@ pub const Session = struct {
     fn onSideFailure(raw: ?*anyopaque, failure: net_mod.Looper.Failure) void {
         const self: *Session = @ptrCast(@alignCast(raw.?));
         self.requestShutdown(failureError(failure));
+    }
+
+    fn onLinkFailure(raw: ?*anyopaque, failure: net_mod.Looper.Failure) void {
+        const self: *Session = @ptrCast(@alignCast(raw.?));
+        const cause = failureError(failure);
+        self.requestShutdown(if (cause == error.CryptoFailure) error.Reconnect else cause);
     }
 
     fn onLinkRead(


### PR DESCRIPTION
Regression from V2. Wrap errors in `.ioFailure` so they do not terminate the process (like in `loopLinkV2()`).