### PR TITLE
Core/Zig: Fix deadlock on network signals

### DIFF
--- a/zig/src/net/daemon.zig
+++ b/zig/src/net/daemon.zig
@@ -269,7 +269,7 @@ pub const Daemon = struct {
             .stop => self.doStop(.clear_environment),
             .evaluateConnection => self.doEvaluateConnection(),
             .resumeGate => self.doResumeGate(),
-            .onReachability => |reachability| self.handleReachability(reachability),
+            .onReachability => |reachability| self.handleReachabilitySignal(reachability),
             .onBetterPath => self.handleBetterPath(),
             .onConnectionStatus => |status| self.handleConnectionStatus(status),
             .onConnectionLastError => |code| self.handleLastError(code),
@@ -313,22 +313,23 @@ pub const Daemon = struct {
         };
     }
 
-    // This is external and is gated through ConnectionGate
+    // Network callbacks may originate while the platform owns a lock that is
+    // also needed by tunnel-controller callbacks. Never wait for the actor
+    // here: starting a connection can synchronously report a snapshot back to
+    // the platform and would otherwise deadlock with that lock held.
     fn onReachability(ctx: ?*anyopaque, reachability: io.ReachabilityInfo) void {
         const self: *Daemon = @ptrCast(@alignCast(ctx.?));
-        if (self.gate) |*gate| {
-            _ = gate.updateReachability(reachability.reachable);
-        }
-        self.actor.perform(.{ .onReachability = reachability }) catch |err| {
-            log.writef(.err, "Unable to handle reachability: {s}", .{@errorName(err)});
+        self.actor.schedule(.{ .onReachability = reachability }) catch |err| {
+            log.writef(.err, "Unable to enqueue reachability: {s}", .{@errorName(err)});
         };
     }
 
-    // This is external and is invoked by ConnectionGate
+    // Like reachability, better-path notifications come from platform code
+    // whose locks must be released before calling back into the controller.
     fn onBetterPath(ctx: ?*anyopaque) void {
         const self: *Daemon = @ptrCast(@alignCast(ctx.?));
-        self.actor.perform(.onBetterPath) catch |err| {
-            log.writef(.err, "Unable to handle better path: {s}", .{@errorName(err)});
+        self.actor.schedule(.onBetterPath) catch |err| {
+            log.writef(.err, "Unable to enqueue better path: {s}", .{@errorName(err)});
         };
     }
 
@@ -600,6 +601,16 @@ pub const Daemon = struct {
         if (self.gate) |*gate| {
             _ = gate.setEnabled(true);
         }
+    }
+
+    // Updates the gate on the actor so that a ready transition and the
+    // resulting connection start are serialized with the corresponding
+    // network-change event.
+    fn handleReachabilitySignal(self: *Daemon, reachability: io.ReachabilityInfo) void {
+        if (self.gate) |*gate| {
+            _ = gate.updateReachability(reachability.reachable);
+        }
+        self.handleReachability(reachability);
     }
 
     // Forwards the event to the underlying connection

--- a/zig/src/testing/mock.zig
+++ b/zig/src/testing/mock.zig
@@ -663,6 +663,11 @@ fn copyFixedString(buffer: *[64]u8, len: *usize, value: []const u8) void {
 }
 
 pub const MockTunnelController = struct {
+    pub const SnapshotBlock = struct {
+        entered: std.atomic.Value(bool) = .init(false),
+        release: std.atomic.Value(bool) = .init(false),
+    };
+
     pub const LastTunnelSettings = struct {
         requires_virtual_device: bool,
         original_module_id: api.UUID,
@@ -681,6 +686,7 @@ pub const MockTunnelController = struct {
     clear_tunnel_settings_count: usize = 0,
     configure_sockets_count: usize = 0,
     report_snapshot_count: usize = 0,
+    snapshot_block: ?*SnapshotBlock = null,
     last_settings_info: ?api.TunnelRemoteInfoWrapper = null,
     last_settings: ?LastTunnelSettings = null,
     reasserting: bool = false,
@@ -721,6 +727,12 @@ fn mockConfigureSockets(ptr: ?*anyopaque, descriptors: []const net_io.SocketDesc
 fn mockReportSnapshot(ptr: ?*anyopaque, snapshot: api.TunnelSnapshot) void {
     const self: *MockTunnelController = @ptrCast(@alignCast(ptr.?));
     self.report_snapshot_count += 1;
+    if (self.snapshot_block) |block| {
+        block.entered.store(true, .release);
+        while (!block.release.load(.acquire)) {
+            std.Thread.yield() catch {};
+        }
+    }
     _ = snapshot;
 }
 

--- a/zig/tests/net/daemon.zig
+++ b/zig/tests/net/daemon.zig
@@ -518,12 +518,66 @@ test "connection daemon connects when previously unreachable network becomes rea
     }, sut.testStatuses());
 
     monitor.setReachable(true);
+    // External network callbacks enqueue work so platform locks can be
+    // released before the actor calls back into the tunnel controller.
+    try std.testing.expectError(error.AlreadyStarted, sut.start());
     try std.testing.expectEqualSlices(api.ConnectionStatus, &.{
         .disconnected,
         .connecting,
         .connected,
     }, sut.testStatuses());
     try std.testing.expectEqual(api.ConnectionStatus.connected, events.connection_status.?);
+}
+
+test "connection daemon does not block the external reachability callback on snapshots" {
+    const allocator = std.testing.allocator;
+    const mock = mock_mod;
+
+    var implementations = [_]net.ConnectionImplementation{mock.mockConnectionImplementation()};
+    var registry = try net.ConnectionRegistry.init(allocator, &implementations);
+    defer registry.deinit(allocator);
+    var controller = mock.MockTunnelController{};
+    var events = mock.DaemonEventRecorder{};
+    var monitor = mock.MockNetworkMonitor{ .reachable = false };
+    var sut = try newDaemon(
+        allocator,
+        mock.connectionProfileJson(),
+        &registry,
+        &controller,
+        &events,
+        &monitor,
+        .{},
+    );
+    defer sut.destroy();
+
+    try sut.start();
+    defer sut.stop();
+
+    var snapshot_block = mock.MockTunnelController.SnapshotBlock{};
+    controller.snapshot_block = &snapshot_block;
+    var callback_returned = std.atomic.Value(bool).init(false);
+    const Emitter = struct {
+        fn run(target: *mock.MockNetworkMonitor, returned: *std.atomic.Value(bool)) void {
+            target.setReachable(true);
+            returned.store(true, .release);
+        }
+    };
+    const emitter = try std.Thread.spawn(.{}, Emitter.run, .{ &monitor, &callback_returned });
+    defer {
+        snapshot_block.release.store(true, .release);
+        emitter.join();
+    }
+
+    var attempts: usize = 0;
+    while (!snapshot_block.entered.load(.acquire) and attempts < 100_000) : (attempts += 1) {
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expect(snapshot_block.entered.load(.acquire));
+    attempts = 0;
+    while (!callback_returned.load(.acquire) and attempts < 100_000) : (attempts += 1) {
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expect(callback_returned.load(.acquire));
 }
 
 test "connection daemon forwards better path events to current connection" {
@@ -553,6 +607,7 @@ test "connection daemon forwards better path events to current connection" {
 
     try sut.start();
     monitor.onBetterPath();
+    try std.testing.expectError(error.AlreadyStarted, sut.start());
     try std.testing.expectEqual(@as(usize, 1), blocking_connection.better_path_count);
 
     sut.stop();


### PR DESCRIPTION
Schedule rather than perform synchronously. For example, Android calls native reachability while holding a lock in JNITunnelController. Reentrancy here always causes a deadlock.

Add tests to exclude similar scenarios with snapshots.