### PR TITLE
Zig: Centralize logging and honor privacy

### DIFF
--- a/Sources/PartoutRuntime/PartoutProviderRuntime.swift
+++ b/Sources/PartoutRuntime/PartoutProviderRuntime.swift
@@ -14,6 +14,7 @@ public final class PartoutProviderRuntime: Sendable {
     private let environment: UserDefaultsEnvironment
     private let messageHandler: DefaultMessageHandler
     private let options: TunnelControllerOptions
+    private let logsPrivateData: Bool
     private let logger: partout_logger_cb?
 
     public init(
@@ -21,6 +22,7 @@ public final class PartoutProviderRuntime: Sendable {
         decoder: NEProtocolDecoder,
         options: TunnelControllerOptions,
         defaults: UserDefaults,
+        logsPrivateData: Bool,
         logger: partout_logger_cb?
     ) throws {
         profile = try Profile(withNEProvider: provider, decoder: decoder)
@@ -29,6 +31,7 @@ public final class PartoutProviderRuntime: Sendable {
         environment = UserDefaultsEnvironment(profileId: profile.id, defaults: defaults)
         messageHandler = DefaultMessageHandler(ctx, environment: environment)
         self.options = options
+        self.logsPrivateData = logsPrivateData
         self.logger = logger
     }
 
@@ -47,7 +50,7 @@ public final class PartoutProviderRuntime: Sendable {
         pp_log(ctx, .os, .notice, "Start runtime")
 
         var init_args = partout_init_args(
-            logs_private_data: true,
+            logs_private_data: logsPrivateData,
             logger: logger
         )
         pp_log(ctx, .os, .info, "Initialize Partout library")

--- a/zig/src/core/api.zig
+++ b/zig/src/core/api.zig
@@ -91,7 +91,6 @@ pub const encodeProfileZ = extensions.encodeProfileZ;
 pub const findActiveConnectionModule = extensions.findActiveConnectionModule;
 pub const hasConnection = extensions.hasConnection;
 pub const isActiveProfileModule = extensions.isActiveProfileModule;
-pub const logDecodedProfile = extensions.logDecodedProfile;
 pub const moduleCacheFilename = extensions.moduleCacheFilename;
 pub const moduleId = extensions.moduleId;
 pub const moduleType = extensions.moduleType;

--- a/zig/src/core/api.zig
+++ b/zig/src/core/api.zig
@@ -73,6 +73,7 @@ pub const TaggedModuleIP = gen.TaggedModuleIP;
 pub const TaggedModuleOnDemand = gen.TaggedModuleOnDemand;
 pub const TaggedModuleOpenVPN = gen.TaggedModuleOpenVPN;
 pub const TaggedModuleWireGuard = gen.TaggedModuleWireGuard;
+pub const TunnelControllerOptions = gen.TunnelControllerOptions;
 pub const TunnelRemoteInfoWrapper = gen.TunnelRemoteInfoWrapper;
 pub const TunnelSnapshot = gen.TunnelSnapshot;
 pub const TunnelSnapshotEnvironment = gen.TunnelSnapshotEnvironment;

--- a/zig/src/core/api_extensions.zig
+++ b/zig/src/core/api_extensions.zig
@@ -5,7 +5,6 @@
 const std = @import("std");
 
 const gen = @import("api_generated.zig");
-const log = @import("logging.zig");
 const util = @import("util.zig");
 const uuid = @import("uuid.zig");
 
@@ -74,24 +73,6 @@ pub fn isActiveProfileModule(profile: *const gen.Profile, module_id: uuid.UUID) 
     return false;
 }
 
-/// Logs a decoded profile using the core logging facility.
-pub fn logDecodedProfile(allocator: std.mem.Allocator, profile: *const gen.Profile) void {
-    if (!log.hasLogger()) return;
-
-    log.write(.notice, "Decoded profile:");
-    log.writef(.notice, "\tID: {s}", .{profile.id[0..]});
-    log.writef(.notice, "\tName: {s}", .{profile.name});
-    if (profile.behavior) |behavior| {
-        const encoded = util.encodeJsonValue(allocator, behavior) catch return;
-        defer allocator.free(encoded);
-        log.writef(.notice, "\tBehavior: {s}", .{encoded});
-    }
-    log.write(.notice, "\tModules:");
-    for (profile.modules) |*module| {
-        logProfileModule(allocator, profile, module);
-    }
-}
-
 /// Returns the schema id stored in a tagged module.
 ///
 /// Custom modules currently do not have a schema-level id, so they use the zero
@@ -155,23 +136,4 @@ pub fn typeBuildsConnection(value: gen.ModuleType) bool {
 /// Reports whether `module` is both active in the profile and connection-capable.
 fn isActiveConnectionModule(profile: *const gen.Profile, module: *const gen.TaggedModule) bool {
     return isActiveProfileModule(profile, moduleId(module)) and typeBuildsConnection(moduleType(module));
-}
-
-fn logProfileModule(
-    allocator: std.mem.Allocator,
-    profile: *const gen.Profile,
-    module: *const gen.TaggedModule,
-) void {
-    const active_marker: u8 = if (isActiveProfileModule(profile, moduleId(module))) '+' else '-';
-    const type_name = moduleType(module).raw();
-    if (log.logsPrivateData()) {
-        const encoded = util.encodeJsonValue(allocator, module) catch {
-            log.writef(.notice, "\t\t{c} {s}: {s}", .{ active_marker, type_name, moduleType(module).raw() });
-            return;
-        };
-        defer allocator.free(encoded);
-        log.writef(.notice, "\t\t{c} {s}: {s}", .{ active_marker, type_name, encoded });
-        return;
-    }
-    log.writef(.notice, "\t\t{c} {s}: {s}", .{ active_marker, type_name, moduleType(module).raw() });
 }

--- a/zig/src/core/logging.zig
+++ b/zig/src/core/logging.zig
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
 const std = @import("std");
+
+const gen = @import("api_generated.zig");
+const manual = @import("api_manual.zig");
 const concurrency = @import("concurrency.zig");
 const util = @import("util.zig");
 
@@ -15,26 +18,42 @@ pub const Level = enum(c_int) {
     debug = 4,
 };
 
+const Logger = *const fn (
+    level: c_int,
+    message: [*:0]const u8,
+) callconv(.c) void;
+
+/// Logger callback registered by the host application.
+///
+/// `message` must be a zero-terminated string.
+pub const Callback = ?Logger;
+
+var mutex: concurrency.Mutex = .{};
+var logs_private_data: bool = false;
+var external_logger: Callback = null;
+
 // ZIGME: Suppress until only Zig ABI
 /// C ABI entry point used by foreign callers to forward a log message.
 // pub export fn partout_log(
 //     level: c_int,
 //     message: [*:0]const u8,
 // ) callconv(.c) void {
-//     dispatch(level, message);
+//     mutex.lock();
+//     const logger = external_logger orelse {
+//         mutex.unlock();
+//         return;
+//     };
+//     mutex.unlock();
+//     dispatch(logger, level, message);
 // }
 
-var mutex: concurrency.Mutex = .{};
-var logs_private_data: bool = false;
-var external_logger: Callback = null;
-
-/// Logger callback registered by the host application.
-///
-/// `message` must be a zero-terminated string.
-pub const Callback = ?*const fn (
+fn dispatch(
+    logger: Logger,
     level: c_int,
     message: [*:0]const u8,
-) callconv(.c) void;
+) void {
+    logger(level, message);
+}
 
 /// Configures global logging state.
 ///
@@ -72,36 +91,390 @@ pub fn hasLogger() bool {
     return external_logger != null;
 }
 
+/// Marks a value as sensitive so `writef` applies the current privacy policy.
+pub fn sensitive(value: anytype) SensitiveValue(@TypeOf(value)) {
+    return .{ .value = value };
+}
+
 /// Writes a core log message.
 ///
 /// Messages are dropped when no logger is installed or when allocating the
 /// zero-terminated copy fails.
 pub fn write(level: Level, message: []const u8) void {
+    mutex.lock();
+    const logger = external_logger orelse {
+        mutex.unlock();
+        return;
+    };
+    mutex.unlock();
+    writeTo(logger, level, message);
+}
+
+fn writeTo(logger: Logger, level: Level, message: []const u8) void {
     const allocator = std.heap.c_allocator;
     var c_message: util.TemporaryCString = .{};
     c_message.init(allocator, message) catch return;
     defer c_message.deinit();
-    dispatch(@intFromEnum(level), c_message.ptr());
+    dispatch(logger, @intFromEnum(level), c_message.ptr());
 }
 
 /// Formats and writes a core log message.
+///
+/// Arguments with a registered logging representation are replaced with
+/// `redacted_value` unless private logging is enabled. Otherwise, their debug
+/// representation is substituted into the format arguments. Privacy-aware
+/// arguments therefore use the `{s}` format specifier.
 pub fn writef(level: Level, comptime fmt: []const u8, args: anytype) void {
-    const allocator = std.heap.c_allocator;
-    const message = std.fmt.allocPrint(allocator, fmt, args) catch return;
-    defer allocator.free(message);
-    write(level, message);
-}
-
-fn dispatch(level: c_int, message: [*:0]const u8) void {
     mutex.lock();
-    // Copy the callback under the lock, then invoke it outside the lock so
-    // loggers can call back into this API.
-    const logger = external_logger;
-    if (logger == null) {
+    const private_data = logs_private_data;
+    const logger = external_logger orelse {
         mutex.unlock();
         return;
-    }
+    };
     mutex.unlock();
+    var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const prepared = prepareArguments(
+        allocator,
+        args,
+        private_data,
+    ) catch return;
+    const message = std.fmt.allocPrint(allocator, fmt, prepared) catch return;
+    writeTo(logger, level, message);
+}
 
-    logger.?(level, message);
+/// Writes a duration in seconds using a compact `h`, `m`, and `s`
+/// representation.
+pub fn logTimeSeconds(
+    level: Level,
+    comptime prefix: []const u8,
+    seconds: f64,
+) void {
+    const ticks: u64 = if (seconds > 0) @intFromFloat(seconds) else 0;
+    logTimeTicks(level, prefix, ticks);
+}
+
+/// Writes a duration in milliseconds using a compact `h`, `m`, and `s`
+/// representation.
+pub fn logTimeMs(
+    level: Level,
+    comptime prefix: []const u8,
+    milliseconds: u64,
+) void {
+    logTimeTicks(level, prefix, milliseconds / 1000);
+}
+
+fn logTimeTicks(
+    level: Level,
+    comptime prefix: []const u8,
+    ticks: u64,
+) void {
+    const hours = ticks / 3600;
+    const minutes = (ticks % 3600) / 60;
+    const seconds = ticks % 60;
+    if (hours > 0 and minutes > 0 and seconds > 0) {
+        writef(level, prefix ++ "{d}h{d}m{d}s", .{ hours, minutes, seconds });
+    } else if (hours > 0 and minutes > 0) {
+        writef(level, prefix ++ "{d}h{d}m", .{ hours, minutes });
+    } else if (hours > 0 and seconds > 0) {
+        writef(level, prefix ++ "{d}h{d}s", .{ hours, seconds });
+    } else if (minutes > 0 and seconds > 0) {
+        writef(level, prefix ++ "{d}m{d}s", .{ minutes, seconds });
+    } else if (hours > 0) {
+        writef(level, prefix ++ "{d}h", .{hours});
+    } else if (minutes > 0) {
+        writef(level, prefix ++ "{d}m", .{minutes});
+    } else {
+        writef(level, prefix ++ "{d}s", .{seconds});
+    }
+}
+
+const redacted_value = "<redacted>";
+
+fn SensitiveValue(comptime T: type) type {
+    return struct {
+        value: T,
+
+        pub fn logging_formatter(
+            allocator: std.mem.Allocator,
+            wrapped: @This(),
+        ) ![]const u8 {
+            return formatExplicitSensitive(allocator, wrapped.value);
+        }
+    };
+}
+
+const ModelAdapter = enum {
+    raw,
+    raw_alloc,
+    pem,
+    hex,
+    ip_settings,
+    json,
+};
+
+const LogFormat = union(enum) {
+    declared,
+    model: ModelAdapter,
+    optional,
+    array,
+    dictionary,
+    dereference,
+};
+
+// API models cannot retroactively declare a logging formatter. Keep their
+// type identity and representation together in this comptime adapter registry.
+const model_adapters = .{
+    .{ manual.Address, ModelAdapter.raw },
+    .{ manual.Endpoint, ModelAdapter.raw_alloc },
+    .{ manual.ExtendedEndpoint, ModelAdapter.raw_alloc },
+    .{ manual.OpenVPNCryptoContainer, ModelAdapter.pem },
+    .{ manual.SecureData, ModelAdapter.hex },
+    .{ manual.Subnet, ModelAdapter.raw_alloc },
+    .{ manual.WireGuardKey, ModelAdapter.raw },
+    .{ gen.IPSettings, ModelAdapter.ip_settings },
+    .{ gen.DNSModule, ModelAdapter.json },
+    .{ gen.DNSModuleProtocolType, ModelAdapter.json },
+    .{ gen.DNSModuleProtocolTypeHttps, ModelAdapter.json },
+    .{ gen.DNSModuleProtocolTypeTls, ModelAdapter.json },
+    .{ gen.HTTPProxyModule, ModelAdapter.json },
+    .{ gen.IPModule, ModelAdapter.json },
+    .{ gen.OnDemandModule, ModelAdapter.json },
+    .{ gen.OpenVPNConfiguration, ModelAdapter.json },
+    .{ gen.OpenVPNCredentials, ModelAdapter.json },
+    .{ gen.OpenVPNModule, ModelAdapter.json },
+    .{ gen.OpenVPNObfuscationMethod, ModelAdapter.json },
+    .{ gen.OpenVPNObfuscationMethodObfuscate, ModelAdapter.json },
+    .{ gen.OpenVPNObfuscationMethodXormask, ModelAdapter.json },
+    .{ gen.OpenVPNStaticKey, ModelAdapter.json },
+    .{ gen.OpenVPNTLSWrap, ModelAdapter.json },
+    .{ gen.Profile, ModelAdapter.json },
+    .{ gen.Route, ModelAdapter.json },
+    .{ gen.TaggedModule, ModelAdapter.json },
+    .{ gen.TunnelControllerOptions, ModelAdapter.json },
+    .{ gen.TunnelRemoteInfoWrapper, ModelAdapter.json },
+    .{ gen.WireGuardConfiguration, ModelAdapter.json },
+    .{ gen.WireGuardLocalInterface, ModelAdapter.json },
+    .{ gen.WireGuardModule, ModelAdapter.json },
+    .{ gen.WireGuardRemoteInterface, ModelAdapter.json },
+};
+
+fn prepareArguments(
+    allocator: std.mem.Allocator,
+    args: anytype,
+    private_data: bool,
+) !PreparedArguments(@TypeOf(args)) {
+    const Args = @TypeOf(args);
+    const args_info = @typeInfo(Args).@"struct";
+    var prepared: PreparedArguments(Args) = undefined;
+    inline for (args_info.fields) |field| {
+        const value = @field(args, field.name);
+        @field(prepared, field.name) = if (comptime logFormat(field.type) != null)
+            if (private_data)
+                try forLog(allocator, value)
+            else
+                redacted_value
+        else
+            value;
+    }
+    return prepared;
+}
+
+fn PreparedArguments(comptime Args: type) type {
+    const args_info = @typeInfo(Args).@"struct";
+    var names: [args_info.fields.len][]const u8 = undefined;
+    var types: [args_info.fields.len]type = undefined;
+    for (args_info.fields, 0..) |field, index| {
+        names[index] = field.name;
+        types[index] = if (logFormat(field.type) != null)
+            []const u8
+        else
+            runtimeType(field.type);
+    }
+    if (args_info.is_tuple) return @Tuple(&types);
+    return @Struct(.auto, null, &names, &types, &@splat(.{}));
+}
+
+fn runtimeType(comptime T: type) type {
+    return switch (@typeInfo(T)) {
+        .comptime_int => i128,
+        .comptime_float => f128,
+        else => T,
+    };
+}
+
+fn logFormat(comptime T: type) ?LogFormat {
+    if (std.meta.hasFn(T, "logging_formatter")) return .declared;
+    if (findModelAdapter(T)) |adapter| return .{ .model = adapter };
+    return switch (@typeInfo(T)) {
+        .optional => |optional| if (logFormat(optional.child) != null)
+            .optional
+        else
+            null,
+        .array => |array| if (isCollectionElement(array.child))
+            .array
+        else
+            null,
+        .pointer => |pointer| switch (pointer.size) {
+            .one => if (logFormat(pointer.child) != null)
+                .dereference
+            else
+                null,
+            .slice => if (isCollectionElement(pointer.child)) .array else null,
+            .many, .c => null,
+        },
+        .@"struct" => if (isDictionary(T)) .dictionary else null,
+        else => null,
+    };
+}
+
+fn forLog(
+    allocator: std.mem.Allocator,
+    value: anytype,
+) ![]const u8 {
+    const T = @TypeOf(value);
+    const format = comptime logFormat(T) orelse unreachable;
+    return switch (format) {
+        .declared => T.logging_formatter(allocator, value),
+        .model => |adapter| formatWithAdapter(allocator, value, adapter),
+        .optional => if (value) |unwrapped|
+            forLog(allocator, unwrapped)
+        else
+            "null",
+        .array => switch (@typeInfo(T)) {
+            .array => formatArray(allocator, &value),
+            .pointer => formatArray(allocator, value),
+            else => unreachable,
+        },
+        .dictionary => formatDictionary(allocator, &value),
+        .dereference => forLog(allocator, value.*),
+    };
+}
+
+fn findModelAdapter(comptime T: type) ?ModelAdapter {
+    inline for (model_adapters) |adapter| {
+        if (T == adapter[0]) return adapter[1];
+    }
+    return null;
+}
+
+fn formatWithAdapter(
+    allocator: std.mem.Allocator,
+    value: anytype,
+    comptime adapter: ModelAdapter,
+) ![]const u8 {
+    return switch (adapter) {
+        .raw => value.raw,
+        .raw_alloc => value.rawAlloc(allocator),
+        .pem => value.pem,
+        .hex => value.hexAlloc(allocator),
+        .ip_settings => formatIPSettings(allocator, value),
+        .json => util.encodeJsonValue(allocator, value),
+    };
+}
+
+fn formatExplicitSensitive(
+    allocator: std.mem.Allocator,
+    value: anytype,
+) ![]const u8 {
+    const T = @TypeOf(value);
+    if (comptime logFormat(T) != null) return forLog(allocator, value);
+    if (comptime isString(T)) return allocator.dupe(u8, value);
+    return std.fmt.allocPrint(allocator, "{any}", .{value});
+}
+
+fn formatIPSettings(
+    allocator: std.mem.Allocator,
+    value: gen.IPSettings,
+) ![]const u8 {
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const writer = &output.writer;
+    try writer.writeAll("addrs ");
+    try writeArray(writer, allocator, value.subnets);
+    try writer.writeAll(", includedRoutes=");
+    try writeArray(writer, allocator, value.included_routes);
+    try writer.writeAll(", excludedRoutes=");
+    try writeArray(writer, allocator, value.excluded_routes);
+    return output.toOwnedSlice();
+}
+
+fn formatArray(
+    allocator: std.mem.Allocator,
+    values: anytype,
+) ![]const u8 {
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    try writeArray(&output.writer, allocator, values);
+    return output.toOwnedSlice();
+}
+
+fn writeArray(
+    writer: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    values: anytype,
+) !void {
+    try writer.writeByte('[');
+    for (values, 0..) |value, index| {
+        if (index > 0) try writer.writeAll(", ");
+        try writeDebug(writer, allocator, value);
+    }
+    try writer.writeByte(']');
+}
+
+fn formatDictionary(
+    allocator: std.mem.Allocator,
+    dictionary: anytype,
+) ![]const u8 {
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const writer = &output.writer;
+    try writer.writeByte('[');
+    var iterator = dictionary.iterator();
+    var index: usize = 0;
+    while (iterator.next()) |entry| : (index += 1) {
+        if (index > 0) try writer.writeAll(", ");
+        try writeDebug(writer, allocator, entry.key_ptr.*);
+        try writer.writeAll(": ");
+        try writeDebug(writer, allocator, entry.value_ptr.*);
+    }
+    try writer.writeByte(']');
+    return output.toOwnedSlice();
+}
+
+fn writeDebug(
+    writer: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    value: anytype,
+) !void {
+    if (comptime logFormat(@TypeOf(value)) != null) {
+        try writer.writeAll(try forLog(allocator, value));
+    } else if (comptime isString(@TypeOf(value))) {
+        try writer.writeAll(value);
+    } else {
+        try writer.print("{any}", .{value});
+    }
+}
+
+fn isCollectionElement(comptime T: type) bool {
+    return logFormat(T) != null or isString(T);
+}
+
+fn isDictionary(comptime T: type) bool {
+    if (!std.meta.hasFn(T, "iterator") or !@hasDecl(T, "Entry")) return false;
+    return @hasField(T.Entry, "key_ptr") and @hasField(T.Entry, "value_ptr");
+}
+
+fn isString(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .array => |array| array.child == u8,
+        .pointer => |pointer| switch (pointer.size) {
+            .one => @typeInfo(pointer.child) == .array and
+                @typeInfo(pointer.child).array.child == u8,
+            .slice => pointer.child == u8,
+            .many, .c => false,
+        },
+        else => false,
+    };
 }

--- a/zig/src/core/logging.zig
+++ b/zig/src/core/logging.zig
@@ -4,8 +4,7 @@
 
 const std = @import("std");
 
-const gen = @import("api_generated.zig");
-const manual = @import("api_manual.zig");
+const api = @import("api.zig");
 const concurrency = @import("concurrency.zig");
 const util = @import("util.zig");
 
@@ -226,38 +225,38 @@ const LogFormat = union(enum) {
 // API models cannot retroactively declare a logging formatter. Keep their
 // type identity and representation together in this comptime adapter registry.
 const model_adapters = .{
-    .{ manual.Address, ModelAdapter.raw },
-    .{ manual.Endpoint, ModelAdapter.raw_alloc },
-    .{ manual.ExtendedEndpoint, ModelAdapter.raw_alloc },
-    .{ manual.OpenVPNCryptoContainer, ModelAdapter.pem },
-    .{ manual.SecureData, ModelAdapter.hex },
-    .{ manual.Subnet, ModelAdapter.raw_alloc },
-    .{ manual.WireGuardKey, ModelAdapter.raw },
-    .{ gen.IPSettings, ModelAdapter.ip_settings },
-    .{ gen.DNSModule, ModelAdapter.json },
-    .{ gen.DNSModuleProtocolType, ModelAdapter.json },
-    .{ gen.DNSModuleProtocolTypeHttps, ModelAdapter.json },
-    .{ gen.DNSModuleProtocolTypeTls, ModelAdapter.json },
-    .{ gen.HTTPProxyModule, ModelAdapter.json },
-    .{ gen.IPModule, ModelAdapter.json },
-    .{ gen.OnDemandModule, ModelAdapter.json },
-    .{ gen.OpenVPNConfiguration, ModelAdapter.json },
-    .{ gen.OpenVPNCredentials, ModelAdapter.json },
-    .{ gen.OpenVPNModule, ModelAdapter.json },
-    .{ gen.OpenVPNObfuscationMethod, ModelAdapter.json },
-    .{ gen.OpenVPNObfuscationMethodObfuscate, ModelAdapter.json },
-    .{ gen.OpenVPNObfuscationMethodXormask, ModelAdapter.json },
-    .{ gen.OpenVPNStaticKey, ModelAdapter.json },
-    .{ gen.OpenVPNTLSWrap, ModelAdapter.json },
-    .{ gen.Profile, ModelAdapter.json },
-    .{ gen.Route, ModelAdapter.json },
-    .{ gen.TaggedModule, ModelAdapter.json },
-    .{ gen.TunnelControllerOptions, ModelAdapter.json },
-    .{ gen.TunnelRemoteInfoWrapper, ModelAdapter.json },
-    .{ gen.WireGuardConfiguration, ModelAdapter.json },
-    .{ gen.WireGuardLocalInterface, ModelAdapter.json },
-    .{ gen.WireGuardModule, ModelAdapter.json },
-    .{ gen.WireGuardRemoteInterface, ModelAdapter.json },
+    .{ api.Address, ModelAdapter.raw },
+    .{ api.Endpoint, ModelAdapter.raw_alloc },
+    .{ api.ExtendedEndpoint, ModelAdapter.raw_alloc },
+    .{ api.OpenVPNCryptoContainer, ModelAdapter.pem },
+    .{ api.SecureData, ModelAdapter.hex },
+    .{ api.Subnet, ModelAdapter.raw_alloc },
+    .{ api.WireGuardKey, ModelAdapter.raw },
+    .{ api.IPSettings, ModelAdapter.ip_settings },
+    .{ api.DNSModule, ModelAdapter.json },
+    .{ api.DNSModuleProtocolType, ModelAdapter.json },
+    .{ api.DNSModuleProtocolTypeHttps, ModelAdapter.json },
+    .{ api.DNSModuleProtocolTypeTls, ModelAdapter.json },
+    .{ api.HTTPProxyModule, ModelAdapter.json },
+    .{ api.IPModule, ModelAdapter.json },
+    .{ api.OnDemandModule, ModelAdapter.json },
+    .{ api.OpenVPNConfiguration, ModelAdapter.json },
+    .{ api.OpenVPNCredentials, ModelAdapter.json },
+    .{ api.OpenVPNModule, ModelAdapter.json },
+    .{ api.OpenVPNObfuscationMethod, ModelAdapter.json },
+    .{ api.OpenVPNObfuscationMethodObfuscate, ModelAdapter.json },
+    .{ api.OpenVPNObfuscationMethodXormask, ModelAdapter.json },
+    .{ api.OpenVPNStaticKey, ModelAdapter.json },
+    .{ api.OpenVPNTLSWrap, ModelAdapter.json },
+    .{ api.Profile, ModelAdapter.json },
+    .{ api.Route, ModelAdapter.json },
+    .{ api.TaggedModule, ModelAdapter.json },
+    .{ api.TunnelControllerOptions, ModelAdapter.json },
+    .{ api.TunnelRemoteInfoWrapper, ModelAdapter.json },
+    .{ api.WireGuardConfiguration, ModelAdapter.json },
+    .{ api.WireGuardLocalInterface, ModelAdapter.json },
+    .{ api.WireGuardModule, ModelAdapter.json },
+    .{ api.WireGuardRemoteInterface, ModelAdapter.json },
 };
 
 fn prepareArguments(
@@ -386,7 +385,7 @@ fn formatExplicitSensitive(
 
 fn formatIPSettings(
     allocator: std.mem.Allocator,
-    value: gen.IPSettings,
+    value: api.IPSettings,
 ) ![]const u8 {
     var output: std.Io.Writer.Allocating = .init(allocator);
     errdefer output.deinit();

--- a/zig/src/net/daemon.zig
+++ b/zig/src/net/daemon.zig
@@ -157,10 +157,10 @@ pub const Daemon = struct {
         original_profile: *const api.Profile,
         context: Context,
     ) Error!*Daemon {
-        // Clone profile for safety, then log it
+        // Clone profile for safety, then log it.
         var profile = try original_profile.clone(allocator);
         errdefer profile.deinit(allocator);
-        api.logDecodedProfile(allocator, &profile);
+        log.writef(.notice, "Decoded profile: {s}", .{&profile});
 
         const daemon = try allocator.create(Daemon);
         errdefer allocator.destroy(daemon);

--- a/zig/src/net/platform.zig
+++ b/zig/src/net/platform.zig
@@ -400,7 +400,9 @@ fn socketFactoryCreate(
         allocator,
         self.socketOptions(endpoint, effective_reachability, timeout),
     ) orelse return error.LinkNotActive;
-    log.writef(.debug, "PlatformSocketFactory: Created socket for {s}", .{endpoint.address});
+    log.writef(.debug, "PlatformSocketFactory: Created socket for {s}", .{
+        log.sensitive(endpoint.address),
+    });
     const fd = wrapper.muxDescriptor() orelse {
         wrapper.nativeIO().cleanup();
         return error.LinkNotActive;

--- a/zig/src/net/platform_dns.zig
+++ b/zig/src/net/platform_dns.zig
@@ -131,7 +131,9 @@ pub const PlatformDNS = struct {
         query_pool.mutex.unlock();
         if (timed_out) {
             thread.detach();
-            log.writef(.err, "DNS resolution timed out for {s}", .{hostname});
+            log.writef(.err, "DNS resolution timed out for {s}", .{
+                log.sensitive(hostname),
+            });
             return error.Timeout;
         }
         thread.join();
@@ -159,7 +161,7 @@ pub const PlatformDNS = struct {
             if (addr == null) continue;
             const numeric = numericHostAlloc(allocator, addr, current.ai_addrlen) catch |err| {
                 log.writef(.err, "getnameinfo() failed for {s}: {s}", .{
-                    hostname,
+                    log.sensitive(hostname),
                     @errorName(err),
                 });
                 continue;
@@ -172,7 +174,10 @@ pub const PlatformDNS = struct {
                 return err;
             };
         }
-        log.writef(.debug, "DNS resolved {s}: {} record(s)", .{ hostname, records.items.len });
+        log.writef(.debug, "DNS resolved {s}: {} record(s)", .{
+            log.sensitive(hostname),
+            records.items.len,
+        });
         return records.toOwnedSlice(allocator);
     }
 };

--- a/zig/src/openvpn/connection.zig
+++ b/zig/src/openvpn/connection.zig
@@ -323,7 +323,7 @@ const OpenVPNConnection = struct {
 
         var owned_endpoint = try cloneEndpoint(self.allocator, endpoint);
         errdefer owned_endpoint.deinit(self.allocator);
-        logSensitiveEndpoint(.notice, "Connect to ", owned_endpoint);
+        log.writef(.notice, "Connect to {s}", .{owned_endpoint});
         const descriptor = self.factory.create(
             self.allocator,
             owned_endpoint,
@@ -438,15 +438,16 @@ const OpenVPNConnection = struct {
         remote_options: *const api.OpenVPNConfiguration,
     ) void {
         log.write(.notice, "Session did start");
-        openvpn_log.sensitiveString(.info, "\tEndpoint: ", remote_endpoint.address);
+        const remote_address = api.Address.parseRaw(remote_endpoint.address) orelse unreachable;
+        log.writef(.info, "\tEndpoint: {s}", .{remote_address});
         log.writef(.info, "\tProtocol: {s}:{d}", .{
             remote_endpoint.proto.socket_type.raw(),
             remote_endpoint.proto.port,
         });
         log.write(.notice, "Local options:");
-        logConfiguration(&self.configuration, true);
+        openvpn_log.logConfiguration(&self.configuration, true);
         log.write(.notice, "Remote options:");
-        logConfiguration(remote_options, false);
+        openvpn_log.logConfiguration(remote_options, false);
         const events = self.events orelse return;
 
         const builder = NetworkSettingsBuilder.init(
@@ -687,231 +688,6 @@ const session_delegate_vtable = SessionDelegate.VTable{
     .did_update_data_count = sessionDidUpdateDataCount,
 };
 
-fn logConfiguration(
-    configuration: *const api.OpenVPNConfiguration,
-    is_local: bool,
-) void {
-    if (is_local) {
-        if (configuration.remotes) |remotes| {
-            if (log.logsPrivateData()) {
-                log.writef(.notice, "\tRemotes: {any}", .{remotes});
-            } else {
-                log.writef(.notice, "\tRemotes: [<redacted> x {d}]", .{remotes.len});
-            }
-        }
-    } else {
-        logSensitiveValue("\tIPv4: ", configuration.ipv4);
-        logSensitiveValue("\tIPv6: ", configuration.ipv6);
-    }
-    if (configuration.routes4) |routes|
-        log.writef(.notice, "\tRoutes (IPv4): {any}", .{routes});
-    if (configuration.routes6) |routes|
-        log.writef(.notice, "\tRoutes (IPv6): {any}", .{routes});
-
-    if (configuration.cipher) |cipher| {
-        log.writef(.notice, "\tCipher: {s}", .{cipher.raw()});
-    } else if (is_local) {
-        log.writef(.notice, "\tCipher: {s}", .{
-            configuration_mod.fallbackCipher(configuration).raw(),
-        });
-    }
-    if (configuration.digest) |digest| {
-        log.writef(.notice, "\tDigest: {s}", .{digest.raw()});
-    } else if (is_local) {
-        log.writef(.notice, "\tDigest: {s}", .{
-            configuration_mod.fallbackDigest(configuration).raw(),
-        });
-    }
-    if (configuration.compression_framing) |framing| {
-        log.writef(.notice, "\tCompression framing: {s}", .{@tagName(framing)});
-    } else if (is_local) {
-        log.writef(.notice, "\tCompression framing: {s}", .{
-            @tagName(configuration_mod.fallbackCompressionFraming(configuration)),
-        });
-    }
-    if (configuration.compression_algorithm) |algorithm| {
-        log.writef(.notice, "\tCompression algorithm: {s}", .{@tagName(algorithm)});
-    } else if (is_local) {
-        log.writef(.notice, "\tCompression algorithm: {s}", .{
-            @tagName(configuration_mod.fallbackCompressionAlgorithm(configuration)),
-        });
-    }
-
-    if (is_local) {
-        log.writef(.notice, "\tUsername authentication: {}", .{
-            configuration.auth_user_pass orelse false,
-        });
-        log.writef(.notice, "\tStatic challenge: {}", .{
-            configuration.static_challenge orelse false,
-        });
-        log.write(
-            .notice,
-            if (configuration.client_certificate != null)
-                "\tClient verification: enabled"
-            else
-                "\tClient verification: disabled",
-        );
-        if (configuration.tls_wrap) |wrap| {
-            log.writef(.notice, "\tTLS wrapping: {s}", .{wrap.strategy.raw()});
-        } else {
-            log.write(.notice, "\tTLS wrapping: disabled");
-        }
-        if (configuration.tls_security_level) |level| {
-            log.writef(.notice, "\tTLS security level: {d}", .{level});
-        } else {
-            log.write(.notice, "\tTLS security level: default");
-        }
-    }
-
-    logPositiveSeconds(
-        "\tKeep-alive interval: ",
-        configuration.keep_alive_interval,
-        is_local,
-    );
-    logPositiveSeconds(
-        "\tKeep-alive timeout: ",
-        configuration.keep_alive_timeout,
-        is_local,
-    );
-    logPositiveSeconds(
-        "\tRenegotiation: ",
-        configuration.renegotiates_after,
-        is_local,
-    );
-    if (configuration.checks_eku orelse false) {
-        log.write(.notice, "\tServer EKU verification: enabled");
-    } else if (is_local) {
-        log.write(.notice, "\tServer EKU verification: disabled");
-    }
-    if (configuration.checks_san_host orelse false) {
-        if (configuration.san_host) |host| {
-            if (log.logsPrivateData()) {
-                log.writef(.notice, "\tHost SAN verification: enabled ({s})", .{host});
-            } else {
-                log.write(.notice, "\tHost SAN verification: enabled (<redacted>)");
-            }
-        } else {
-            log.write(.notice, "\tHost SAN verification: enabled (-)");
-        }
-    } else if (is_local) {
-        log.write(.notice, "\tHost SAN verification: disabled");
-    }
-
-    if (configuration.randomize_endpoint orelse false)
-        log.write(.notice, "\tRandomize endpoint: true");
-    if (configuration.randomize_hostnames orelse false)
-        log.write(.notice, "\tRandomize hostnames: true");
-
-    if (configuration.routing_policies) |policies| {
-        log.writef(.notice, "\tGateway: {any}", .{policies});
-    } else if (is_local) {
-        log.write(.notice, "\tGateway: not configured");
-    }
-
-    if (configuration.dns_servers) |servers| {
-        if (servers.len > 0) {
-            logSensitiveStrings(.notice, "\tDNS: ", servers);
-        } else if (is_local) {
-            log.write(.notice, "\tDNS: not configured");
-        }
-    } else if (is_local) {
-        log.write(.notice, "\tDNS: not configured");
-    }
-    if (configuration.dns_domain) |domain|
-        openvpn_log.sensitiveString(.notice, "\tDNS domain: ", domain);
-    if (configuration.search_domains) |domains| {
-        if (domains.len > 0)
-            logSensitiveStrings(.notice, "\tSearch domains: ", domains);
-    }
-
-    if (configuration.http_proxy) |proxy|
-        logSensitiveProxy(.notice, "\tHTTP proxy: ", proxy);
-    if (configuration.https_proxy) |proxy|
-        logSensitiveProxy(.notice, "\tHTTPS proxy: ", proxy);
-    if (configuration.proxy_auto_configuration_url) |url|
-        openvpn_log.sensitiveString(.notice, "\tPAC: ", url);
-    if (configuration.proxy_bypass_domains) |domains| {
-        if (domains.len > 0)
-            logSensitiveStrings(.notice, "\tProxy bypass domains: ", domains);
-    }
-
-    if (configuration.mtu) |mtu| {
-        log.writef(.notice, "\tMTU: {d}", .{mtu});
-    } else if (is_local) {
-        log.write(.notice, "\tMTU: default");
-    }
-    if (configuration.xor_method) |method|
-        log.writef(.notice, "\tXOR: {s}", .{@tagName(std.meta.activeTag(method))});
-    if (configuration.no_pull_mask) |mask|
-        log.writef(.notice, "\tNot pulled: {any}", .{mask});
-}
-
-fn logPositiveSeconds(
-    comptime prefix: []const u8,
-    value: ?f64,
-    print_never: bool,
-) void {
-    if (value) |seconds| {
-        if (seconds > 0) {
-            openvpn_log.timeSeconds(.notice, prefix, seconds);
-            return;
-        }
-    }
-    if (print_never) log.write(.notice, prefix ++ "never");
-}
-
-fn logSensitiveValue(comptime prefix: []const u8, value: anytype) void {
-    if (value) |unwrapped| {
-        if (log.logsPrivateData()) {
-            log.writef(.notice, prefix ++ "{any}", .{unwrapped});
-        } else {
-            log.write(.notice, prefix ++ "<redacted>");
-        }
-    } else {
-        log.write(.notice, prefix ++ "not configured");
-    }
-}
-
-fn logSensitiveStrings(
-    level: core.logging.Level,
-    comptime prefix: []const u8,
-    values: []const []const u8,
-) void {
-    if (log.logsPrivateData()) {
-        log.writef(level, prefix ++ "{any}", .{values});
-    } else {
-        log.writef(level, prefix ++ "[<redacted> x {d}]", .{values.len});
-    }
-}
-
-fn logSensitiveProxy(
-    level: core.logging.Level,
-    comptime prefix: []const u8,
-    endpoint: api.Endpoint,
-) void {
-    if (log.logsPrivateData()) {
-        log.writef(level, prefix ++ "{s}:{d}", .{ endpoint.address, endpoint.port });
-    } else {
-        log.write(level, prefix ++ "<redacted>");
-    }
-}
-
-fn logSensitiveEndpoint(
-    level: core.logging.Level,
-    comptime prefix: []const u8,
-    endpoint: api.ExtendedEndpoint,
-) void {
-    if (log.logsPrivateData()) {
-        log.writef(level, prefix ++ "{s}:{s}:{d}", .{
-            endpoint.address,
-            endpoint.proto.socket_type.raw(),
-            endpoint.proto.port,
-        });
-    } else {
-        log.write(level, prefix ++ "<redacted>");
-    }
-}
-
 const EndpointResolver = struct {
     endpoints: []const api.ExtendedEndpoint,
     next_endpoint_index: usize = 0,
@@ -963,7 +739,7 @@ const EndpointResolver = struct {
                 error.Timeout,
                 => {
                     log.writef(.err, "Unable to resolve {s}: {s}", .{
-                        source.address,
+                        log.sensitive(source.address),
                         @errorName(err),
                     });
                     continue;

--- a/zig/src/openvpn/internal/logging.zig
+++ b/zig/src/openvpn/internal/logging.zig
@@ -2,58 +2,224 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-const core_mod = @import("../../core/exports.zig");
+const std = @import("std");
 
+const core_mod = @import("../../core/exports.zig");
+const configuration_mod = @import("configuration.zig");
+
+const api = core_mod.api;
 const log = core_mod.logging;
 
-pub fn sensitiveString(
-    level: log.Level,
-    comptime prefix: []const u8,
-    value: []const u8,
+pub fn logConfiguration(
+    value: *const api.OpenVPNConfiguration,
+    is_local: bool,
 ) void {
-    log.writef(level, prefix ++ "{s}", .{
-        if (log.logsPrivateData()) value else "<redacted>",
-    });
-}
-
-pub fn timeSeconds(
-    level: log.Level,
-    comptime prefix: []const u8,
-    seconds: f64,
-) void {
-    const ticks: u64 = if (seconds > 0) @intFromFloat(seconds) else 0;
-    timeTicks(level, prefix, ticks);
-}
-
-pub fn timeMilliseconds(
-    level: log.Level,
-    comptime prefix: []const u8,
-    milliseconds: u64,
-) void {
-    timeTicks(level, prefix, milliseconds / 1000);
-}
-
-fn timeTicks(
-    level: log.Level,
-    comptime prefix: []const u8,
-    ticks: u64,
-) void {
-    const hours = ticks / 3600;
-    const minutes = (ticks % 3600) / 60;
-    const seconds = ticks % 60;
-    if (hours > 0 and minutes > 0 and seconds > 0) {
-        log.writef(level, prefix ++ "{d}h{d}m{d}s", .{ hours, minutes, seconds });
-    } else if (hours > 0 and minutes > 0) {
-        log.writef(level, prefix ++ "{d}h{d}m", .{ hours, minutes });
-    } else if (hours > 0 and seconds > 0) {
-        log.writef(level, prefix ++ "{d}h{d}s", .{ hours, seconds });
-    } else if (minutes > 0 and seconds > 0) {
-        log.writef(level, prefix ++ "{d}m{d}s", .{ minutes, seconds });
-    } else if (hours > 0) {
-        log.writef(level, prefix ++ "{d}h", .{hours});
-    } else if (minutes > 0) {
-        log.writef(level, prefix ++ "{d}m", .{minutes});
+    if (is_local) {
+        if (value.remotes) |remotes|
+            log.writef(.notice, "\tRemotes: {s}", .{remotes});
     } else {
-        log.writef(level, prefix ++ "{d}s", .{seconds});
+        if (value.ipv4) |ipv4| {
+            log.writef(.notice, "\tIPv4: {s}", .{ipv4});
+        } else {
+            log.write(.notice, "\tIPv4: not configured");
+        }
+        if (value.ipv6) |ipv6| {
+            log.writef(.notice, "\tIPv6: {s}", .{ipv6});
+        } else {
+            log.write(.notice, "\tIPv6: not configured");
+        }
     }
+    if (value.routes4) |routes|
+        log.writef(.notice, "\tRoutes (IPv4): {s}", .{routes});
+    if (value.routes6) |routes|
+        log.writef(.notice, "\tRoutes (IPv6): {s}", .{routes});
+
+    if (value.cipher) |cipher| {
+        log.writef(.notice, "\tCipher: {s}", .{cipher.raw()});
+    } else if (is_local) {
+        log.writef(.notice, "\tCipher: {s}", .{
+            configuration_mod.fallbackCipher(value).raw(),
+        });
+    }
+    if (value.digest) |digest| {
+        log.writef(.notice, "\tDigest: {s}", .{digest.raw()});
+    } else if (is_local) {
+        log.writef(.notice, "\tDigest: {s}", .{
+            configuration_mod.fallbackDigest(value).raw(),
+        });
+    }
+    if (value.compression_framing) |framing| {
+        log.writef(.notice, "\tCompression framing: {s}", .{@tagName(framing)});
+    } else if (is_local) {
+        log.writef(.notice, "\tCompression framing: {s}", .{
+            @tagName(configuration_mod.fallbackCompressionFraming(value)),
+        });
+    }
+    if (value.compression_algorithm) |algorithm| {
+        log.writef(.notice, "\tCompression algorithm: {s}", .{@tagName(algorithm)});
+    } else if (is_local) {
+        log.writef(.notice, "\tCompression algorithm: {s}", .{
+            @tagName(configuration_mod.fallbackCompressionAlgorithm(value)),
+        });
+    }
+
+    if (is_local) {
+        log.writef(.notice, "\tUsername authentication: {}", .{
+            value.auth_user_pass orelse false,
+        });
+        log.writef(.notice, "\tStatic challenge: {}", .{
+            value.static_challenge orelse false,
+        });
+        log.write(
+            .notice,
+            if (value.client_certificate != null)
+                "\tClient verification: enabled"
+            else
+                "\tClient verification: disabled",
+        );
+        if (value.tls_wrap) |wrap| {
+            log.writef(.notice, "\tTLS wrapping: {s}", .{wrap.strategy.raw()});
+        } else {
+            log.write(.notice, "\tTLS wrapping: disabled");
+        }
+        if (value.tls_security_level) |level| {
+            log.writef(.notice, "\tTLS security level: {d}", .{level});
+        } else {
+            log.write(.notice, "\tTLS security level: default");
+        }
+    }
+
+    logPositiveSeconds(
+        "\tKeep-alive interval: ",
+        value.keep_alive_interval,
+        is_local,
+    );
+    logPositiveSeconds(
+        "\tKeep-alive timeout: ",
+        value.keep_alive_timeout,
+        is_local,
+    );
+    logPositiveSeconds(
+        "\tRenegotiation: ",
+        value.renegotiates_after,
+        is_local,
+    );
+    if (value.checks_eku orelse false) {
+        log.write(.notice, "\tServer EKU verification: enabled");
+    } else if (is_local) {
+        log.write(.notice, "\tServer EKU verification: disabled");
+    }
+    if (value.checks_san_host orelse false) {
+        if (value.san_host) |host|
+            log.writef(
+                .notice,
+                "\tHost SAN verification: enabled ({s})",
+                .{log.sensitive(host)},
+            )
+        else
+            log.write(.notice, "\tHost SAN verification: enabled (-)");
+    } else if (is_local) {
+        log.write(.notice, "\tHost SAN verification: disabled");
+    }
+
+    if (value.randomize_endpoint orelse false)
+        log.write(.notice, "\tRandomize endpoint: true");
+    if (value.randomize_hostnames orelse false)
+        log.write(.notice, "\tRandomize hostnames: true");
+
+    if (value.routing_policies) |policies| {
+        log.writef(.notice, "\tGateway: {any}", .{policies});
+    } else if (is_local) {
+        log.write(.notice, "\tGateway: not configured");
+    }
+
+    if (value.dns_servers) |servers| {
+        if (servers.len > 0) {
+            log.writef(.notice, "\tDNS: {s}", .{servers});
+        } else if (is_local) {
+            log.write(.notice, "\tDNS: not configured");
+        }
+    } else if (is_local) {
+        log.write(.notice, "\tDNS: not configured");
+    }
+    if (value.dns_domain) |domain|
+        log.writef(.notice, "\tDNS domain: {s}", .{log.sensitive(domain)});
+    if (value.search_domains) |domains| {
+        if (domains.len > 0)
+            log.writef(.notice, "\tSearch domains: {s}", .{domains});
+    }
+
+    if (value.http_proxy) |proxy|
+        log.writef(.notice, "\tHTTP proxy: {s}", .{proxy});
+    if (value.https_proxy) |proxy|
+        log.writef(.notice, "\tHTTPS proxy: {s}", .{proxy});
+    if (value.proxy_auto_configuration_url) |url|
+        log.writef(.notice, "\tPAC: {s}", .{log.sensitive(url)});
+    if (value.proxy_bypass_domains) |domains| {
+        if (domains.len > 0)
+            log.writef(
+                .notice,
+                "\tProxy bypass domains: {s}",
+                .{domains},
+            );
+    }
+
+    if (value.mtu) |mtu| {
+        log.writef(.notice, "\tMTU: {d}", .{mtu});
+    } else if (is_local) {
+        log.write(.notice, "\tMTU: default");
+    }
+    if (value.xor_method) |method|
+        log.writef(.notice, "\tXOR: {s}", .{@tagName(std.meta.activeTag(method))});
+    if (value.no_pull_mask) |mask|
+        log.writef(.notice, "\tNot pulled: {any}", .{mask});
+}
+
+pub fn logNegotiatedOptions(value: *const api.OpenVPNConfiguration) void {
+    log.write(.notice, "Negotiated options (remote overrides local)");
+    if (value.cipher) |cipher|
+        log.writef(.notice, "\tCipher: {s}", .{cipher.raw()});
+    if (value.compression_framing) |framing|
+        log.writef(.notice, "\tCompression framing: {s}", .{@tagName(framing)});
+    if (value.compression_algorithm) |algorithm|
+        log.writef(.notice, "\tCompression algorithm: {s}", .{@tagName(algorithm)});
+    if (value.keep_alive_interval) |interval|
+        log.logTimeSeconds(.notice, "\tKeep-alive interval: ", interval);
+    if (value.keep_alive_timeout) |timeout|
+        log.logTimeSeconds(.notice, "\tKeep-alive timeout: ", timeout);
+}
+
+fn logPositiveSeconds(
+    comptime prefix: []const u8,
+    value: ?f64,
+    print_never: bool,
+) void {
+    if (value) |seconds| {
+        if (seconds > 0) {
+            log.logTimeSeconds(.notice, prefix, seconds);
+            return;
+        }
+    }
+    if (print_never) log.write(.notice, prefix ++ "never");
+}
+
+pub fn pushReply(
+    allocator: std.mem.Allocator,
+    value: anytype,
+) ![]const u8 {
+    const marker = "auth-token ";
+    const start = std.mem.indexOf(u8, value.original, marker) orelse
+        return allocator.dupe(u8, value.original);
+    const value_start = start + marker.len;
+    const value_end = std.mem.indexOfScalarPos(
+        u8,
+        value.original,
+        value_start,
+        ',',
+    ) orelse value.original.len;
+    return std.mem.concat(allocator, u8, &.{
+        value.original[0..start],
+        "auth-token",
+        value.original[value_end..],
+    });
 }

--- a/zig/src/openvpn/internal/push.zig
+++ b/zig/src/openvpn/internal/push.zig
@@ -5,8 +5,9 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const core_mod = @import("../../core/exports.zig");
-const parser_mod = @import("../parser.zig");
 const constants_mod = @import("constants.zig");
+const logging = @import("logging.zig");
+const parser_mod = @import("../parser.zig");
 
 const api = core_mod.api;
 
@@ -18,6 +19,7 @@ pub const PushReply = struct {
     options: api.OpenVPNConfiguration,
 
     pub const prefix = "PUSH_REPLY,";
+    pub const logging_formatter = logging.pushReply;
 
     pub fn parse(
         allocator: std.mem.Allocator,
@@ -50,29 +52,6 @@ pub const PushReply = struct {
             .original = original,
             .options = try self.options.clone(allocator),
         };
-    }
-
-    /// Mirrors Swift's `PushReply.description`, removing the auth-token value
-    /// even when private logging is enabled.
-    pub fn logDescriptionAlloc(
-        self: PushReply,
-        allocator: std.mem.Allocator,
-    ) ![]u8 {
-        const marker = "auth-token ";
-        const start = std.mem.indexOf(u8, self.original, marker) orelse
-            return allocator.dupe(u8, self.original);
-        const value_start = start + marker.len;
-        const value_end = std.mem.indexOfScalarPos(
-            u8,
-            self.original,
-            value_start,
-            ',',
-        ) orelse self.original.len;
-        return std.mem.concat(allocator, u8, &.{
-            self.original[0..start],
-            "auth-token",
-            self.original[value_end..],
-        });
     }
 
     pub fn deinit(self: *PushReply, allocator: std.mem.Allocator) void {

--- a/zig/src/openvpn/internal/session.zig
+++ b/zig/src/openvpn/internal/session.zig
@@ -13,7 +13,6 @@ const crypto_mod = @import("crypto.zig");
 const data_mod = @import("data.zig");
 const errors_mod = @import("errors.zig");
 const helpers_mod = @import("helpers.zig");
-const logging_mod = @import("logging.zig");
 const packet_mod = @import("packet.zig");
 const processing_mod = @import("processing.zig");
 const push_mod = @import("push.zig");
@@ -26,7 +25,6 @@ const session_mod = @This();
 const api = core_mod.api;
 const c = helpers_mod.c;
 const log = core_mod.logging;
-const openvpn_log = logging_mod;
 
 const ActiveContext = session_context_mod.ActiveContext;
 const ActivePhase = session_context_mod.ActivePhase;
@@ -770,8 +768,10 @@ pub const Session = struct {
         context.setPushReply(reply);
         reply_transferred = true;
         context.removeOldNegotiators();
-        context.logNegotiatorKeys();
-        context.logDataKeys();
+        const negotiator_keys = context.negotiatorKeys();
+        log.writef(.info, "Negotiators: {any}", .{negotiator_keys.slice()});
+        const data_keys = context.dataKeys();
+        log.writef(.info, "Data channels: {any}", .{data_keys.slice()});
         if (active.phase == .started) return;
         active.phase = .started;
         self.scheduleNextPing(context) catch |err|
@@ -824,7 +824,7 @@ pub const Session = struct {
     ) !void {
         const delay = self.keepAliveIntervalMs(context) orelse
             self.options.ping_timeout_check_interval_ms;
-        openvpn_log.timeMilliseconds(.debug, "Schedule ping check after ", delay);
+        log.logTimeMs(.debug, "Schedule ping check after ", delay);
         try self.ping_timer.init(delay, onPingTimer, self);
     }
 
@@ -875,20 +875,20 @@ pub const Session = struct {
     ) ?u64 {
         if (context.push_reply) |reply| {
             if (reply.options.keep_alive_interval) |seconds|
-                if (seconds > 0) return secondsToMilliseconds(seconds);
+                if (seconds > 0) return secondsToMs(seconds);
         }
         if (self.configuration.keep_alive_interval) |seconds|
-            if (seconds > 0) return secondsToMilliseconds(seconds);
+            if (seconds > 0) return secondsToMs(seconds);
         return null;
     }
 
     fn keepAliveTimeoutMs(self: *const Session, context: *ActiveContext) u64 {
         if (context.push_reply) |reply| {
             if (reply.options.keep_alive_timeout) |seconds|
-                if (seconds > 0) return secondsToMilliseconds(seconds);
+                if (seconds > 0) return secondsToMs(seconds);
         }
         if (self.configuration.keep_alive_timeout) |seconds|
-            if (seconds > 0) return secondsToMilliseconds(seconds);
+            if (seconds > 0) return secondsToMs(seconds);
         return self.options.ping_timeout_ms;
     }
 
@@ -949,7 +949,7 @@ pub const Session = struct {
         };
     }
 
-    fn secondsToMilliseconds(seconds: f64) u64 {
+    fn secondsToMs(seconds: f64) u64 {
         if (!(seconds > 0)) return 0;
         const milliseconds = seconds * 1000.0;
         if (milliseconds >= @as(f64, @floatFromInt(std.math.maxInt(u64))))

--- a/zig/src/openvpn/internal/session_context.zig
+++ b/zig/src/openvpn/internal/session_context.zig
@@ -35,6 +35,15 @@ pub const IdleContext = struct {
 
 /// Mutable state owned by an active session and touched only on its looper.
 pub const ActiveContext = struct {
+    pub const KeyList = struct {
+        values: [ControlConstants.number_of_keys]u8 = undefined,
+        len: usize = 0,
+
+        pub fn slice(self: *const KeyList) []const u8 {
+            return self.values[0..self.len];
+        }
+    };
+
     allocator: std.mem.Allocator,
     data_link: DataLink,
     with_local_options: bool,
@@ -101,7 +110,8 @@ pub const ActiveContext = struct {
             if (old != negotiator) old.destroy();
         }
         self.negotiators[negotiator.key] = negotiator;
-        self.logNegotiatorKeys();
+        const keys = self.negotiatorKeys();
+        log.writef(.info, "Negotiators: {any}", .{keys.slice()});
         self.current_negotiator_key = negotiator.key;
         log.writef(.info, "Negotiator: Current key is {d}", .{negotiator.key});
     }
@@ -160,28 +170,26 @@ pub const ActiveContext = struct {
         self.data_count.reset();
     }
 
-    pub fn logNegotiatorKeys(self: *const ActiveContext) void {
-        var keys: [ControlConstants.number_of_keys]u8 = undefined;
-        var count: usize = 0;
+    pub fn negotiatorKeys(self: *const ActiveContext) KeyList {
+        var result: KeyList = .{};
         for (self.negotiators, 0..) |negotiator, key| {
             if (negotiator != null) {
-                keys[count] = @intCast(key);
-                count += 1;
+                result.values[result.len] = @intCast(key);
+                result.len += 1;
             }
         }
-        log.writef(.info, "Negotiators: {any}", .{keys[0..count]});
+        return result;
     }
 
-    pub fn logDataKeys(self: *const ActiveContext) void {
-        var keys: [ControlConstants.number_of_keys]u8 = undefined;
-        var count: usize = 0;
+    pub fn dataKeys(self: *const ActiveContext) KeyList {
+        var result: KeyList = .{};
         for (self.data_channels, 0..) |channel, key| {
             if (channel != null) {
-                keys[count] = @intCast(key);
-                count += 1;
+                result.values[result.len] = @intCast(key);
+                result.len += 1;
             }
         }
-        log.writef(.info, "Data channels: {any}", .{keys[0..count]});
+        return result;
     }
 };
 

--- a/zig/src/openvpn/internal/session_negotiator.zig
+++ b/zig/src/openvpn/internal/session_negotiator.zig
@@ -369,7 +369,7 @@ pub const Negotiator = struct {
         if (self.state != .connected) return false;
         const seconds = self.options.configuration.renegotiates_after orelse return false;
         if (seconds <= 0) return false;
-        return self.elapsedMs() >= secondsToMilliseconds(seconds);
+        return self.elapsedMs() >= secondsToMs(seconds);
     }
 
     const EnqueueCipherText = *const fn (
@@ -661,9 +661,7 @@ pub const Negotiator = struct {
         if (self.continued_push_reply_message) |old| self.allocator.free(old);
         self.continued_push_reply_message = null;
 
-        const reply_description = try reply.logDescriptionAlloc(self.allocator);
-        defer self.allocator.free(reply_description);
-        log.writef(.info, "Received PUSH_REPLY: \"{s}\"", .{reply_description});
+        log.writef(.info, "Received PUSH_REPLY: \"{s}\"", .{reply});
 
         if (reply.options.compression_framing != null) {
             if (reply.options.compression_algorithm) |algorithm| {
@@ -798,7 +796,7 @@ pub const Negotiator = struct {
             delay_ms *| @as(u64, std.time.ns_per_ms);
     }
 
-    fn secondsToMilliseconds(seconds: f64) u64 {
+    fn secondsToMs(seconds: f64) u64 {
         if (!(seconds > 0)) return 0;
         const milliseconds = seconds * 1000.0;
         if (milliseconds >= @as(f64, @floatFromInt(std.math.maxInt(u64))))

--- a/zig/src/openvpn/internal/settings.zig
+++ b/zig/src/openvpn/internal/settings.zig
@@ -30,7 +30,7 @@ pub const NetworkSettingsBuilder = struct {
         self: NetworkSettingsBuilder,
         allocator: std.mem.Allocator,
     ) ![]api.TaggedModule {
-        self.print();
+        openvpn_log.logNegotiatedOptions(self.remote_options);
         log.write(.info, "Build modules from local/remote options");
         var result: std.ArrayList(api.TaggedModule) = .empty;
         errdefer {
@@ -58,20 +58,6 @@ pub const NetworkSettingsBuilder = struct {
         };
         if (http_proxy) |module| try result.append(allocator, .{ .HTTPProxy = module });
         return result.toOwnedSlice(allocator);
-    }
-
-    pub fn print(self: NetworkSettingsBuilder) void {
-        log.write(.notice, "Negotiated options (remote overrides local)");
-        if (self.remote_options.cipher) |cipher|
-            log.writef(.notice, "\tCipher: {s}", .{cipher.raw()});
-        if (self.remote_options.compression_framing) |framing|
-            log.writef(.notice, "\tCompression framing: {s}", .{@tagName(framing)});
-        if (self.remote_options.compression_algorithm) |algorithm|
-            log.writef(.notice, "\tCompression algorithm: {s}", .{@tagName(algorithm)});
-        if (self.remote_options.keep_alive_interval) |interval|
-            openvpn_log.timeSeconds(.notice, "\tKeep-alive interval: ", interval);
-        if (self.remote_options.keep_alive_timeout) |timeout|
-            openvpn_log.timeSeconds(.notice, "\tKeep-alive timeout: ", timeout);
     }
 
     pub fn deinitModules(allocator: std.mem.Allocator, modules_value: []api.TaggedModule) void {
@@ -169,15 +155,24 @@ pub const NetworkSettingsBuilder = struct {
                 .gateway = route.gateway orelse default_gateway,
             };
             if (resolved.destination) |destination| {
-                log.writef(.info, "\t" ++ family ++ ": Add route {s}/{d} -> {s}", .{
-                    destination.address.raw,
-                    destination.prefix_length,
-                    if (resolved.gateway) |gateway| gateway.raw else "*",
-                });
+                if (resolved.gateway) |gateway| {
+                    log.writef(.info, "\t" ++ family ++ ": Add route {s} -> {s}", .{
+                        destination,
+                        gateway,
+                    });
+                } else {
+                    log.writef(.info, "\t" ++ family ++ ": Add route {s} -> *", .{
+                        destination,
+                    });
+                }
             } else {
-                log.writef(.info, "\t" ++ family ++ ": Set default gateway -> {s}", .{
-                    if (resolved.gateway) |gateway| gateway.raw else "*",
-                });
+                if (resolved.gateway) |gateway| {
+                    log.writef(.info, "\t" ++ family ++ ": Set default gateway -> {s}", .{
+                        gateway,
+                    });
+                } else {
+                    log.write(.info, "\t" ++ family ++ ": Set default gateway -> *");
+                }
             }
             try effective.append(allocator, resolved);
         }
@@ -208,7 +203,7 @@ pub const NetworkSettingsBuilder = struct {
             );
             return null;
         }
-        logSensitiveStrings("\tDNS: Set servers ", raw_servers.items);
+        log.writef(.info, "\tDNS: Set servers {s}", .{raw_servers.items});
 
         const servers = try addressesAlloc(allocator, raw_servers.items);
         errdefer freeAddresses(allocator, servers);
@@ -221,8 +216,8 @@ pub const NetworkSettingsBuilder = struct {
             (try api.Address.parseRawAlloc(allocator, domain)) orelse return error.InvalidAddress
         else
             null;
-        if (raw_domain) |domain|
-            openvpn_log.sensitiveString(.info, "\tDNS: Set domain: ", domain);
+        if (domain_name) |domain|
+            log.writef(.info, "\tDNS: Set domain: {s}", .{domain});
         errdefer if (domain_name) |*domain| domain.deinit(allocator);
 
         var raw_search: std.ArrayList([]const u8) = .empty;
@@ -237,7 +232,11 @@ pub const NetworkSettingsBuilder = struct {
             }
         }
         if (raw_search.items.len > 0)
-            logSensitiveStrings("\tDNS: Set search domains: ", raw_search.items);
+            log.writef(
+                .info,
+                "\tDNS: Set search domains: {s}",
+                .{raw_search.items},
+            );
 
         const search_domains: ?[]api.Address = if (raw_search.items.len > 0)
             try addressesAlloc(allocator, raw_search.items)
@@ -272,16 +271,12 @@ pub const NetworkSettingsBuilder = struct {
             self.local_options.proxy_auto_configuration_url;
         if (proxy_source == null and secure_source == null and pac_source == null) return null;
 
-        if (secure_source) |value| logSensitiveEndpoint(
-            "\tHTTPProxy: Set HTTPS proxy ",
-            value,
-        );
-        if (proxy_source) |value| logSensitiveEndpoint(
-            "\tHTTPProxy: Set HTTP proxy ",
-            value,
-        );
+        if (secure_source) |value|
+            log.writef(.info, "\tHTTPProxy: Set HTTPS proxy {s}", .{value});
+        if (proxy_source) |value|
+            log.writef(.info, "\tHTTPProxy: Set HTTP proxy {s}", .{value});
         if (pac_source) |value|
-            openvpn_log.sensitiveString(.info, "\tHTTPProxy: Set PAC ", value);
+            log.writef(.info, "\tHTTPProxy: Set PAC {s}", .{log.sensitive(value)});
 
         var proxy = if (proxy_source) |value| try value.clone(allocator) else null;
         errdefer if (proxy) |*value| value.deinit(allocator);
@@ -297,7 +292,11 @@ pub const NetworkSettingsBuilder = struct {
             if (self.remote_options.proxy_bypass_domains) |domains| try raw_bypass.appendSlice(allocator, domains);
         }
         if (raw_bypass.items.len > 0)
-            logSensitiveStrings("\tHTTPProxy: Set by-pass list: ", raw_bypass.items);
+            log.writef(
+                .info,
+                "\tHTTPProxy: Set by-pass list: {s}",
+                .{raw_bypass.items},
+            );
         const bypass = try addressesAlloc(allocator, raw_bypass.items);
         errdefer freeAddresses(allocator, bypass);
 
@@ -310,22 +309,6 @@ pub const NetworkSettingsBuilder = struct {
         };
     }
 };
-
-fn logSensitiveStrings(comptime prefix: []const u8, values: []const []const u8) void {
-    if (!log.logsPrivateData()) {
-        log.writef(.info, prefix ++ "[<redacted> x {d}]", .{values.len});
-        return;
-    }
-    log.writef(.info, prefix ++ "{any}", .{values});
-}
-
-fn logSensitiveEndpoint(comptime prefix: []const u8, endpoint: api.Endpoint) void {
-    if (!log.logsPrivateData()) {
-        log.write(.info, prefix ++ "<redacted>");
-        return;
-    }
-    log.writef(.info, prefix ++ "{s}:{d}", .{ endpoint.address, endpoint.port });
-}
 
 fn addressesAlloc(
     allocator: std.mem.Allocator,

--- a/zig/src/testing.zig
+++ b/zig/src/testing.zig
@@ -42,6 +42,7 @@ pub const openvpn_internal = if (openvpn_enabled) struct {
     pub const data = @import("openvpn/internal/data.zig");
     pub const errors = @import("openvpn/internal/errors.zig");
     pub const helpers = @import("openvpn/internal/helpers.zig");
+    pub const logging = @import("openvpn/internal/logging.zig");
     pub const packet = @import("openvpn/internal/packet.zig");
     pub const processing = @import("openvpn/internal/processing.zig");
     pub const push = @import("openvpn/internal/push.zig");

--- a/zig/src/wireguard/adapter.zig
+++ b/zig/src/wireguard/adapter.zig
@@ -252,11 +252,8 @@ pub const WireGuardAdapter = struct {
             }
             return;
         }
-        logSocketDescriptors(descriptors);
-        self.controller.configureSockets(descriptors) catch |err| {
-            log.writef(.err, "Unable to configure backend sockets: {s}", .{@errorName(err)});
-            return err;
-        };
+        log.writef(.info, "Socket descriptors: {any}", .{descriptors});
+        try self.controller.configureSockets(descriptors);
     }
 
     pub fn didUpdateReachable(
@@ -405,22 +402,6 @@ pub const WireGuardAdapter = struct {
         return uapi.parseRuntimeDataCount(text);
     }
 };
-
-fn logSocketDescriptors(descriptors: []const net.SocketDescriptor) void {
-    const allocator = std.heap.c_allocator;
-    var output: std.Io.Writer.Allocating = .init(allocator);
-    defer output.deinit();
-    const writer = &output.writer;
-    writer.writeAll("Socket descriptors: [") catch return;
-    for (descriptors, 0..) |descriptor, index| {
-        if (index > 0) writer.writeAll(", ") catch return;
-        writer.print("{any}", .{descriptor}) catch return;
-    }
-    writer.writeByte(']') catch return;
-    const message = output.toOwnedSlice() catch return;
-    defer allocator.free(message);
-    log.write(.info, message);
-}
 
 fn buildConfiguration(
     allocator: std.mem.Allocator,

--- a/zig/src/wireguard/connection.zig
+++ b/zig/src/wireguard/connection.zig
@@ -142,10 +142,33 @@ const WireGuardConnection = struct {
         errdefer events.status(events.ctx, .disconnected);
 
         self.adapter.start(allocator) catch |err| {
-            // Adapter activation errors are the local diagnostic signal. The
-            // generic connection contract deliberately exposes no WireGuard-
-            // specific categories, so log the concrete error before erasing it.
-            log.writef(.fault, "Unable to start adapter: {s}", .{@errorName(err)});
+            switch (err) {
+                error.CannotLocateTunnelFileDescriptor => {
+                    log.write(
+                        .fault,
+                        "Starting tunnel failed: could not determine file descriptor",
+                    );
+                },
+                error.DNSResolutionFailure, error.InvalidEndpoint => {
+                    log.write(.fault, "DNS resolution failed");
+                },
+                error.TunNotAvailable => {
+                    log.writef(
+                        .fault,
+                        "Starting tunnel failed with setTunnelNetworkSettings returning {s}",
+                        .{@errorName(err)},
+                    );
+                },
+                error.CouldNotStartBackend => {
+                    log.write(.fault, "Starting tunnel backend failed");
+                },
+                else => {
+                    // Adapter activation errors are the local diagnostic signal. The
+                    // generic connection contract deliberately exposes no WireGuard-
+                    // specific categories, so log the concrete error before erasing it.
+                    log.writef(.fault, "Unable to start adapter: {s}", .{@errorName(err)});
+                },
+            }
             return error.UnableToStart;
         };
         log.writef(.info, "Tunnel interface is {s}", .{

--- a/zig/src/wireguard/resolver.zig
+++ b/zig/src/wireguard/resolver.zig
@@ -162,7 +162,7 @@ pub const PeerEndpointResolver = struct {
                 reachability,
             ) catch |err| {
                 log.writef(.err, "Failed to resolve endpoint {s}: {s}", .{
-                    if (log.logsPrivateData()) endpoint.address else "<redacted>",
+                    endpoint,
                     @errorName(err),
                 });
                 if (err == error.OutOfMemory) return error.OutOfMemory;
@@ -220,7 +220,25 @@ pub const PeerEndpointResolver = struct {
                 .owned = true,
             };
             previous.deinit(allocator);
-            logMapping(entry.base.address, entry.target.address);
+            const source_address = api.Address.parseRaw(
+                entry.base.address,
+            ) orelse unreachable;
+            const target_address = api.Address.parseRaw(
+                entry.target.address,
+            ) orelse unreachable;
+            if (std.mem.eql(u8, source_address.raw, target_address.raw)) {
+                log.writef(
+                    .debug,
+                    "DNS64: mapped {s} to itself.",
+                    .{source_address},
+                );
+            } else {
+                log.writef(
+                    .debug,
+                    "DNS64: mapped {s} to {s}",
+                    .{ source_address, target_address },
+                );
+            }
         }
     }
 
@@ -236,7 +254,7 @@ pub const PeerEndpointResolver = struct {
             // Numeric endpoints bypass hostname resolution, but still pass
             // through `resolveAddress` when UAPI is built so DNS64 synthesis
             // can adapt an IPv4 literal to the active network.
-            logMapping(endpoint.address, endpoint.address);
+            log.writef(.debug, "DNS64: mapped {s} to itself.", .{address});
             return endpoint.clone(allocator);
         }
 
@@ -253,7 +271,8 @@ pub const PeerEndpointResolver = struct {
         defer util.freeSlice(net.DNSRecord, allocator, records);
 
         const target_address = preferredAddress(records) orelse return error.DNSResolutionFailure;
-        logMapping(endpoint.address, target_address);
+        const target = api.Address.parseRaw(target_address) orelse unreachable;
+        log.writef(.debug, "DNS64: mapped {s} to {s}", .{ address, target });
         return (api.Endpoint{
             .address = target_address,
             .port = endpoint.port,
@@ -272,12 +291,4 @@ fn preferredAddress(records: []const net.DNSRecord) ?[]const u8 {
         if (address.family == .v4) return address.raw;
     }
     return first;
-}
-
-fn logMapping(source: []const u8, target: []const u8) void {
-    if (std.mem.eql(u8, source, target)) {
-        log.writef(.debug, "DNS64: mapped {s} to itself.", .{source});
-    } else {
-        log.writef(.debug, "DNS64: mapped {s} to {s}", .{ source, target });
-    }
 }

--- a/zig/tests/all.zig
+++ b/zig/tests/all.zig
@@ -44,6 +44,7 @@ comptime {
         _ = @import("openvpn/internal/data.zig");
         _ = @import("openvpn/internal/errors.zig");
         _ = @import("openvpn/internal/helpers.zig");
+        _ = @import("openvpn/internal/logging.zig");
         _ = @import("openvpn/internal/packet.zig");
         _ = @import("openvpn/internal/processing.zig");
         _ = @import("openvpn/internal/push.zig");

--- a/zig/tests/core/logging.zig
+++ b/zig/tests/core/logging.zig
@@ -4,7 +4,49 @@
 
 const std = @import("std");
 
+const api = @import("source").core_api;
 const logging = @import("source").core_logging;
+
+const CapturingLogger = struct {
+    var message: [256]u8 = undefined;
+    var message_len: usize = 0;
+
+    fn reset() void {
+        message_len = 0;
+    }
+
+    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+        const value = std.mem.span(raw_message);
+        message_len = @min(value.len, message.len);
+        @memcpy(message[0..message_len], value[0..message_len]);
+    }
+
+    fn lastMessage() []const u8 {
+        return message[0..message_len];
+    }
+};
+
+const ReplacementLogger = struct {
+    var called = false;
+
+    fn reset() void {
+        called = false;
+    }
+
+    fn log(_: c_int, _: [*:0]const u8) callconv(.c) void {
+        called = true;
+    }
+};
+
+const ReconfiguringValue = struct {
+    pub fn logging_formatter(
+        allocator: std.mem.Allocator,
+        _: ReconfiguringValue,
+    ) ![]const u8 {
+        logging.init(false, ReplacementLogger.log);
+        return allocator.dupe(u8, "secret");
+    }
+};
 
 test "private data flag round-trips" {
     logging.init(true, null);
@@ -40,4 +82,217 @@ test "external logger callback receives log messages" {
     try std.testing.expect(TestLogger.called);
     try std.testing.expect(TestLogger.saw_level);
     try std.testing.expect(TestLogger.saw_message);
+}
+
+test "duration helpers log compact time representations" {
+    CapturingLogger.reset();
+    logging.init(false, CapturingLogger.log);
+    defer logging.deinit();
+
+    logging.logTimeSeconds(.debug, "Elapsed: ", 3661);
+    try std.testing.expectEqualStrings(
+        "Elapsed: 1h1m1s",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.logTimeMs(.debug, "Delay: ", 120_000);
+    try std.testing.expectEqualStrings(
+        "Delay: 2m",
+        CapturingLogger.lastMessage(),
+    );
+}
+
+test "writef automatically redacts registered argument types" {
+    CapturingLogger.reset();
+    logging.init(false, CapturingLogger.log);
+    defer logging.deinit();
+
+    const endpoint = api.Endpoint{
+        .address = "example.com",
+        .port = 443,
+    };
+    logging.writef(.notice, "Public: {d}, endpoint: {s}", .{
+        42,
+        endpoint,
+    });
+    try std.testing.expectEqualStrings(
+        "Public: 42, endpoint: <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+
+    const address = api.Address.parseRaw("192.0.2.1").?;
+    logging.writef(.debug, "DNS64: mapped {s} to itself.", .{address});
+    try std.testing.expectEqualStrings(
+        "DNS64: mapped <redacted> to itself.",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.writef(.debug, "DNS resolved {s}", .{
+        logging.sensitive("example.com"),
+    });
+    try std.testing.expectEqualStrings(
+        "DNS resolved <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.writef(.debug, "Sensitive number: {s}", .{
+        logging.sensitive(@as(u16, 42)),
+    });
+    try std.testing.expectEqualStrings(
+        "Sensitive number: <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.init(true, CapturingLogger.log);
+    logging.writef(.notice, "Public: {d}, endpoint: {s}", .{
+        42,
+        endpoint,
+    });
+    try std.testing.expectEqualStrings(
+        "Public: 42, endpoint: example.com:443",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.writef(.debug, "DNS resolved {s}", .{
+        logging.sensitive("example.com"),
+    });
+    try std.testing.expectEqualStrings(
+        "DNS resolved example.com",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.writef(.debug, "Sensitive number: {s}", .{
+        logging.sensitive(@as(u16, 42)),
+    });
+    try std.testing.expectEqualStrings(
+        "Sensitive number: 42",
+        CapturingLogger.lastMessage(),
+    );
+}
+
+test "sensitive values use the policy captured by writef" {
+    CapturingLogger.reset();
+    logging.init(true, CapturingLogger.log);
+    defer logging.deinit();
+
+    const marked_while_private = logging.sensitive("example.com");
+    logging.init(false, CapturingLogger.log);
+    logging.writef(.debug, "DNS resolved {s}", .{marked_while_private});
+    try std.testing.expectEqualStrings(
+        "DNS resolved <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+
+    const marked_while_redacted = logging.sensitive("example.com");
+    logging.init(true, CapturingLogger.log);
+    logging.writef(.debug, "DNS resolved {s}", .{marked_while_redacted});
+    try std.testing.expectEqualStrings(
+        "DNS resolved example.com",
+        CapturingLogger.lastMessage(),
+    );
+}
+
+test "writef dispatches with the same state used to prepare arguments" {
+    CapturingLogger.reset();
+    ReplacementLogger.reset();
+    logging.init(true, CapturingLogger.log);
+    defer logging.deinit();
+
+    logging.writef(.debug, "{s}", .{ReconfiguringValue{}});
+
+    try std.testing.expectEqualStrings(
+        "secret",
+        CapturingLogger.lastMessage(),
+    );
+    try std.testing.expect(!ReplacementLogger.called);
+}
+
+test "writef infers array and dictionary debug representations" {
+    CapturingLogger.reset();
+    logging.init(true, CapturingLogger.log);
+    defer logging.deinit();
+
+    const endpoints = [_]api.Endpoint{
+        .{ .address = "alpha.example", .port = 1 },
+        .{ .address = "beta.example", .port = 2 },
+    };
+    logging.writef(.notice, "Array: {s}", .{&endpoints});
+    try std.testing.expectEqualStrings(
+        "Array: [alpha.example:1, beta.example:2]",
+        CapturingLogger.lastMessage(),
+    );
+
+    var dictionary = std.StringHashMap(api.Endpoint).init(std.testing.allocator);
+    defer dictionary.deinit();
+    try dictionary.put("key", .{ .address = "value.example", .port = 3 });
+    logging.writef(.notice, "Dictionary: {s}", .{&dictionary});
+    try std.testing.expectEqualStrings(
+        "Dictionary: [key: value.example:3]",
+        CapturingLogger.lastMessage(),
+    );
+
+    const addresses = [_]api.Address{
+        api.Address.parseRaw("one.example").?,
+        api.Address.parseRaw("two.example").?,
+    };
+    logging.writef(.notice, "Addresses: {s}", .{&addresses});
+    try std.testing.expectEqualStrings(
+        "Addresses: [one.example, two.example]",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.init(false, CapturingLogger.log);
+    logging.writef(.notice, "Array: {s}", .{&endpoints});
+    try std.testing.expectEqualStrings(
+        "Array: <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+}
+
+test "writef recognizes generated sensitive models without generated methods" {
+    CapturingLogger.reset();
+    logging.init(true, CapturingLogger.log);
+    defer logging.deinit();
+
+    const subnets = [_]api.Subnet{api.Subnet.parseRaw("10.0.0.2/24").?};
+    const settings = api.IPSettings{ .subnets = &subnets };
+    logging.writef(.notice, "Settings: {s}", .{settings});
+    try std.testing.expectEqualStrings(
+        "Settings: addrs [10.0.0.2/24], includedRoutes=[], excludedRoutes=[]",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.init(false, CapturingLogger.log);
+    logging.writef(.notice, "Settings: {s}", .{settings});
+    try std.testing.expectEqualStrings(
+        "Settings: <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+
+    const credentials = api.OpenVPNCredentials{
+        .username = "alice",
+        .password = "secret",
+        .otp_method = .none,
+    };
+    logging.writef(.notice, "Credentials: {s}", .{credentials});
+    try std.testing.expectEqualStrings(
+        "Credentials: <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.init(true, CapturingLogger.log);
+    logging.writef(.notice, "Credentials: {s}", .{credentials});
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        CapturingLogger.lastMessage(),
+        "\"password\":\"secret\"",
+    ) != null);
+
+    const module = api.TaggedModule{ .DNS = .{} };
+    logging.writef(.notice, "Module: {s}", .{module});
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        CapturingLogger.lastMessage(),
+        "Module: {\"type\":\"DNS\"",
+    ));
 }

--- a/zig/tests/net/platform_dns.zig
+++ b/zig/tests/net/platform_dns.zig
@@ -5,10 +5,26 @@
 const std = @import("std");
 const source = @import("source");
 
+const logging = source.core_logging;
 const platform_dns = source.net_platform_dns;
 const c = platform_dns.testing.C;
 const PlatformDNS = platform_dns.PlatformDNS;
 const ReachabilityInfo = source.net_io.ReachabilityInfo;
+
+const CapturingLogger = struct {
+    var message: [256]u8 = undefined;
+    var message_len: usize = 0;
+
+    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+        const value = std.mem.span(raw_message);
+        message_len = @min(value.len, message.len);
+        @memcpy(message[0..message_len], value[0..message_len]);
+    }
+
+    fn lastMessage() []const u8 {
+        return message[0..message_len];
+    }
+};
 
 test "DNS resolver times out and caps abandoned queries" {
     const HangingResolver = struct {
@@ -28,6 +44,8 @@ test "DNS resolver times out and caps abandoned queries" {
     const allocator = std.testing.allocator;
     const max_pending_queries = platform_dns.testing.maxPendingQueries;
     var dns = PlatformDNS.init();
+    logging.init(false, CapturingLogger.log);
+    defer logging.deinit();
     HangingResolver.release.store(false, .release);
     defer {
         HangingResolver.release.store(true, .release);
@@ -45,6 +63,10 @@ test "DNS resolver times out and caps abandoned queries" {
             HangingResolver.resolve,
         ));
     }
+    try std.testing.expectEqualStrings(
+        "DNS resolution timed out for <redacted>",
+        CapturingLogger.lastMessage(),
+    );
     try std.testing.expectEqual(max_pending_queries, platform_dns.testing.pendingCount());
     try std.testing.expectError(error.Timeout, platform_dns.testing.resolveWith(
         &dns,

--- a/zig/tests/openvpn/internal/logging.zig
+++ b/zig/tests/openvpn/internal/logging.zig
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+const std = @import("std");
+const source = @import("source");
+
+const api = source.core.api;
+const logging = source.core_logging;
+const openvpn_logging = source.openvpn_internal.logging;
+
+const CapturingLogger = struct {
+    var message: [512]u8 = undefined;
+    var message_len: usize = 0;
+
+    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+        const value = std.mem.span(raw_message);
+        message_len = @min(value.len, message.len);
+        @memcpy(message[0..message_len], value[0..message_len]);
+    }
+
+    fn lastMessage() []const u8 {
+        return message[0..message_len];
+    }
+};
+
+test "logConfiguration accepts empty sensitive strings" {
+    const configuration = api.OpenVPNConfiguration{
+        .checks_san_host = true,
+        .san_host = "",
+        .dns_domain = "",
+        .proxy_auto_configuration_url = "",
+    };
+    logging.init(false, null);
+    defer logging.deinit();
+
+    openvpn_logging.logConfiguration(&configuration, true);
+}
+
+test "logConfiguration formats route collections as strings" {
+    const routes = [_]api.Route{
+        .{ .destination = api.Subnet.parseRaw("10.0.0.0/24").? },
+    };
+    const configuration = api.OpenVPNConfiguration{ .routes4 = &routes };
+    logging.init(false, CapturingLogger.log);
+    defer logging.deinit();
+
+    openvpn_logging.logConfiguration(&configuration, false);
+    try std.testing.expectEqualStrings(
+        "\tRoutes (IPv4): <redacted>",
+        CapturingLogger.lastMessage(),
+    );
+
+    logging.init(true, CapturingLogger.log);
+    openvpn_logging.logConfiguration(&configuration, false);
+    try std.testing.expectEqualStrings(
+        "\tRoutes (IPv4): [{\"destination\":\"10.0.0.0/24\"}]",
+        CapturingLogger.lastMessage(),
+    );
+}

--- a/zig/tests/openvpn/internal/push.zig
+++ b/zig/tests/openvpn/internal/push.zig
@@ -6,7 +6,23 @@ const std = @import("std");
 const source = @import("source");
 
 const api = source.core.api;
+const logging = source.core_logging;
 const push = source.openvpn_internal.push;
+
+const CapturingLogger = struct {
+    var message: [512]u8 = undefined;
+    var message_len: usize = 0;
+
+    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+        const value = std.mem.span(raw_message);
+        message_len = @min(value.len, message.len);
+        @memcpy(message[0..message_len], value[0..message_len]);
+    }
+
+    fn lastMessage() []const u8 {
+        return message[0..message_len];
+    }
+};
 
 test "PUSH_REPLY without negotiated options preserves nil values" {
     var reply = (try push.PushReply.parse(
@@ -183,21 +199,34 @@ test "PUSH_REPLY clone owns independent storage" {
     try std.testing.expect(reply.original.ptr != copy.original.ptr);
 }
 
-test "PUSH_REPLY log description strips auth-token values" {
+test "writef formats PUSH_REPLY and always strips auth-token values" {
     const allocator = std.testing.allocator;
     var reply = (try push.PushReply.parse(
         allocator,
         "PUSH_REPLY,ping 10,auth-token somethingsecret,cipher AES-256-GCM",
     )).?;
     defer reply.deinit(allocator);
-    const description = try reply.logDescriptionAlloc(allocator);
-    defer allocator.free(description);
+    logging.init(true, CapturingLogger.log);
+    defer logging.deinit();
+
+    logging.writef(.info, "{s}", .{reply});
 
     try std.testing.expectEqualStrings(
         "PUSH_REPLY,ping 10,auth-token,cipher AES-256-GCM",
-        description,
+        CapturingLogger.lastMessage(),
     );
-    try std.testing.expect(std.mem.indexOf(u8, description, "somethingsecret") == null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        CapturingLogger.lastMessage(),
+        "somethingsecret",
+    ) == null);
+
+    logging.init(false, CapturingLogger.log);
+    logging.writef(.info, "{s}", .{reply});
+    try std.testing.expectEqualStrings(
+        "<redacted>",
+        CapturingLogger.lastMessage(),
+    );
 }
 
 test "PUSH_REPLY distinguishes a route gateway from redirect gateway policy" {

--- a/zig/tests/openvpn/internal/settings.zig
+++ b/zig/tests/openvpn/internal/settings.zig
@@ -345,3 +345,16 @@ test "NetworkSettingsBuilder builds endpoint, PAC, and merged proxy bypass setti
     try std.testing.expect(masked.pac_url == null);
     try std.testing.expectEqual(@as(usize, 2), masked.bypass_domains.len);
 }
+
+test "NetworkSettingsBuilder accepts an empty PAC URL" {
+    const allocator = std.testing.allocator;
+    const local = api.OpenVPNConfiguration{
+        .proxy_auto_configuration_url = "",
+    };
+    const remote = api.OpenVPNConfiguration{};
+    const result = try NetworkSettingsBuilder.init(&local, &remote).modules(allocator);
+    defer NetworkSettingsBuilder.deinitModules(allocator, result);
+
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+    try std.testing.expectEqualStrings("", result[0].HTTPProxy.pac_url.?);
+}


### PR DESCRIPTION
First, centralize how log arguments are handled. Then, mimic the way Swift redacts sensitive log values through the logsPrivateData preference, but do it automagically.