### PR TITLE
Android: Provide JNI wrapper

### DIFF
--- a/Sources/PartoutCore/OpenAPI/Codegen/TunnelControllerOptions.swift
+++ b/Sources/PartoutCore/OpenAPI/Codegen/TunnelControllerOptions.swift
@@ -10,12 +10,10 @@ public struct TunnelControllerOptions: Sendable, Codable, Hashable {
 
     public var dnsFallbackServers: [String]
     public var logsSnapshots: Bool
-    public var minDataCountDelta: ModelUInt64
 
-    public init(dnsFallbackServers: [String], logsSnapshots: Bool, minDataCountDelta: ModelUInt64) {
+    public init(dnsFallbackServers: [String], logsSnapshots: Bool) {
         self.dnsFallbackServers = dnsFallbackServers
         self.logsSnapshots = logsSnapshots
-        self.minDataCountDelta = minDataCountDelta
     }
 }
 

--- a/Sources/PartoutCore/OpenAPI/Extensions/Core/TunnelControllerOptions+Extensions.swift
+++ b/Sources/PartoutCore/OpenAPI/Extensions/Core/TunnelControllerOptions+Extensions.swift
@@ -4,6 +4,6 @@
 
 extension TunnelControllerOptions {
     public init() {
-        self.init(dnsFallbackServers: [], logsSnapshots: false, minDataCountDelta: .zero)
+        self.init(dnsFallbackServers: [], logsSnapshots: false)
     }
 }

--- a/Sources/PartoutRuntime/PartoutProviderRuntime.swift
+++ b/Sources/PartoutRuntime/PartoutProviderRuntime.swift
@@ -15,6 +15,7 @@ public final class PartoutProviderRuntime: Sendable {
     private let messageHandler: DefaultMessageHandler
     private let options: TunnelControllerOptions
     private let logsPrivateData: Bool
+    private let minDataCountDelta: Int64?
     private let logger: partout_logger_cb?
 
     public init(
@@ -23,6 +24,7 @@ public final class PartoutProviderRuntime: Sendable {
         options: TunnelControllerOptions,
         defaults: UserDefaults,
         logsPrivateData: Bool,
+        minDataCountDelta: Int64? = nil,
         logger: partout_logger_cb?
     ) throws {
         profile = try Profile(withNEProvider: provider, decoder: decoder)
@@ -32,6 +34,7 @@ public final class PartoutProviderRuntime: Sendable {
         messageHandler = DefaultMessageHandler(ctx, environment: environment)
         self.options = options
         self.logsPrivateData = logsPrivateData
+        self.minDataCountDelta = minDataCountDelta
         self.logger = logger
     }
 
@@ -77,7 +80,7 @@ public final class PartoutProviderRuntime: Sendable {
             is_daemon: false,
             starts_immediately: false,
             cache_dir: nil,
-            min_data_count_delta: options.minDataCountDelta
+            min_data_count_delta: UInt64(minDataCountDelta ?? .zero)
         )
         let result = profileJSON.withCString { profile in
             withUnsafePointer(to: &bindings) { bindingsPtr in

--- a/Tests/PartoutCoreTests/SerializationTests.swift
+++ b/Tests/PartoutCoreTests/SerializationTests.swift
@@ -53,13 +53,11 @@ struct SerializationTests {
 
         let options = TunnelControllerOptions(
             dnsFallbackServers: ["1.1.1.1", "2606:4700:4700::1111"],
-            logsSnapshots: true,
-            minDataCountDelta: 4_096
+            logsSnapshots: true
         )
         let decodedOptions = try decodeEncoded(options, as: TunnelControllerOptions.self)
         #expect(decodedOptions.dnsFallbackServers == options.dnsFallbackServers)
         #expect(decodedOptions.logsSnapshots == options.logsSnapshots)
-        #expect(decodedOptions.minDataCountDelta == options.minDataCountDelta)
     }
 
     // MARK: - Custom codable

--- a/cross/android/io/partout/NativeTunnelControllerJNI.kt
+++ b/cross/android/io/partout/NativeTunnelControllerJNI.kt
@@ -11,8 +11,8 @@ Three layers are involved in this:
 - NativeTunnelController.swift (+ tun_android.c)
 
 Where:
-- PartoutVpnServiceRuntime owns PartoutTunnelController and forwards its JNI ref to Engine.start()
-- The engine sets up the Swift/C NativeTunnelController with the JNI ref
+- PartoutVpnServiceRuntime owns PartoutTunnelController and forwards its JNI ref to PartoutWrapper
+- PartoutWrapper sets up the Swift/C NativeTunnelController with the JNI ref
 - On setup, NativeTunnelController sets itself (via C) as the PartoutTunnelController delegate
 - When needed, NativeTunnelController calls PartoutTunnelController methods via JNI
 - When needed, PartoutTunnelController calls NativeTunnelController methods via the JNI delegate

--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -14,6 +14,7 @@ import android.os.Looper
 import android.os.Message
 import android.os.Messenger
 import android.util.Log
+import io.partout.abi.PartoutException
 import io.partout.models.TaggedProfile
 import io.partout.models.TunnelControllerOptions
 import io.partout.models.TunnelSnapshot
@@ -28,14 +29,15 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 
 class PartoutVpnServiceRuntime(
     private val logTag: String,
     private val jniLogTag: String,
     val service: VpnService,
-    private val engine: Engine,
-    private val options: TunnelControllerOptions
+    private val wrapper: PartoutWrapperProtocol,
+    private val engine: Engine
 ): TunnelControllerDelegate {
     // Execute actions in serial queue
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -47,10 +49,7 @@ class PartoutVpnServiceRuntime(
     private var controller: PartoutTunnelController? = null
 
     // Deliver snapshots with mutex
-    private val snapshotEmitter = SnapshotEmitter(
-        if (options.logsSnapshots) logTag else null,
-        service
-    )
+    private val snapshotEmitter = SnapshotEmitter(logTag, service)
 
     init {
         serviceScope.launch {
@@ -116,8 +115,20 @@ class PartoutVpnServiceRuntime(
         // Stop current tunnel if running
         stopTunnel()
 
+        val startOptions = runCatching {
+            engine.prepareStart(intent, profileJSON)
+        }.getOrElse {
+            it.throwIfCancellation()
+            Log.e(logTag, "Unable to prepare VPN daemon", it)
+            stopService()
+            return@launchCommand
+        }
+
         // Observe snapshots during start attempt
-        snapshotEmitter.accept(profileId)
+        snapshotEmitter.accept(
+            profileId,
+            startOptions.controllerOptions.logsSnapshots
+        )
 
         isRunning = true
         activeProfileId = profileId
@@ -128,9 +139,20 @@ class PartoutVpnServiceRuntime(
                 service,
                 serviceScope,
                 this,
-                options
+                startOptions.controllerOptions
             )
-            engine.start(intent, newController, profileJSON)
+            val code = withContext(Dispatchers.IO) {
+                wrapper.partoutInit(logTag, startOptions.logsPrivateData)
+                wrapper.partoutDaemonStart(
+                    profileJSON,
+                    service.cacheDir.absolutePath,
+                    newController,
+                    startOptions.minDataCountDelta
+                )
+            }
+            if (code != 0) {
+                throw PartoutException(code, null)
+            }
             // Does not throw from now
             Log.i(logTag, "Started VPN daemon")
             controller = newController
@@ -188,7 +210,9 @@ class PartoutVpnServiceRuntime(
         }
         Log.i(logTag, "Stopping VPN daemon")
         runCatching {
-            engine.stop()
+            withContext(Dispatchers.IO) {
+                wrapper.partoutDaemonStop()
+            }
         }.onFailure {
             Log.e(logTag, "Unable to stop VPN daemon", it)
         }
@@ -230,17 +254,19 @@ class PartoutVpnServiceRuntime(
 
     //region Snapshots
     private class SnapshotEmitter(
-        private val logTag: String?,
+        private val logTag: String,
         private val service: Service
     ) {
         private val lock = Any()
         private var isAccepting = false
+        private var logsSnapshots = false
         private var activeProfileId: String? = null
         @Volatile private var latestSnapshot: TunnelSnapshot? = null
 
-        fun accept(profileId: String) {
+        fun accept(profileId: String, logsSnapshots: Boolean) {
             synchronized(lock) {
                 isAccepting = true
+                this.logsSnapshots = logsSnapshots
                 activeProfileId = profileId
                 latestSnapshot = null
             }
@@ -249,6 +275,7 @@ class PartoutVpnServiceRuntime(
         fun shutdown() {
             synchronized(lock) {
                 isAccepting = false
+                logsSnapshots = false
                 activeProfileId = null
             }
         }
@@ -270,6 +297,7 @@ class PartoutVpnServiceRuntime(
                 broadcast(finalSnapshot)
             }
             isAccepting = false
+            logsSnapshots = false
             activeProfileId = null
         }
 
@@ -300,8 +328,8 @@ class PartoutVpnServiceRuntime(
         }
 
         private fun logIfNeeded(message: String) {
-            logTag?.let {
-                Log.d(it, message)
+            if (logsSnapshots) {
+                Log.d(logTag, message)
             }
         }
 
@@ -388,9 +416,14 @@ class PartoutVpnServiceRuntime(
     //endregion
 
     //region Engine
+    data class StartOptions(
+        val logsPrivateData: Boolean,
+        val minDataCountDelta: Long,
+        val controllerOptions: TunnelControllerOptions
+    )
+
     interface Engine {
-        suspend fun start(intent: Intent?, controller: NativeTunnelControllerJNI, profileJSON: String)
-        suspend fun stop()
+        suspend fun prepareStart(intent: Intent?, profileJSON: String): StartOptions
         suspend fun readLastProfile(): String
         suspend fun writeLastProfile(json: String)
         suspend fun deleteLastProfile(id: String)

--- a/cross/android/io/partout/PartoutWrapper.kt
+++ b/cross/android/io/partout/PartoutWrapper.kt
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package io.partout
+
+import io.partout.abi.PartoutResult
+import io.partout.models.TaggedProfile
+import kotlinx.serialization.json.Json
+
+interface PartoutWrapperProtocol {
+    fun partoutInit(tag: String, logsPrivateData: Boolean)
+    fun partoutVersion(): String
+    fun partoutImportProfile(
+        text: String,
+        name: String?
+    ): String?
+    fun partoutDaemonStart(
+        profile: String,
+        cacheDir: String,
+        controller: NativeTunnelControllerJNI,
+        minDataCountDelta: Long
+    ): Int
+    fun partoutDaemonStop()
+}
+
+class PartoutWrapper(
+    libraryName: String
+): PartoutWrapperProtocol {
+    init {
+        runCatching {
+            // Name of the NDK .so without "lib" prefix or ".so"
+            System.loadLibrary(libraryName)
+        }.onFailure {
+            it.printStackTrace()
+            error("Unable to load Partout JNI wrapper")
+        }.getOrNull()
+    }
+
+    //region Convenience overloads
+    suspend fun importProfile(text: String, name: String?): TaggedProfile {
+        val result = runCatching {
+            PartoutResult.await { completion ->
+                val json = partoutImportProfile(text, name)
+                val code = if (json != null) 0 else -1
+                completion.onComplete(code, json)
+            }
+        }.getOrThrow()
+        val profileJSON = result.json
+        if (profileJSON == null) {
+            error("partoutImportProfile() succeeded without payload")
+        }
+        return json.decodeFromString<TaggedProfile>(profileJSON)
+    }
+    //endregion
+
+    //region ABI
+    override external fun partoutInit(tag: String, logsPrivateData: Boolean)
+    override external fun partoutVersion(): String
+    override external fun partoutImportProfile(
+        text: String,
+        name: String?
+    ): String?
+    override external fun partoutDaemonStart(
+        profile: String,
+        cacheDir: String,
+        controller: NativeTunnelControllerJNI,
+        minDataCountDelta: Long
+    ): Int
+    override external fun partoutDaemonStop()
+    //endregion
+
+    companion object {
+        private val json = Json {
+            ignoreUnknownKeys = true
+        }
+    }
+}

--- a/cross/android/io/partout/models/TunnelControllerOptions.kt
+++ b/cross/android/io/partout/models/TunnelControllerOptions.kt
@@ -33,7 +33,6 @@ import kotlinx.serialization.Contextual
  *
  * @param dnsFallbackServers 
  * @param logsSnapshots 
- * @param minDataCountDelta 
  */
 @Serializable
 
@@ -43,10 +42,7 @@ data class TunnelControllerOptions (
     val dnsFallbackServers: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "logsSnapshots")
-    val logsSnapshots: kotlin.Boolean,
-
-    @SerialName(value = "minDataCountDelta")
-    val minDataCountDelta: kotlin.Long
+    val logsSnapshots: kotlin.Boolean
 
 ) {
 

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -1096,12 +1096,9 @@ components:
           type: array
         logsSnapshots:
           type: boolean
-        minDataCountDelta:
-          $ref: "#/components/schemas/UInt64"
       required:
         - dnsFallbackServers
         - logsSnapshots
-        - minDataCountDelta
       type: object
       description: Common options to give to ``TunnelController``.
     TunnelRemoteInfoWrapper:

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -602,6 +602,7 @@ fn addCSources(module: *std.Build.Module, use_openvpn: bool, use_wireguard: bool
     module.addCSourceFiles(.{
         .files = &.{
             "src/partout.c",
+            "src/partout_jni.c",
         },
         .flags = c_flags,
     });

--- a/zig/src/files.cmake
+++ b/zig/src/files.cmake
@@ -146,6 +146,7 @@ src/openvpn/c/mss_fix.c
 src/openvpn/c/pkt_proc.c
 src/openvpn/c/test/openvpn_crypto_mock.c
 src/partout.c
+src/partout_jni.c
 src/wireguard/c/backend.c
 src/wireguard/c/key.c
 src/wireguard/c/x25519.c

--- a/zig/src/partout_jni.c
+++ b/zig/src/partout_jni.c
@@ -127,4 +127,6 @@ void daemon_bindings_free(partout_daemon_bindings *b) {
     }
     PP_JNI_DETACH(env);
 }
+#else
+typedef int partout_jni_disabled;
 #endif

--- a/zig/src/partout_jni.c
+++ b/zig/src/partout_jni.c
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Davide De Rosa
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include "portable/conditionals.h"
+
+#if PARTOUT_ANDROID
+#include <stdlib.h>
+#include <android/log.h>
+#include "portable/common.h"
+#include "partout.h"
+
+#define PARTOUT_JNI_CB(e, c) PARTOUT_CB(abi_completion_proxy, abi_handler_create(e, c))
+static void daemon_bindings_free(partout_daemon_bindings *b);
+
+static void android_logger(int level, const char *message) {
+    int android_level = 0;
+    switch (level) {
+        case PartoutLogLevelDebug:
+            android_level = ANDROID_LOG_VERBOSE;
+            break;
+        case PartoutLogLevelInfo:
+            android_level = ANDROID_LOG_DEBUG;
+            break;
+        case PartoutLogLevelNotice:
+            android_level = ANDROID_LOG_INFO;
+            break;
+        case PartoutLogLevelError:
+            android_level = ANDROID_LOG_WARN;
+            break;
+        case PartoutLogLevelFault:
+            android_level = ANDROID_LOG_FATAL;
+            break;
+    }
+    __android_log_print(android_level, "Partout", "%s", message);
+}
+
+JNIEXPORT void JNICALL
+Java_io_partout_PartoutWrapper_partoutInit(
+        JNIEnv *env,
+        jobject thiz,
+        jstring tag,
+        jboolean logs_private_data
+) {
+    (void)thiz;
+    partout_init_args args = { 0 };
+    const char *cTag = (*env)->GetStringUTFChars(env, tag, NULL);
+    args.logs_private_data = logs_private_data;
+    args.logger = android_logger;
+    partout_init(&args);
+    (*env)->ReleaseStringUTFChars(env, tag, cTag);
+}
+
+JNIEXPORT jstring JNICALL
+Java_io_partout_PartoutWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
+    (void)thiz;
+    jstring jmsg = (*env)->NewStringUTF(env, partout_version());
+    return jmsg;
+}
+
+JNIEXPORT jstring JNICALL
+Java_io_partout_PartoutWrapper_partoutImportProfile(
+        JNIEnv *env,
+        jobject thiz,
+        jstring text,
+        jstring name
+) {
+    (void)thiz;
+    const char *cText = (*env)->GetStringUTFChars(env, text, NULL);
+    const char *cName = name ? (*env)->GetStringUTFChars(env, name, NULL) : NULL;
+    char *json = partout_import_profile(cText, cName);
+    (*env)->ReleaseStringUTFChars(env, text, cText);
+    if (cName) (*env)->ReleaseStringUTFChars(env, name, cName);
+
+    jstring jJSON = json ? (*env)->NewStringUTF(env, json) : NULL;
+    free(json);
+    return jJSON;
+}
+
+JNIEXPORT jint JNICALL
+Java_io_partout_PartoutWrapper_partoutDaemonStart(
+        JNIEnv *env,
+        jobject thiz,
+        jstring profile,
+        jstring cacheDir,
+        jobject controller,
+        jlong minDataCountDelta
+) {
+    (void) thiz;
+    const char *cProfile = (*env)->GetStringUTFChars(env, profile, NULL);
+    const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
+
+    partout_daemon_bindings bindings = {0};
+    bindings.controller = (*env)->NewGlobalRef(env, controller);
+    bindings.release = daemon_bindings_free;
+
+    partout_daemon_start_args args = {0};
+    args.profile = cProfile;
+    args.options.is_daemon = false;
+    args.options.cache_dir = cCacheDir;
+    args.options.min_data_count_delta = minDataCountDelta;
+    args.bindings = &bindings;
+    const jint result = partout_daemon_start(&args);
+
+    (*env)->ReleaseStringUTFChars(env, profile, cProfile);
+    (*env)->ReleaseStringUTFChars(env, cacheDir, cCacheDir);
+    return result;
+}
+
+JNIEXPORT void JNICALL
+Java_io_partout_PartoutWrapper_partoutDaemonStop(
+        JNIEnv *env,
+        jobject thiz
+) {
+    (void)env;
+    (void)thiz;
+    partout_daemon_stop();
+}
+
+void daemon_bindings_free(partout_daemon_bindings *b) {
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
+    if (b->controller) {
+        (*env)->DeleteGlobalRef(env, b->controller);
+        b->controller = NULL;
+    }
+    PP_JNI_DETACH(env);
+}
+#endif


### PR DESCRIPTION
Embedding the JNI wrapper allows the runtime to be more self-contained. Consumers won't have to interact with C code.

Make minDataCountDelta a daemon option because the native tunnel controllers don't handle that logic, only Zig does.