### PR TITLE
Zig: Review concurrency complexity

### DIFF
--- a/zig/src/core/concurrency.zig
+++ b/zig/src/core/concurrency.zig
@@ -92,9 +92,10 @@ pub const Drainer = struct {
 
 /// Reusable single-threaded executor for delayed, one-shot callbacks.
 ///
-/// `init` manages one replaceable callback, whereas `schedule` manages several
-/// independent callbacks through caller-owned `Scheduled` handles. The two
-/// scheduling modes must not be mixed while either mode has pending work.
+/// `scheduleReplacing` manages one replaceable callback, whereas
+/// `scheduleAppending` manages several independent callbacks through
+/// caller-owned `Scheduled` handles. The two scheduling modes must not be mixed
+/// while either mode has pending work.
 /// Callbacks run serially on the same worker thread and never under the
 /// executor mutex.
 ///
@@ -102,7 +103,7 @@ pub const Drainer = struct {
 /// until the corresponding callback completes or is cancelled. `deinit` joins
 /// the worker and therefore must not be called from one of its callbacks.
 pub const RunAfter = struct {
-    /// Callback used by the replaceable `init` scheduling mode.
+    /// Callback used by `scheduleReplacing`.
     pub const Callback = *const fn (?*anyopaque) void;
 
     /// Caller-owned handle for an independent one-shot callback.
@@ -128,7 +129,7 @@ pub const RunAfter = struct {
         /// after the callback returns.
         pub const Callback = *const fn (*Scheduled, Outcome) void;
 
-        /// Borrowed application context supplied to `schedule`.
+        /// Borrowed application context supplied to `scheduleAppending`.
         context: ?*anyopaque = null,
 
         /// Callback to notify when this handle reaches a terminal outcome.
@@ -139,6 +140,24 @@ pub const RunAfter = struct {
 
         /// Private intrusive linkage used by the executor's pending list.
         next: ?*Scheduled = null,
+    };
+
+    /// Internal scheduling operation.
+    const Schedule = union(enum) {
+        /// Replaces a pending callback in the executor's single callback slot.
+        replace: struct {
+            delay_ms: u64,
+            callback: Callback,
+            context: ?*anyopaque,
+        },
+
+        /// Appends an independent callback through a caller-owned handle.
+        append: struct {
+            scheduled: *Scheduled,
+            delay_ms: u64,
+            callback: Scheduled.Callback,
+            context: ?*anyopaque,
+        },
     };
 
     /// Lifecycle of the replaceable callback slot and worker thread.
@@ -207,50 +226,84 @@ pub const RunAfter = struct {
         try self.startLocked();
     }
 
-    /// Schedules the replaceable one-shot callback.
+    /// Schedules a one-shot callback, replacing a pending callback.
     ///
-    /// A pending callback previously submitted with `init` is silently
-    /// replaced. If a callback is already running, the new callback waits for
-    /// it to return before its own delay begins being serviced. This mode must
-    /// not be used while independent callbacks from `schedule` are pending.
-    /// The function starts the worker lazily and reports failure to spawn it.
-    pub fn init(
+    /// If a callback is already running, the replacement waits for it to return
+    /// before its own delay begins being serviced. This mode must not be used
+    /// while callbacks submitted with `scheduleAppending` are pending. The
+    /// function starts the worker lazily and reports failure to spawn it.
+    pub fn scheduleReplacing(
         self: *RunAfter,
         delay_ms: u64,
         callback: Callback,
-        callback_ctx: ?*anyopaque,
+        context: ?*anyopaque,
     ) std.Thread.SpawnError!void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        std.debug.assert(self.state != .stopping);
-        std.debug.assert(!self.scheduling);
-        try self.startLocked();
-
-        self.initLocked(delay_ms, callback, callback_ctx);
+        return self.schedule(.{ .replace = .{
+            .delay_ms = delay_ms,
+            .callback = callback,
+            .context = context,
+        } });
     }
 
-    /// Adds an independent one-shot callback without replacing earlier ones.
+    /// Appends an independent one-shot callback without replacing earlier ones.
     ///
     /// Delays are best-effort and quantized to `scheduler_resolution_ms`; a
     /// callback may run late but is given a full extra tick so it does not run
     /// early at a tick boundary. This mode must not be started while a callback
-    /// submitted with `init` is pending. The function starts the worker lazily
-    /// and reports failure to spawn it.
-    pub fn schedule(
+    /// submitted with `scheduleReplacing` is pending. The function starts the
+    /// worker lazily and reports failure to spawn it.
+    pub fn scheduleAppending(
         self: *RunAfter,
         scheduled: *Scheduled,
         delay_ms: u64,
         callback: Scheduled.Callback,
         context: ?*anyopaque,
     ) std.Thread.SpawnError!void {
+        return self.schedule(.{ .append = .{
+            .scheduled = scheduled,
+            .delay_ms = delay_ms,
+            .callback = callback,
+            .context = context,
+        } });
+    }
+
+    /// Dispatches a scheduling operation.
+    fn schedule(self: *RunAfter, request: Schedule) std.Thread.SpawnError!void {
         self.mutex.lock();
         defer self.mutex.unlock();
 
         std.debug.assert(self.state != .stopping);
-        std.debug.assert(self.scheduling or self.state != .scheduled);
-        try self.startLocked();
+        switch (request) {
+            .replace => |options| {
+                std.debug.assert(!self.scheduling);
+                try self.startLocked();
+                self.replaceLocked(
+                    options.delay_ms,
+                    options.callback,
+                    options.context,
+                );
+            },
+            .append => |options| {
+                std.debug.assert(self.scheduling or self.state != .scheduled);
+                try self.startLocked();
+                self.appendLocked(
+                    options.scheduled,
+                    options.delay_ms,
+                    options.callback,
+                    options.context,
+                );
+            },
+        }
+    }
 
+    /// Appends an independent callback while `mutex` is held.
+    fn appendLocked(
+        self: *RunAfter,
+        scheduled: *Scheduled,
+        delay_ms: u64,
+        callback: Scheduled.Callback,
+        context: ?*anyopaque,
+    ) void {
         scheduled.* = .{
             .context = context,
             .callback = callback,
@@ -267,16 +320,16 @@ pub const RunAfter = struct {
 
         if (!self.scheduling) {
             self.scheduling = true;
-            self.initLocked(scheduler_resolution_ms, runScheduled, self);
+            self.replaceLocked(scheduler_resolution_ms, runScheduled, self);
         }
     }
 
     /// Cancels pending callbacks without stopping the worker thread.
     ///
     /// A callback that is already running is allowed to finish. Any queued
-    /// successor from `init` is discarded, and every independent callback that
-    /// is still pending is synchronously notified with `.cancelled` after the
-    /// executor mutex is released.
+    /// successor from `scheduleReplacing` is discarded, and every independent
+    /// callback that is still pending is synchronously notified with
+    /// `.cancelled` after the executor mutex is released.
     pub fn cancel(self: *RunAfter) void {
         self.mutex.lock();
         const cancelled = self.cancelLocked();
@@ -424,7 +477,7 @@ pub const RunAfter = struct {
         }
 
         if (self.scheduled_head != null) {
-            self.initLocked(scheduler_resolution_ms, runScheduled, self);
+            self.replaceLocked(scheduler_resolution_ms, runScheduled, self);
         } else {
             self.scheduling = false;
         }
@@ -437,7 +490,7 @@ pub const RunAfter = struct {
     ///
     /// Incrementing `generation` interrupts any delay currently being observed
     /// by the worker.
-    fn initLocked(
+    fn replaceLocked(
         self: *RunAfter,
         delay_ms: u64,
         callback: Callback,

--- a/zig/src/net/daemon.zig
+++ b/zig/src/net/daemon.zig
@@ -585,7 +585,7 @@ pub const Daemon = struct {
         log.writef(.info, "Resume connection gate in {} milliseconds", .{delay_ms});
 
         // Contextually cancels the previous attempt
-        self.resume_gate_timer.init(delay_ms, onResumeGate, self) catch |err| {
+        self.resume_gate_timer.scheduleReplacing(delay_ms, onResumeGate, self) catch |err| {
             log.writef(.err, "Unable to schedule resume connection gate, resume now: {s}", .{@errorName(err)});
             self.doResumeGate();
         };

--- a/zig/src/net/looper.zig
+++ b/zig/src/net/looper.zig
@@ -99,7 +99,6 @@ pub const Looper = struct {
         Errors.ReentrantCall;
     pub const DetachError = SubmissionError || Errors.ReentrantCall;
     pub const ResumeReadingError = SubmissionError;
-    pub const ScheduleError = SubmissionError || Errors.TaskFailure;
     pub const StopError = SubmissionError ||
         Errors.InvalidState ||
         Errors.ReentrantCall;
@@ -446,38 +445,6 @@ pub const Looper = struct {
         return thread_id == std.Thread.getCurrentId();
     }
 
-    /// With no delay, runs inline on the looper thread or enqueues on it.
-    /// Delayed work is always enqueued asynchronously after `delay_ms`.
-    pub fn schedule(self: *Looper, delay_ms: ?u64, task: Task) ScheduleError!void {
-        if (delay_ms == null and self.isOnQueue()) {
-            task.call() catch |err| {
-                log.writef(.err, "Scheduled task failed: {s}", .{@errorName(err)});
-                return error.TaskFailure;
-            };
-            return;
-        }
-
-        self.lock.lock();
-        defer self.lock.unlock();
-        if (self.state != .started) {
-            log.writef(.debug, "Ignoring schedule before start() or after finish", .{});
-            return error.Cancelled;
-        }
-        if (delay_ms) |delay| {
-            const node = try self.createCommandNode(.{ .perform = task });
-            self.scheduler.schedule(
-                &node.timer,
-                delay,
-                onScheduledCommand,
-                self,
-            ) catch @panic("Looper scheduler failed after start");
-            return;
-        }
-        const node = try self.createCommandNode(.{ .perform = task });
-        self.commands.append(node);
-        self.wakeLocked();
-    }
-
     /// Performs a task synchronously with the worker. Runs inline
     /// if on the same queue to prevent deadlock.
     pub fn perform(
@@ -516,7 +483,7 @@ pub const Looper = struct {
             log.writef(.debug, "Ignoring perform before start() or after finish", .{});
             return error.Cancelled;
         }
-        const node = self.createCommandNode(.{ .schedule = .{
+        const node = self.createCommandNode(.{ .perform = .{
             .task = .{ .context = &holder, .callback = Holder.run },
             .completion = &completion,
         } }) catch |err| {
@@ -792,7 +759,7 @@ pub const Looper = struct {
                         };
                     }
                 },
-                .schedule => |command| {
+                .perform => |command| {
                     self.lock.unlock();
                     command.task.call() catch unreachable;
                     self.lock.lock();
@@ -801,15 +768,6 @@ pub const Looper = struct {
                     // Give the synchronous caller a chance to return before
                     // processing the rest of this detached command batch.
                     self.lock.unlock();
-                    self.lock.lock();
-                },
-                .perform => |task| {
-                    self.lock.unlock();
-                    task.call() catch |err| {
-                        self.lock.lock();
-                        outcome.failure = .{ .user = err };
-                        self.lock.unlock();
-                    };
                     self.lock.lock();
                 },
                 .stop => {
@@ -966,13 +924,16 @@ pub const Looper = struct {
                     },
                     error.Backpressure => {
                         if (opposite) |other| {
-                            if (self.suspendReadAndScheduleRetry(other, fd_set)) |failure| {
-                                return .{ .fatal = failure };
-                            }
+                            self.suspendRead(other, fd_set) catch |suspend_err| {
+                                return .{ .fatal = .{ .system = suspend_err } };
+                            };
+                            self.scheduleReadRetry(other) catch |schedule_err| {
+                                return .{ .fatal = .{ .system = schedule_err } };
+                            };
                         }
-                        if (self.scheduleWriteRetry(side_io)) |failure| {
-                            return .{ .fatal = failure };
-                        }
+                        self.scheduleWriteRetry(side_io) catch |schedule_err| {
+                            return .{ .fatal = .{ .system = schedule_err } };
+                        };
                         watch_writes = false;
                         break;
                     },
@@ -1044,49 +1005,55 @@ pub const Looper = struct {
         return .ok;
     }
 
-    fn suspendReadAndScheduleRetry(
+    fn suspendRead(
         self: *Looper,
         side_io: *SideIO,
         fd_set: *DescriptorSet,
-    ) ?Failure {
-        side_io.setRead(self.mux, false) catch |err| return .{ .system = err };
+    ) io.Error!void {
+        try side_io.setRead(self.mux, false);
         fd_set.removeReadable(side_io.fd);
+    }
 
+    fn scheduleReadRetry(
+        self: *Looper,
+        side_io: *const SideIO,
+    ) std.mem.Allocator.Error!void {
         self.lock.lock();
         defer self.lock.unlock();
         const index = sideIndex(side_io.side);
-        if (self.state != .started or self.read_retries[index]) return null;
-        const node = self.createCommandNode(.{ .enable_read = .{
+        if (self.state != .started or self.read_retries[index]) return;
+        const node = try self.createCommandNode(.{ .enable_read = .{
             .side = side_io.side,
             .id = side_io.id,
-        } }) catch |err| return .{ .system = err };
+        } });
         self.read_retries[index] = true;
         self.scheduler.schedule(
             &node.timer,
             no_buf_retry_delay_ms,
             onScheduledCommand,
             self,
-        ) catch @panic("Looper read-retry scheduling failed after start");
-        return null;
+        ) catch unreachable;
     }
 
-    fn scheduleWriteRetry(self: *Looper, side_io: *SideIO) ?Failure {
+    fn scheduleWriteRetry(
+        self: *Looper,
+        side_io: *const SideIO,
+    ) std.mem.Allocator.Error!void {
         self.lock.lock();
         defer self.lock.unlock();
         const index = sideIndex(side_io.side);
-        if (self.state != .started or self.write_retries[index]) return null;
-        const node = self.createCommandNode(.{ .enable_write = .{
+        if (self.state != .started or self.write_retries[index]) return;
+        const node = try self.createCommandNode(.{ .enable_write = .{
             .side = side_io.side,
             .id = side_io.id,
-        } }) catch |err| return .{ .system = err };
+        } });
         self.write_retries[index] = true;
         self.scheduler.schedule(
             &node.timer,
             no_buf_retry_delay_ms,
             onScheduledCommand,
             self,
-        ) catch @panic("Looper write-retry scheduling failed after start");
-        return null;
+        ) catch unreachable;
     }
 
     fn detachImmediately(self: *Looper, side: io.Side, failure: Failure) void {
@@ -1335,7 +1302,7 @@ pub const Looper = struct {
             switch (node.command) {
                 .attach => |command| self.queueCompletionLocked(command.completion, error.Cancelled),
                 .detach => |command| self.queueCompletionLocked(command.completion, error.Cancelled),
-                .schedule => |command| self.queueCompletionLocked(command.completion, error.Cancelled),
+                .perform => |command| self.queueCompletionLocked(command.completion, error.Cancelled),
                 else => {},
             }
             self.allocator.destroy(node);

--- a/zig/src/net/looper.zig
+++ b/zig/src/net/looper.zig
@@ -89,6 +89,7 @@ pub const Looper = struct {
     const Errors = queue_mod.Errors;
     const SubmissionError = std.mem.Allocator.Error || Errors.Cancelled;
     const CompletionError = queue_mod.CompletionError;
+    const RetryScheduleError = std.mem.Allocator.Error || std.Thread.SpawnError;
     pub const InitError = std.mem.Allocator.Error || Errors.MuxFailure;
     pub const StartError = std.mem.Allocator.Error ||
         std.Thread.SpawnError ||
@@ -761,7 +762,12 @@ pub const Looper = struct {
                 },
                 .perform => |command| {
                     self.lock.unlock();
-                    command.task.call() catch unreachable;
+                    command.task.call() catch |err| {
+                        log.writef(.fault, "Unexpected perform task failure: {s}", .{
+                            @errorName(err),
+                        });
+                        @panic("Looper perform task failed unexpectedly");
+                    };
                     self.lock.lock();
                     completeNow(command.completion, null);
                     self.condition.broadcast();
@@ -928,11 +934,21 @@ pub const Looper = struct {
                                 return .{ .fatal = .{ .system = suspend_err } };
                             };
                             self.scheduleReadRetry(other) catch |schedule_err| {
-                                return .{ .fatal = .{ .system = schedule_err } };
+                                if (schedule_err == error.OutOfMemory)
+                                    return .{ .fatal = .{ .system = error.OutOfMemory } };
+                                log.writef(.fault, "Unable to schedule read retry: {s}", .{
+                                    @errorName(schedule_err),
+                                });
+                                @panic("Looper read-retry scheduling failed after start");
                             };
                         }
                         self.scheduleWriteRetry(side_io) catch |schedule_err| {
-                            return .{ .fatal = .{ .system = schedule_err } };
+                            if (schedule_err == error.OutOfMemory)
+                                return .{ .fatal = .{ .system = error.OutOfMemory } };
+                            log.writef(.fault, "Unable to schedule write retry: {s}", .{
+                                @errorName(schedule_err),
+                            });
+                            @panic("Looper write-retry scheduling failed after start");
                         };
                         watch_writes = false;
                         break;
@@ -1017,7 +1033,7 @@ pub const Looper = struct {
     fn scheduleReadRetry(
         self: *Looper,
         side_io: *const SideIO,
-    ) std.mem.Allocator.Error!void {
+    ) RetryScheduleError!void {
         self.lock.lock();
         defer self.lock.unlock();
         const index = sideIndex(side_io.side);
@@ -1026,19 +1042,21 @@ pub const Looper = struct {
             .side = side_io.side,
             .id = side_io.id,
         } });
+        errdefer self.allocator.destroy(node);
         self.read_retries[index] = true;
-        self.scheduler.scheduleAppending(
+        errdefer self.read_retries[index] = false;
+        try self.scheduler.scheduleAppending(
             &node.timer,
             no_buf_retry_delay_ms,
             onScheduledCommand,
             self,
-        ) catch unreachable;
+        );
     }
 
     fn scheduleWriteRetry(
         self: *Looper,
         side_io: *const SideIO,
-    ) std.mem.Allocator.Error!void {
+    ) RetryScheduleError!void {
         self.lock.lock();
         defer self.lock.unlock();
         const index = sideIndex(side_io.side);
@@ -1047,13 +1065,15 @@ pub const Looper = struct {
             .side = side_io.side,
             .id = side_io.id,
         } });
+        errdefer self.allocator.destroy(node);
         self.write_retries[index] = true;
-        self.scheduler.scheduleAppending(
+        errdefer self.write_retries[index] = false;
+        try self.scheduler.scheduleAppending(
             &node.timer,
             no_buf_retry_delay_ms,
             onScheduledCommand,
             self,
-        ) catch unreachable;
+        );
     }
 
     fn detachImmediately(self: *Looper, side: io.Side, failure: Failure) void {

--- a/zig/src/net/looper.zig
+++ b/zig/src/net/looper.zig
@@ -1027,7 +1027,7 @@ pub const Looper = struct {
             .id = side_io.id,
         } });
         self.read_retries[index] = true;
-        self.scheduler.schedule(
+        self.scheduler.scheduleAppending(
             &node.timer,
             no_buf_retry_delay_ms,
             onScheduledCommand,
@@ -1048,7 +1048,7 @@ pub const Looper = struct {
             .id = side_io.id,
         } });
         self.write_retries[index] = true;
-        self.scheduler.schedule(
+        self.scheduler.scheduleAppending(
             &node.timer,
             no_buf_retry_delay_ms,
             onScheduledCommand,

--- a/zig/src/net/looper_queue.zig
+++ b/zig/src/net/looper_queue.zig
@@ -54,7 +54,7 @@ pub const OnRead = struct {
 ///
 /// - .wait and .system are fatal syscall failures
 /// - .io causes a side to be detached, but lets the loop continue
-/// - .user comes from `OnRead` and `Task` callback invocations
+/// - .user comes from `OnRead` callback invocations
 ///
 /// Swift MuxError is resolved to error.MuxFailure and is not
 /// mapped here because it's always returned synchronously.
@@ -130,7 +130,6 @@ pub const Errors = struct {
     pub const MuxFailure = error{MuxFailure};
     pub const OperationCancelled = error{OperationCancelled};
     pub const ReentrantCall = error{ReentrantCall};
-    pub const TaskFailure = error{TaskFailure};
     pub const TransformFailure = error{TransformFailure};
     pub const WriteIncomplete = error{WriteIncomplete};
 };
@@ -203,11 +202,10 @@ pub const Command = union(enum) {
     },
     enable_read: SideIdentity,
     enable_write: SideIdentity,
-    schedule: struct {
+    perform: struct {
         task: Task,
         completion: *Completion,
     },
-    perform: Task,
     stop,
 };
 

--- a/zig/src/net/platform_dns.zig
+++ b/zig/src/net/platform_dns.zig
@@ -97,7 +97,7 @@ pub const PlatformDNS = struct {
         }, reachability, resolve_fn) catch |err| return err;
 
         var timer: core.RunAfter = .{};
-        timer.init(timeout_ms, Query.timeout, query) catch |err| {
+        timer.scheduleReplacing(timeout_ms, Query.timeout, query) catch |err| {
             timer.deinit();
             query_pool.releaseUnstarted(query);
             log.writef(.err, "Unable to start DNS timeout: {s}", .{@errorName(err)});

--- a/zig/src/openvpn/connection.zig
+++ b/zig/src/openvpn/connection.zig
@@ -55,8 +55,8 @@ const OpenVPNConnection = struct {
     factory: net.SocketFactory,
     looper: *net.Looper,
     serialized_executor: net.SerializedExecutor,
-    session_options: SessionOptions,
     connection_options: net.ConnectionOptions,
+    session_options: SessionOptions,
     configuration: api.OpenVPNConfiguration,
     credentials: ?api.OpenVPNCredentials,
     endpoints: []api.ExtendedEndpoint,
@@ -139,8 +139,8 @@ const OpenVPNConnection = struct {
             .factory = sandbox.factory,
             .looper = looper,
             .serialized_executor = sandbox.serialized_executor,
-            .session_options = session_options,
             .connection_options = sandbox.options,
+            .session_options = session_options,
             .configuration = configuration,
             .credentials = credentials,
             .endpoints = endpoints,
@@ -208,6 +208,7 @@ const OpenVPNConnection = struct {
         defer self.allocator.free(ca_filename);
         const session = Session.create(
             self.allocator,
+            self.serialized_executor,
             self.looper,
             self.configuration,
             self.credentials,

--- a/zig/src/openvpn/internal/session.zig
+++ b/zig/src/openvpn/internal/session.zig
@@ -104,9 +104,9 @@ pub const SessionDelegate = struct {
 
 /// Default V3 OpenVPN session implementation.
 ///
-/// `Session` is heap-only: callbacks, the shutdown actor, and timer contexts
-/// borrow this stable address until `destroy` joins them. Its `Looper` is
-/// borrowed and dedicated to this session for the same lifetime.
+/// `Session` is heap-only: callbacks and timer contexts borrow this stable
+/// address until `destroy` joins them. Its `Looper` is borrowed and dedicated
+/// to this session for the same lifetime.
 pub const Session = struct {
     pub const Error = errors_mod.SessionError;
 
@@ -118,35 +118,22 @@ pub const Session = struct {
     ca_filename: []u8,
     options: SessionOptions,
 
+    executor: net.SerializedExecutor,
     looper: *net.Looper,
     control_channel: *ControlChannel,
-    shutdown_actor: ?*ShutdownActor,
     lifecycle_lock: core.Mutex = .{},
+    shutdown_request_lock: core.Mutex = .{},
     negotiation_timer: core.RunAfter = .{},
     ping_timer: core.RunAfter = .{},
 
     delegate: ?SessionDelegate = null,
     state: SessionState = .{ .stopped = .{ .with_local_options = true } },
     link_processor: ?*LinkProcessor = null,
-
-    const ShutdownRequest = struct {
-        cause: ?SessionError,
-        timeout_ms: ?u64 = null,
-    };
-
-    const ShutdownActorError = error{
-        ShutdownFailure,
-    };
-
-    const ShutdownActor = core.Actor(
-        Session,
-        ShutdownRequest,
-        ShutdownActorError,
-        handleShutdownRequest,
-    );
+    requested_shutdown_cause: ?SessionError = null,
 
     pub fn create(
         allocator: std.mem.Allocator,
+        executor: net.SerializedExecutor,
         looper: *net.Looper,
         configuration: api.OpenVPNConfiguration,
         credentials: ?api.OpenVPNCredentials,
@@ -157,6 +144,7 @@ pub const Session = struct {
     ) Error!*Session {
         return createUnwrapped(
             allocator,
+            executor,
             looper,
             configuration,
             credentials,
@@ -169,6 +157,7 @@ pub const Session = struct {
 
     fn createUnwrapped(
         allocator: std.mem.Allocator,
+        executor: net.SerializedExecutor,
         looper: *net.Looper,
         configuration: api.OpenVPNConfiguration,
         credentials: ?api.OpenVPNCredentials,
@@ -206,16 +195,12 @@ pub const Session = struct {
             .caches_directory = owned_caches_directory,
             .ca_filename = owned_ca_filename,
             .options = options,
+            .executor = executor,
             .looper = looper,
             .control_channel = control_channel,
-            .shutdown_actor = null,
         };
+        errdefer self.shutdown_request_lock.deinit();
         errdefer self.lifecycle_lock.deinit();
-        self.shutdown_actor = try ShutdownActor.create(allocator, self);
-        errdefer {
-            self.shutdown_actor.?.destroy();
-            self.shutdown_actor = null;
-        }
         return self;
     }
 
@@ -230,17 +215,10 @@ pub const Session = struct {
         self.negotiation_timer.cancel();
         self.ping_timer.cancel();
 
-        // Keep timer synchronization and the shutdown actor alive while the
-        // regular lifecycle path finishes: prepare/finish both cancel timers,
-        // and an already-running timer callback may still queue shutdown.
         self.shutdown(null, 0) catch {};
         self.negotiation_timer.deinit();
         self.ping_timer.deinit();
 
-        if (self.shutdown_actor) |actor| {
-            self.shutdown_actor = null;
-            actor.destroy();
-        }
         switch (self.state) {
             .stopped => {},
             .active => |active| active.context.destroy(),
@@ -252,6 +230,7 @@ pub const Session = struct {
         if (self.credentials) |*credentials| credentials.deinit(self.allocator);
         self.allocator.free(self.caches_directory);
         self.allocator.free(self.ca_filename);
+        self.shutdown_request_lock.deinit();
         self.lifecycle_lock.deinit();
         const allocator = self.allocator;
         allocator.destroy(self);
@@ -351,8 +330,7 @@ pub const Session = struct {
     }
 
     /// Prepares state on the looper, detaches from this external thread, then
-    /// finishes state on the looper. Calling it from a callback is rejected;
-    /// callback failures go through `ShutdownActor` instead.
+    /// finishes state on the looper.
     pub fn shutdown(
         self: *Session,
         cause: ?SessionError,
@@ -397,20 +375,27 @@ pub const Session = struct {
         try self.looper.perform(void, &finish, finishShutdownOnQueue);
     }
 
-    fn requestShutdown(self: *const Session, cause: ?SessionError) void {
-        const actor = self.shutdown_actor orelse return;
-        actor.schedule(.{ .cause = cause }) catch {};
+    fn requestShutdown(self: *Session, cause: SessionError) void {
+        self.shutdown_request_lock.lock();
+        if (self.requested_shutdown_cause != null) {
+            self.shutdown_request_lock.unlock();
+            return;
+        }
+        self.requested_shutdown_cause = cause;
+        self.shutdown_request_lock.unlock();
+        self.executor.run(self, shutdownOnExecutor);
     }
 
-    fn handleShutdownRequest(
-        self: *Session,
-        request: ShutdownRequest,
-    ) ShutdownActorError!void {
-        self.shutdown(request.cause, request.timeout_ms) catch |err| {
+    fn shutdownOnExecutor(raw: *anyopaque) void {
+        const self: *Session = @ptrCast(@alignCast(raw));
+        self.shutdown_request_lock.lock();
+        const cause = self.requested_shutdown_cause;
+        self.requested_shutdown_cause = null;
+        self.shutdown_request_lock.unlock();
+        self.shutdown(cause orelse return, null) catch |err| {
             log.writef(.err, "Unable to shut down session on looper queue: {s}", .{
                 @errorName(err),
             });
-            return error.ShutdownFailure;
         };
     }
 

--- a/zig/src/openvpn/internal/session.zig
+++ b/zig/src/openvpn/internal/session.zig
@@ -793,7 +793,7 @@ pub const Session = struct {
     }
 
     fn scheduleNegotiationTick(self: *Session) !void {
-        try self.negotiation_timer.init(
+        try self.negotiation_timer.scheduleReplacing(
             self.options.tick_interval_ms,
             onNegotiationTimer,
             self,
@@ -824,7 +824,7 @@ pub const Session = struct {
         const delay = self.keepAliveIntervalMs(context) orelse
             self.options.ping_timeout_check_interval_ms;
         log.logTimeMs(.debug, "Schedule ping check after ", delay);
-        try self.ping_timer.init(delay, onPingTimer, self);
+        try self.ping_timer.scheduleReplacing(delay, onPingTimer, self);
     }
 
     fn onPingTimer(raw: ?*anyopaque) void {

--- a/zig/src/openvpn/internal/session.zig
+++ b/zig/src/openvpn/internal/session.zig
@@ -390,7 +390,6 @@ pub const Session = struct {
         const self: *Session = @ptrCast(@alignCast(raw));
         self.shutdown_request_lock.lock();
         const cause = self.requested_shutdown_cause;
-        self.requested_shutdown_cause = null;
         self.shutdown_request_lock.unlock();
         self.shutdown(cause orelse return, null) catch |err| {
             log.writef(.err, "Unable to shut down session on looper queue: {s}", .{

--- a/zig/src/openvpn/internal/session.zig
+++ b/zig/src/openvpn/internal/session.zig
@@ -379,7 +379,11 @@ pub const Session = struct {
     }
 
     fn requestShutdown(self: *Session, cause: SessionError) void {
-        if (!self.claimShutdown()) return;
+        self.shutdown_request_lock.lock();
+        defer self.shutdown_request_lock.unlock();
+        if (self.shutdown_pending) return;
+        self.shutdown_pending = true;
+
         self.shutdown_request_cause = cause;
         self.executor.run(self, shutdownOnExecutor);
     }

--- a/zig/src/openvpn/internal/session.zig
+++ b/zig/src/openvpn/internal/session.zig
@@ -122,14 +122,16 @@ pub const Session = struct {
     looper: *net.Looper,
     control_channel: *ControlChannel,
     lifecycle_lock: core.Mutex = .{},
-    shutdown_request_lock: core.Mutex = .{},
     negotiation_timer: core.RunAfter = .{},
     ping_timer: core.RunAfter = .{},
 
     delegate: ?SessionDelegate = null,
     state: SessionState = .{ .stopped = .{ .with_local_options = true } },
     link_processor: ?*LinkProcessor = null,
-    requested_shutdown_cause: ?SessionError = null,
+
+    shutdown_request_lock: core.Mutex = .{},
+    shutdown_pending: bool = false,
+    shutdown_request_cause: ?SessionError = null,
 
     pub fn create(
         allocator: std.mem.Allocator,
@@ -336,6 +338,7 @@ pub const Session = struct {
         cause: ?SessionError,
         timeout_ms: ?u64,
     ) Error!void {
+        if (!self.claimShutdown()) return;
         return self.shutdownUnwrapped(cause, timeout_ms) catch |err|
             errors_mod.sessionError(err);
     }
@@ -376,26 +379,29 @@ pub const Session = struct {
     }
 
     fn requestShutdown(self: *Session, cause: SessionError) void {
-        self.shutdown_request_lock.lock();
-        if (self.requested_shutdown_cause != null) {
-            self.shutdown_request_lock.unlock();
-            return;
-        }
-        self.requested_shutdown_cause = cause;
-        self.shutdown_request_lock.unlock();
+        if (!self.claimShutdown()) return;
+        self.shutdown_request_cause = cause;
         self.executor.run(self, shutdownOnExecutor);
     }
 
     fn shutdownOnExecutor(raw: *anyopaque) void {
         const self: *Session = @ptrCast(@alignCast(raw));
         self.shutdown_request_lock.lock();
-        const cause = self.requested_shutdown_cause;
+        const cause = self.shutdown_request_cause;
         self.shutdown_request_lock.unlock();
-        self.shutdown(cause orelse return, null) catch |err| {
+        self.shutdownUnwrapped(cause orelse return, null) catch |err| {
             log.writef(.err, "Unable to shut down session on looper queue: {s}", .{
                 @errorName(err),
             });
         };
+    }
+
+    fn claimShutdown(self: *Session) bool {
+        self.shutdown_request_lock.lock();
+        defer self.shutdown_request_lock.unlock();
+        if (self.shutdown_pending) return false;
+        self.shutdown_pending = true;
+        return true;
     }
 
     fn setLinkOnQueue(raw: ?*anyopaque) !void {
@@ -506,6 +512,7 @@ pub const Session = struct {
     /// while the Session is alive, and must stop forwarding before `destroy`.
     pub fn looperDidTerminate(self: *Session, failure: ?net.Looper.Failure) void {
         std.debug.assert(self.looper.isOnQueue());
+        _ = self.claimShutdown();
         if (failure) |value| switch (value) {
             .user => |cause| log.writef(.err, "Session looper finished with error: {s}", .{
                 @errorName(cause),

--- a/zig/src/wireguard/connection.zig
+++ b/zig/src/wireguard/connection.zig
@@ -238,7 +238,11 @@ const WireGuardConnection = struct {
 
     fn startDataCountTimer(self: *WireGuardConnection) std.Thread.SpawnError!void {
         self.data_count_timer_active = true;
-        self.data_count_timer.init(self.data_count_interval_ms, onDataCountTimer, self) catch |err| {
+        self.data_count_timer.scheduleReplacing(
+            self.data_count_interval_ms,
+            onDataCountTimer,
+            self,
+        ) catch |err| {
             self.data_count_timer_active = false;
             return err;
         };
@@ -269,7 +273,11 @@ const WireGuardConnection = struct {
 
         self.reportDataCount(events);
         if (!self.data_count_timer_active) return;
-        self.data_count_timer.init(self.data_count_interval_ms, onDataCountTimer, self) catch |err| {
+        self.data_count_timer.scheduleReplacing(
+            self.data_count_interval_ms,
+            onDataCountTimer,
+            self,
+        ) catch |err| {
             log.writef(.err, "Unable to reschedule data count timer: {s}", .{@errorName(err)});
             self.data_count_timer_active = false;
         };
@@ -281,7 +289,7 @@ const WireGuardConnection = struct {
         log.writef(.debug, "Retry backend restart in {} milliseconds", .{
             self.temporary_shutdown_retry_delay_ms,
         });
-        self.temporary_shutdown_retry_timer.init(
+        self.temporary_shutdown_retry_timer.scheduleReplacing(
             self.temporary_shutdown_retry_delay_ms,
             onTemporaryShutdownRetry,
             self,

--- a/zig/tests/core/concurrency.zig
+++ b/zig/tests/core/concurrency.zig
@@ -183,7 +183,7 @@ test "drainer waits until in-flight work completes" {
 test "RunAfter runs callback after delay" {
     var did_run = AtomicBool.init(false);
     var run_after = core.RunAfter{};
-    try run_after.init(1, storeTrue, &did_run);
+    try run_after.scheduleReplacing(1, storeTrue, &did_run);
     defer run_after.deinit();
 
     waitUntil(&did_run);
@@ -192,7 +192,7 @@ test "RunAfter runs callback after delay" {
 test "RunAfter cancel prevents callback" {
     var did_run = AtomicBool.init(false);
     var run_after = core.RunAfter{};
-    try run_after.init(100, storeTrue, &did_run);
+    try run_after.scheduleReplacing(100, storeTrue, &did_run);
 
     run_after.cancel();
     run_after.deinit();
@@ -200,12 +200,12 @@ test "RunAfter cancel prevents callback" {
     try std.testing.expect(!did_run.load(.acquire));
 }
 
-test "RunAfter init cancels previous callback" {
+test "RunAfter replace cancels previous callback" {
     var first_did_run = AtomicBool.init(false);
     var second_did_run = AtomicBool.init(false);
     var run_after = core.RunAfter{};
-    try run_after.init(100, storeTrue, &first_did_run);
-    try run_after.init(1, storeTrue, &second_did_run);
+    try run_after.scheduleReplacing(100, storeTrue, &first_did_run);
+    try run_after.scheduleReplacing(1, storeTrue, &second_did_run);
     defer run_after.deinit();
 
     waitUntil(&second_did_run);
@@ -218,10 +218,10 @@ test "RunAfter reuses worker thread" {
     var run_after = core.RunAfter{};
     defer run_after.deinit();
 
-    try run_after.init(1, ThreadRecorder.record, &recorder);
+    try run_after.scheduleReplacing(1, ThreadRecorder.record, &recorder);
     waitUntil(&recorder.first_did_run);
 
-    try run_after.init(1, ThreadRecorder.record, &recorder);
+    try run_after.scheduleReplacing(1, ThreadRecorder.record, &recorder);
     waitUntil(&recorder.second_did_run);
 
     recorder.mutex.lock();
@@ -237,10 +237,10 @@ test "RunAfter can reschedule while callback is running" {
     defer run_after.deinit();
     defer recorder.first_can_finish.store(true, .release);
 
-    try run_after.init(1, BlockingRecorder.record, &recorder);
+    try run_after.scheduleReplacing(1, BlockingRecorder.record, &recorder);
     waitUntil(&recorder.first_did_start);
 
-    try run_after.init(1, BlockingRecorder.record, &recorder);
+    try run_after.scheduleReplacing(1, BlockingRecorder.record, &recorder);
     settleScheduler();
     try std.testing.expect(!recorder.second_did_run.load(.acquire));
 
@@ -256,8 +256,8 @@ test "RunAfter schedules independent one-shot callbacks" {
     var run_after = core.RunAfter{};
     defer run_after.deinit();
 
-    try run_after.schedule(&later, 100, ScheduledProbe.record, &later_probe);
-    try run_after.schedule(&earlier, 1, ScheduledProbe.record, &earlier_probe);
+    try run_after.scheduleAppending(&later, 100, ScheduledProbe.record, &later_probe);
+    try run_after.scheduleAppending(&earlier, 1, ScheduledProbe.record, &earlier_probe);
 
     waitUntil(&earlier_probe.elapsed);
     try std.testing.expect(!later_probe.elapsed.load(.acquire));
@@ -273,7 +273,7 @@ test "RunAfter cancel releases scheduled callbacks" {
     var run_after = core.RunAfter{};
     defer run_after.deinit();
 
-    try run_after.schedule(&scheduled, 100, ScheduledProbe.record, &probe);
+    try run_after.scheduleAppending(&scheduled, 100, ScheduledProbe.record, &probe);
     run_after.cancel();
 
     try std.testing.expect(probe.cancelled.load(.acquire));

--- a/zig/tests/net/daemon.zig
+++ b/zig/tests/net/daemon.zig
@@ -682,7 +682,7 @@ const DelayedConnection = struct {
         const self: *DelayedConnection = @ptrCast(@alignCast(ptr));
         self.start_thread = std.Thread.getCurrentId();
         events.status(events.ctx, .connecting);
-        self.timer.init(1, onTimer, self) catch return error.UnableToStart;
+        self.timer.scheduleReplacing(1, onTimer, self) catch return error.UnableToStart;
         events.status(events.ctx, .connected);
         return true;
     }

--- a/zig/tests/net/looper.zig
+++ b/zig/tests/net/looper.zig
@@ -27,14 +27,6 @@ fn yieldRepeatedly() void {
     }
 }
 
-fn waitUntilWithin(value: *const AtomicBool, timeout_ms: u64) bool {
-    var remaining_ms = timeout_ms;
-    while (!value.load(.acquire) and remaining_ms > 0) : (remaining_ms -= 1) {
-        source.core.sleepMs(1);
-    }
-    return value.load(.acquire);
-}
-
 const Pipe = struct {
     fds: [2]std.c.fd_t,
 
@@ -120,27 +112,6 @@ fn descriptor(pipe: Pipe, mock: *MockIO) Looper.Descriptor {
     };
 }
 
-const DelayedTaskProbe = struct {
-    looper: *Looper,
-    fired: AtomicBool = AtomicBool.init(false),
-    ran_on_queue: AtomicBool = AtomicBool.init(false),
-
-    fn run(raw: ?*anyopaque) anyerror!void {
-        const self: *DelayedTaskProbe = @ptrCast(@alignCast(raw.?));
-        self.ran_on_queue.store(self.looper.isOnQueue(), .release);
-        self.fired.store(true, .release);
-    }
-};
-
-const CancellationProbe = struct {
-    fired: AtomicBool = AtomicBool.init(false),
-
-    fn run(raw: ?*anyopaque) anyerror!void {
-        const self: *CancellationProbe = @ptrCast(@alignCast(raw.?));
-        self.fired.store(true, .release);
-    }
-};
-
 const FinishCallProbe = struct {
     called: AtomicBool = AtomicBool.init(false),
 
@@ -160,84 +131,6 @@ test "perform completes synchronously with its result" {
         try looper.perform(u8, null, returnFortyTwo),
     );
     try looper.stop();
-}
-
-test "delayed task waits before running on the looper" {
-    const delay_ms = 100;
-    var looper = try initLooper(.{ .callback = noopFinish });
-    defer looper.deinit();
-    try looper.start();
-    var probe = DelayedTaskProbe{ .looper = &looper };
-
-    try looper.schedule(delay_ms, .{
-        .context = &probe,
-        .callback = DelayedTaskProbe.run,
-    });
-
-    source.core.sleepMs(15);
-    try std.testing.expect(!probe.fired.load(.acquire));
-    try std.testing.expect(waitUntilWithin(&probe.fired, 750));
-
-    try std.testing.expect(probe.ran_on_queue.load(.acquire));
-    try looper.stop();
-}
-
-test "independent delayed tasks run in delay order" {
-    const later_delay_ms = 500;
-    const earlier_delay_ms = 40;
-    var looper = try initLooper(.{ .callback = noopFinish });
-    defer looper.deinit();
-    try looper.start();
-    var later = DelayedTaskProbe{ .looper = &looper };
-    var earlier = DelayedTaskProbe{ .looper = &looper };
-
-    try looper.schedule(later_delay_ms, .{
-        .context = &later,
-        .callback = DelayedTaskProbe.run,
-    });
-    // A synchronous barrier proves that the loop has observed the later task.
-    try looper.performTask(.{ .callback = noopTask });
-    source.core.sleepMs(10);
-
-    try looper.schedule(earlier_delay_ms, .{
-        .context = &earlier,
-        .callback = DelayedTaskProbe.run,
-    });
-
-    try std.testing.expect(waitUntilWithin(&earlier.fired, 250));
-    try std.testing.expect(!later.fired.load(.acquire));
-    try std.testing.expect(earlier.ran_on_queue.load(.acquire));
-    try looper.stop();
-}
-
-test "stop and deinit cancel delayed tasks" {
-    const delay_ms = 300;
-
-    var stopped_looper = try initLooper(.{ .callback = noopFinish });
-    defer stopped_looper.deinit();
-    try stopped_looper.start();
-    var stopped_probe = CancellationProbe{};
-    try stopped_looper.schedule(delay_ms, .{
-        .context = &stopped_probe,
-        .callback = CancellationProbe.run,
-    });
-    try stopped_looper.stop();
-
-    var deinitialized_looper = try initLooper(.{ .callback = noopFinish });
-    var needs_deinit = true;
-    defer if (needs_deinit) deinitialized_looper.deinit();
-    try deinitialized_looper.start();
-    var deinitialized_probe = CancellationProbe{};
-    try deinitialized_looper.schedule(delay_ms, .{
-        .context = &deinitialized_probe,
-        .callback = CancellationProbe.run,
-    });
-    deinitialized_looper.deinit();
-    needs_deinit = false;
-
-    source.core.sleepMs(delay_ms + 50);
-    try std.testing.expect(!stopped_probe.fired.load(.acquire));
-    try std.testing.expect(!deinitialized_probe.fired.load(.acquire));
 }
 
 test "deinit does not invoke the finish callback" {
@@ -265,12 +158,16 @@ test "perform completion is released before later commands finish" {
     defer looper.deinit();
     try looper.start();
 
-    // Hold the loop so perform and the second task land in the same detached
-    // command batch, in that order.
-    try looper.schedule(null, .{
-        .context = &first_task,
-        .callback = BlockingTask.run,
-    });
+    var first_worker = PerformWorker{
+        .looper = &looper,
+        .task = .{ .context = &first_task, .callback = BlockingTask.run },
+    };
+    var first_thread = try std.Thread.spawn(.{}, PerformWorker.run, .{&first_worker});
+    var first_joined = false;
+    defer if (!first_joined) {
+        first_task.release.store(true, .release);
+        first_thread.join();
+    };
     waitUntil(&first_task.entered);
 
     var worker = PerformWorker{ .looper = &looper };
@@ -284,21 +181,36 @@ test "perform completion is released before later commands finish" {
     waitUntil(&worker.started);
     yieldRepeatedly();
 
-    try looper.schedule(null, .{
-        .context = &second_task,
-        .callback = BlockingTask.run,
-    });
+    var second_worker = PerformWorker{
+        .looper = &looper,
+        .task = .{ .context = &second_task, .callback = BlockingTask.run },
+    };
+    var second_thread = try std.Thread.spawn(.{}, PerformWorker.run, .{&second_worker});
+    var second_joined = false;
+    defer if (!second_joined) {
+        second_task.release.store(true, .release);
+        second_thread.join();
+    };
+    waitUntil(&second_worker.started);
+    yieldRepeatedly();
+
     first_task.release.store(true, .release);
     waitUntil(&second_task.entered);
     yieldRepeatedly();
     const completed_before_second_task = worker.done.load(.acquire);
 
     second_task.release.store(true, .release);
+    first_thread.join();
+    first_joined = true;
     worker_thread.join();
     worker_joined = true;
+    second_thread.join();
+    second_joined = true;
 
     try std.testing.expect(completed_before_second_task);
+    try std.testing.expect(first_worker.failure == null);
     try std.testing.expect(worker.failure == null);
+    try std.testing.expect(second_worker.failure == null);
     try looper.stop();
 }
 
@@ -311,19 +223,11 @@ test "work is rejected before start and after terminal cleanup" {
     finish_probe.looper = &looper;
     defer looper.deinit();
 
-    try std.testing.expectError(
-        error.Cancelled,
-        looper.schedule(1, .{ .callback = noopTask }),
-    );
     try looper.start();
     try looper.stop();
 
     try std.testing.expect(finish_probe.oob_was_cancelled.load(.acquire));
     try std.testing.expectError(error.Cancelled, looper.resumeReading(.link));
-    try std.testing.expectError(
-        error.Cancelled,
-        looper.schedule(null, .{ .callback = noopTask }),
-    );
     try std.testing.expectError(
         error.Cancelled,
         looper.performTask(.{ .callback = noopTask }),
@@ -572,10 +476,16 @@ test "deinit cancels a detach queued during a running command" {
         .pair = .{ .link = descriptor(pipe, &mock) },
     });
 
-    try looper.schedule(null, .{
-        .context = &blocking_task,
-        .callback = BlockingTask.run,
-    });
+    var blocking_worker = PerformWorker{
+        .looper = &looper,
+        .task = .{ .context = &blocking_task, .callback = BlockingTask.run },
+    };
+    var blocking_thread = try std.Thread.spawn(.{}, PerformWorker.run, .{&blocking_worker});
+    var blocking_joined = false;
+    defer if (!blocking_joined) {
+        blocking_task.release.store(true, .release);
+        blocking_thread.join();
+    };
     waitUntil(&blocking_task.entered);
 
     var detacher = DetachWorker{ .looper = &looper };
@@ -603,9 +513,12 @@ test "deinit cancels a detach queued during a running command" {
     try std.testing.expect(detacher.failure.? == error.Cancelled);
 
     blocking_task.release.store(true, .release);
+    blocking_thread.join();
+    blocking_joined = true;
     deinit_thread.join();
     deinit_joined = true;
 
+    try std.testing.expect(blocking_worker.failure == null);
     try std.testing.expect(deinit_worker.done.load(.acquire));
     try std.testing.expect(mock.cleaned.load(.acquire));
 }
@@ -617,10 +530,16 @@ test "deinit cancels a perform queued during a running command" {
     defer if (needs_deinit) looper.deinit();
     try looper.start();
 
-    try looper.schedule(null, .{
-        .context = &blocking_task,
-        .callback = BlockingTask.run,
-    });
+    var blocking_worker = PerformWorker{
+        .looper = &looper,
+        .task = .{ .context = &blocking_task, .callback = BlockingTask.run },
+    };
+    var blocking_thread = try std.Thread.spawn(.{}, PerformWorker.run, .{&blocking_worker});
+    var blocking_joined = false;
+    defer if (!blocking_joined) {
+        blocking_task.release.store(true, .release);
+        blocking_thread.join();
+    };
     waitUntil(&blocking_task.entered);
 
     var worker = PerformWorker{ .looper = &looper };
@@ -645,10 +564,13 @@ test "deinit cancels a perform queued during a running command" {
     worker_thread.join();
     worker_joined = true;
     blocking_task.release.store(true, .release);
+    blocking_thread.join();
+    blocking_joined = true;
     deinit_thread.join();
     deinit_joined = true;
     needs_deinit = false;
 
+    try std.testing.expect(blocking_worker.failure == null);
     try std.testing.expect(worker.was_cancelled.load(.acquire));
     try std.testing.expect(deinit_worker.done.load(.acquire));
 }
@@ -666,6 +588,7 @@ const BlockingTask = struct {
 
 const PerformWorker = struct {
     looper: *Looper,
+    task: Looper.Task = .{ .callback = noopTask },
     started: AtomicBool = AtomicBool.init(false),
     done: AtomicBool = AtomicBool.init(false),
     was_cancelled: AtomicBool = AtomicBool.init(false),
@@ -673,7 +596,7 @@ const PerformWorker = struct {
 
     fn run(self: *PerformWorker) void {
         self.started.store(true, .release);
-        self.looper.performTask(.{ .callback = noopTask }) catch |err| {
+        self.looper.performTask(self.task) catch |err| {
             self.failure = err;
             self.was_cancelled.store(err == error.Cancelled, .release);
         };

--- a/zig/tests/openvpn/internal/session.zig
+++ b/zig/tests/openvpn/internal/session.zig
@@ -23,6 +23,8 @@ test "Session borrows an externally managed Looper" {
     };
 
     const allocator = std.testing.allocator;
+    const executor = try source.mock.MockSerializedExecutor.create(allocator);
+    defer executor.destroy();
     var looper = try net.Looper.init(allocator, .{
         .on_finish = .{ .callback = Callbacks.onFinish },
     });
@@ -33,6 +35,7 @@ test "Session borrows an externally managed Looper" {
 
     const session = try Session.create(
         allocator,
+        executor.interface(),
         &looper,
         .{},
         null,


### PR DESCRIPTION
- Merge replace/append semantics in RunAfter, `init` was also a very bad name
- Delete ShutdownActor from OpenVPN session by running shutdown on the daemon executor
- Delete unused Looper.schedule(), schedule R/W retries internally