### PR TITLE
NE: Let managers rely on external storage

### DIFF
--- a/Sources/PartoutCore/Misc/Keychain.swift
+++ b/Sources/PartoutCore/Misc/Keychain.swift
@@ -7,6 +7,12 @@
 // Service -> Where
 // Account -> Account
 
+/// Extra fields of keychain entries.
+public enum KeychainMetadata {
+    case label(String)
+    case comment(String)
+}
+
 /// Defines keychain access and modification.
 public protocol Keychain: Sendable {
 
@@ -17,11 +23,11 @@ public protocol Keychain: Sendable {
 
      - Parameter password: The password to set.
      - Parameter username: The username to set the password for.
-     - Parameter label: An optional label.
+     - Parameter metadata: Optional metadata.
      - Returns: The reference to the password.
      **/
     @discardableResult
-    func set(password: String, for username: String, label: String?) throws -> Data
+    func set(password: String, for username: String, metadata: [KeychainMetadata]?) throws -> Data
 
     /**
      Removes a password.

--- a/Sources/PartoutCore/Profile/Profile.swift
+++ b/Sources/PartoutCore/Profile/Profile.swift
@@ -189,6 +189,19 @@ extension Profile {
     }
 }
 
+// MARK: - Events
+
+/// Represents events emitted from a profile source.
+public enum ProfilesEvent: Sendable {
+    public enum Change: Sendable {
+        case upsert(Profile)
+        case remove(Profile.ID)
+    }
+
+    case snapshot([Profile])
+    case changes([Change])
+}
+
 // MARK: - Logging
 
 extension Profile {

--- a/Sources/PartoutCore/Profile/Profile.swift
+++ b/Sources/PartoutCore/Profile/Profile.swift
@@ -192,6 +192,8 @@ extension Profile {
 // MARK: - Events
 
 /// Represents events emitted from a profile source.
+///
+/// A source must emit a ``snapshot(_:)`` before emitting incremental ``changes(_:)``.
 public enum ProfilesEvent: Sendable {
     public enum Change: Sendable {
         case upsert(Profile)

--- a/Sources/PartoutOS/Apple/AppleKeychain.swift
+++ b/Sources/PartoutOS/Apple/AppleKeychain.swift
@@ -180,13 +180,10 @@ public final class AppleKeychain: Keychain {
         switch status {
         case errSecSuccess:
             break
-
         case errSecUserCanceled:
             throw PartoutError(.operationCancelled)
-
         case errSecItemNotFound:
-            throw PartoutError(.keychainItemNotFound)
-
+            return []
         default:
             pp_log(ctx, .core, .error, "allPasswordReferences(), keychain status is \(status)")
             throw PartoutError(.keychainItemNotFound, status)

--- a/Sources/PartoutOS/Apple/AppleKeychain.swift
+++ b/Sources/PartoutOS/Apple/AppleKeychain.swift
@@ -21,7 +21,11 @@ public final class AppleKeychain: Keychain {
     }
 
     @discardableResult
-    public func set(password: String, for username: String, label: String? = nil) throws -> Data {
+    public func set(
+        password: String,
+        for username: String,
+        metadata: [KeychainMetadata]? = nil
+    ) throws -> Data {
         var existingReference: Data?
         do {
             let reference = try passwordReference(for: username)
@@ -57,9 +61,7 @@ public final class AppleKeychain: Keychain {
 
             var attributes: [String: Any] = [:]
             attributes[kSecValueData as String] = password.data(using: .utf8)
-            if let label {
-                attributes[kSecAttrLabel as String] = label
-            }
+            metadata.map { attributes.apply($0) }
 
             let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
             guard status == errSecSuccess else {
@@ -73,11 +75,11 @@ public final class AppleKeychain: Keychain {
             var query: [String: Any] = [:]
             setScope(query: &query)
             query[kSecClass as String] = kSecClassGenericPassword
-            query[kSecAttrLabel as String] = label
             query[kSecAttrAccount as String] = username
             query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
             query[kSecValueData as String] = password.data(using: .utf8)
             query[kSecReturnPersistentRef as String] = true
+            metadata.map { query.apply($0) }
 
             var ref: CFTypeRef?
             let status = SecItemAdd(query as CFDictionary, &ref)
@@ -245,6 +247,19 @@ private extension AppleKeychain {
             #if os(macOS)
             query[kSecUseDataProtectionKeychain as String] = true
             #endif
+        }
+    }
+}
+
+private extension Dictionary where Key == String, Value == Any {
+    mutating func apply(_ metadata: [KeychainMetadata]) {
+        for entry in metadata ?? [] {
+            switch entry {
+            case .label(let label):
+                self[kSecAttrLabel as String] = label
+            case .comment(let comment):
+                self[kSecAttrComment as String] = comment
+            }
         }
     }
 }

--- a/Sources/PartoutOS/Apple/AppleKeychain.swift
+++ b/Sources/PartoutOS/Apple/AppleKeychain.swift
@@ -27,14 +27,10 @@ public final class AppleKeychain: Keychain {
         metadata: [KeychainMetadata]? = nil
     ) throws -> Data {
         var existingReference: Data?
+        let currentPassword: String?
         do {
             let reference = try passwordReference(for: username)
-            let currentPassword = try self.password(forReference: reference)
-
-            // return existing reference if content has not changed
-            guard password != currentPassword else {
-                return reference
-            }
+            currentPassword = try self.password(forReference: reference)
 
             // keep going
             existingReference = reference
@@ -48,6 +44,7 @@ public final class AppleKeychain: Keychain {
             }
 
             // otherwise, no pre-existing password
+            currentPassword = nil
         } catch {
 
             // IMPORTANT: rethrow any other unknown error (leave this code explicit)
@@ -60,7 +57,9 @@ public final class AppleKeychain: Keychain {
             query[kSecValuePersistentRef as String] = existingReference
 
             var attributes: [String: Any] = [:]
-            attributes[kSecValueData as String] = password.data(using: .utf8)
+            if password != currentPassword {
+                attributes[kSecValueData as String] = password.data(using: .utf8)
+            }
             metadata.map { attributes.apply($0) }
 
             let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)

--- a/Sources/PartoutOS/Apple/AppleKeychain.swift
+++ b/Sources/PartoutOS/Apple/AppleKeychain.swift
@@ -252,7 +252,7 @@ private extension AppleKeychain {
 
 private extension Dictionary where Key == String, Value == Any {
     mutating func apply(_ metadata: [KeychainMetadata]) {
-        for entry in metadata ?? [] {
+        for entry in metadata {
             switch entry {
             case .label(let label):
                 self[kSecAttrLabel as String] = label

--- a/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
@@ -17,6 +17,8 @@ public actor LegacyNETunnelStrategy {
 
     private let coder: NEProtocolCoder
 
+    private let preferences: NETunnelPreferences
+
     private let options: Set<Option>
 
     private nonisolated let managersSubject: CurrentValueStream<[Profile.ID: NETunnelProviderManager]>
@@ -36,10 +38,25 @@ public actor LegacyNETunnelStrategy {
         coder: NEProtocolCoder,
 //        options: Set<Option> = []
     ) {
+        self.init(
+            ctx,
+            bundleIdentifier: bundleIdentifier,
+            coder: coder,
+            preferences: .live
+        )
+    }
+
+    init(
+        _ ctx: PartoutLoggerContext,
+        bundleIdentifier: String,
+        coder: NEProtocolCoder,
+        preferences: NETunnelPreferences
+    ) {
         pp_log(ctx, .os, .info, "LegacyNETunnelStrategy.init()")
         self.ctx = ctx
         self.bundleIdentifier = bundleIdentifier
         self.coder = coder
+        self.preferences = preferences
 //        self.options = options
         options = []
         managersSubject = CurrentValueStream([:])
@@ -105,7 +122,7 @@ extension LegacyNETunnelStrategy: TunnelObservableStrategy {
               manager.connection.status.asTunnelStatus != .inactive else {
             return nil
         }
-        try await manager.loadFromPreferences()
+        try await preferences.load(manager)
         guard let session = manager.connection as? NETunnelProviderSession else {
             return nil
         }
@@ -208,7 +225,7 @@ extension LegacyNETunnelStrategy: NETunnelManagerRepository {
         guard let manager = allManagers[profileId] else {
             return
         }
-        try await manager.removeFromPreferences()
+        try await preferences.remove(manager)
         allManagers.removeValue(forKey: profileId)
         try? coder.removeProfile(withId: profileId)
     }
@@ -313,11 +330,11 @@ private extension LegacyNETunnelStrategy {
 
         let manager = managerBlock()
         let pendingSaveTask = PendingSaveTask(task: Task { @Sendable in
-            try await manager.loadFromPreferences()
+            try await preferences.load(manager)
             try Task.checkCancellation()
             block(manager)
             try Task.checkCancellation()
-            try await manager.saveToPreferences()
+            try await preferences.save(manager)
         })
         self.pendingSaveTask = pendingSaveTask
 
@@ -415,19 +432,21 @@ private extension LegacyNETunnelStrategy {
     func reloadAllManagers() async throws {
         var removedManagers = allManagers
 
-        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-        allManagers = managers.reduce(into: [:]) {
-            guard $1.tunnelBundleIdentifier == bundleIdentifier else {
-                $1.removeFromPreferences()
-                return
+        let loadedManagers = try await preferences.loadAll()
+        var managers: [Profile.ID: NETunnelProviderManager] = [:]
+        for manager in loadedManagers {
+            guard manager.tunnelBundleIdentifier == bundleIdentifier else {
+                try? await preferences.remove(manager)
+                continue
             }
-            guard let profileId = $1.tunnelProtocol?.profileId else {
-                $1.removeFromPreferences()
-                return
+            guard let profileId = manager.tunnelProtocol?.profileId else {
+                try? await preferences.remove(manager)
+                continue
             }
-            $0[profileId] = $1
+            managers[profileId] = manager
             removedManagers.removeValue(forKey: profileId)
         }
+        allManagers = managers
 
         // clean up coder data of removed managers
         removedManagers.forEach {

--- a/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
@@ -543,9 +543,6 @@ private extension NEVPNConnection {
     }
 }
 
-extension NETunnelProviderManager: @retroactive @unchecked Sendable {
-}
-
 private extension NETunnelProviderManager {
     var asSnapshot: TunnelSnapshot? {
         guard let profileId else {

--- a/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
@@ -36,6 +36,7 @@ public actor LegacyNETunnelStrategy {
         coder: NEProtocolCoder,
 //        options: Set<Option> = []
     ) {
+        pp_log(ctx, .os, .info, "LegacyNETunnelStrategy.init()")
         self.ctx = ctx
         self.bundleIdentifier = bundleIdentifier
         self.coder = coder

--- a/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/LegacyNETunnelStrategy.swift
@@ -1,0 +1,583 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+@preconcurrency import NetworkExtension
+
+/// A tunnel strategy based on `NETunnelProviderManager`.
+@available(*, deprecated, renamed: "NETunnelStrategy")
+public actor LegacyNETunnelStrategy {
+    public enum Option: Sendable {
+        case multiple
+    }
+
+    private let ctx: PartoutLoggerContext
+
+    private let bundleIdentifier: String
+
+    private let coder: NEProtocolCoder
+
+    private let options: Set<Option>
+
+    private nonisolated let managersSubject: CurrentValueStream<[Profile.ID: NETunnelProviderManager]>
+
+    private var allManagers: [Profile.ID: NETunnelProviderManager] {
+        didSet {
+            managersSubject.send(allManagers)
+        }
+    }
+
+    private var pendingSaveTask: PendingSaveTask?
+
+    // TODO: #218/passepartout, support .multiple option after implementing in PTP
+    public init(
+        _ ctx: PartoutLoggerContext,
+        bundleIdentifier: String,
+        coder: NEProtocolCoder,
+//        options: Set<Option> = []
+    ) {
+        self.ctx = ctx
+        self.bundleIdentifier = bundleIdentifier
+        self.coder = coder
+//        self.options = options
+        options = []
+        managersSubject = CurrentValueStream([:])
+        allManagers = [:]
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onVPNConfigurationChange),
+            name: .NEVPNConfigurationChange,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onVPNStatus),
+            name: .NEVPNStatusDidChange,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}
+
+// MARK: - TunnelObservableStrategy
+
+extension LegacyNETunnelStrategy: TunnelObservableStrategy {
+    public func prepare(purge: Bool) async throws {
+        try await reloadAllManagers()
+        if purge {
+            await coder.purge(managers: Array(allManagers.values))
+        }
+    }
+
+    public func install(_ profile: Profile, connect: Bool, options: Sendable?) async throws {
+        if connect, !self.options.contains(.multiple) {
+            await disconnectCurrentManagers()
+        }
+        let nsOptions = options as? [String: NSObject]
+        try await save(profile, forConnecting: connect, options: nsOptions)
+    }
+
+    public func uninstall(profileId: Profile.ID) async throws {
+        try await remove(profileId: profileId)
+    }
+
+    public func disconnect(from profileId: Profile.ID) async throws {
+        guard let manager = allManagers[profileId] else {
+            return
+        }
+        try await saveAtomically(manager) {
+            $0.isOnDemandEnabled = false
+        }
+        // XXX: Mitigate races where the on-demand flag, despite saveToPreferences(),
+        // is not disabled yet, thus causing the tunnel to reconnect
+        try await Task.sleep(for: .milliseconds(200))
+        manager.connection.stopVPNTunnel()
+        await manager.connection.waitForDisconnection()
+    }
+
+    public func sendMessage(_ message: Data, to profileId: Profile.ID) async throws -> Data? {
+        guard let manager = allManagers[profileId],
+              manager.connection.status.asTunnelStatus != .inactive else {
+            return nil
+        }
+        try await manager.loadFromPreferences()
+        guard let session = manager.connection as? NETunnelProviderSession else {
+            return nil
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            do {
+                try session.sendProviderMessage(message) { response in
+                    continuation.resume(returning: response)
+                }
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    public nonisolated var didUpdateActiveProfiles: AsyncStream<[Profile.ID: TunnelSnapshot]> {
+        let stream = activeProfilesStream
+        return AsyncStream { [weak self] continuation in
+            let task = Task { [weak self] in
+                for await activeProfiles in stream {
+                    guard let self else {
+                        continuation.finish()
+                        return
+                    }
+                    guard !Task.isCancelled else {
+                        pp_log(ctx, .os, .debug, "Cancelled NETunnelStrategy.didUpdateActiveProfiles")
+                        break
+                    }
+                    pp_log(ctx, .os, .debug, "NETunnelStrategy.activeProfiles -> \(activeProfiles.values.description)")
+                    continuation.yield(activeProfiles)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+}
+
+// MARK: - NETunnelManagerRepository
+
+extension LegacyNETunnelStrategy: NETunnelManagerRepository {
+    public func fetch() async throws -> [NETunnelProviderManager] {
+        try await reloadAllManagers()
+        let managers = Array(allManagers.values)
+        await coder.purge(managers: managers)
+        return managers
+    }
+
+    public func save<O>(_ profile: Profile, forConnecting: Bool, options: O?) async throws {
+        profile.log(.os, .notice, withPreamble: "Encoded profile:")
+
+        let proto = try coder.protocolConfiguration(from: profile)
+
+        // store custom data on the side
+        proto.profileId = profile.id
+
+        let manager: NETunnelProviderManager
+        do {
+            manager = try await saveAtomically(profile.id) {
+                $0.localizedDescription = profile.name
+                $0.protocolConfiguration = proto
+
+                let shouldEnableOnDemand: Bool
+                if profile.isInteractive {
+                    shouldEnableOnDemand = false
+                } else if let onDemandModule = profile.firstModule(ofType: OnDemandModule.self, ifActive: true) {
+                    let rules = onDemandModule.neRules(self.ctx)
+                    if !rules.isEmpty {
+                        $0.onDemandRules = rules
+                    } else {
+                        $0.onDemandRules = [NEOnDemandRuleConnect()]
+                    }
+                    shouldEnableOnDemand = true
+                } else {
+                    shouldEnableOnDemand = false
+                }
+
+                // do not alter these two flags unless connecting explicitly
+                $0.isEnabled = forConnecting || $0.isEnabled
+                $0.isOnDemandEnabled = (forConnecting || $0.isOnDemandEnabled) && shouldEnableOnDemand
+            }
+        } catch {
+
+            // revert adds, retain updates
+            if allManagers[profile.id] == nil {
+                try? coder.removeProfile(withId: profile.id)
+            }
+
+            throw error
+        }
+
+        if forConnecting {
+            let options = options as? [String: NSObject]
+            try manager.connection.startVPNTunnel(options: options)
+        }
+    }
+
+    public func remove(profileId: Profile.ID) async throws {
+        guard let manager = allManagers[profileId] else {
+            return
+        }
+        try await manager.removeFromPreferences()
+        allManagers.removeValue(forKey: profileId)
+        try? coder.removeProfile(withId: profileId)
+    }
+
+    public nonisolated func profile(from manager: NETunnelProviderManager) throws -> Profile {
+        guard let proto = manager.tunnelProtocol else {
+            throw PartoutError(.decoding)
+        }
+        return try coder.profile(from: proto)
+    }
+
+    public nonisolated var managersStream: AsyncStream<[Profile.ID: NETunnelProviderManager]> {
+        let stream = managersSubject.subscribe().dropFirst()
+        return AsyncStream { [weak self] continuation in
+            let task = Task { [weak self] in
+                for await value in stream {
+                    guard let self else {
+                        continuation.finish()
+                        return
+                    }
+                    guard !Task.isCancelled else {
+                        pp_log(self.ctx, .os, .debug, "Cancelled NETunnelStrategy.managersStream")
+                        break
+                    }
+                    continuation.yield(value)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+}
+
+// MARK: - Notifications
+
+private extension LegacyNETunnelStrategy {
+
+    @objc
+    nonisolated func onVPNConfigurationChange(_ notification: Notification) {
+        guard let manager = notification.object as? NETunnelProviderManager,
+              manager.tunnelBundleIdentifier == bundleIdentifier,
+              let profileId = manager.tunnelProtocol?.profileId else {
+            return
+        }
+
+        pp_log(ctx, .os, .debug, "NEVPNConfigurationChange(\(profileId)): \(notification)")
+        Task {
+            do {
+                try await reloadAllManagers()
+            } catch {
+                pp_log(ctx, .os, .error, "Unable to reload managers: \(error)")
+            }
+        }
+    }
+
+    @objc
+    nonisolated func onVPNStatus(_ notification: Notification) {
+        guard let connection = notification.object as? NETunnelProviderSession,
+              let manager = connection.manager as? NETunnelProviderManager,
+              manager.tunnelBundleIdentifier == bundleIdentifier,
+              let profileId = manager.tunnelProtocol?.profileId else {
+            return
+        }
+
+//        pp_log(ctx, .os, .debug, "NEVPNStatusDidChange: \(notification)")
+        pp_log(ctx, .os, .debug, "NEVPNStatus(\(profileId)) -> \(connection.status.rawValue)")
+        Task {
+            await updateCurrentManagersIfNeeded(with: manager, profileId: profileId)
+        }
+    }
+}
+
+// MARK: - Concurrency
+
+private extension LegacyNETunnelStrategy {
+    func saveAtomically(
+        _ profileId: Profile.ID,
+        block: @escaping @Sendable (NETunnelProviderManager) -> Void
+    ) async throws -> NETunnelProviderManager {
+        try await saveAtomically(
+            self.allManagers[profileId] ?? NETunnelProviderManager(),
+            block: block
+        )
+    }
+
+    @discardableResult
+    func saveAtomically(
+        _ managerBlock: @escaping @autoclosure () -> NETunnelProviderManager,
+        block: @escaping @Sendable (NETunnelProviderManager) -> Void
+    ) async throws -> NETunnelProviderManager {
+        while let pendingSaveTask {
+            do {
+                try await pendingSaveTask.task.value
+                clearPendingSaveTask(pendingSaveTask)
+            } catch {
+                clearPendingSaveTask(pendingSaveTask)
+                throw error
+            }
+        }
+
+        let manager = managerBlock()
+        let pendingSaveTask = PendingSaveTask(task: Task { @Sendable in
+            try await manager.loadFromPreferences()
+            try Task.checkCancellation()
+            block(manager)
+            try Task.checkCancellation()
+            try await manager.saveToPreferences()
+        })
+        self.pendingSaveTask = pendingSaveTask
+
+        do {
+            try await pendingSaveTask.task.value
+            clearPendingSaveTask(pendingSaveTask)
+        } catch {
+            clearPendingSaveTask(pendingSaveTask)
+            throw error
+        }
+        return manager
+    }
+
+    func clearPendingSaveTask(_ pendingSaveTask: PendingSaveTask) {
+        guard self.pendingSaveTask?.id == pendingSaveTask.id else {
+            return
+        }
+        self.pendingSaveTask = nil
+    }
+
+    func disconnectCurrentManagers() async {
+        await withTaskGroup(of: Void.self) { group in
+            allManagers.forEach { pair in
+                let status = pair.value.connection.status.asTunnelStatus
+                guard status != .inactive || pair.value.isOnDemandEnabled == true else {
+                    return
+                }
+                group.addTask { [weak self] in
+                    guard let self else {
+                        return
+                    }
+                    pp_log(ctx, .os, .notice, "Disconnect from \(pair.key)...")
+                    do {
+                        try await disconnect(from: pair.key)
+                    } catch {
+                        pp_log(ctx, .os, .error, "Unable to disconnect from \(pair.key): \(error)")
+                    }
+                    pp_log(ctx, .os, .notice, "Disconnection of \(pair.key) complete!")
+                }
+            }
+        }
+    }
+}
+
+private struct PendingSaveTask: Sendable {
+    let id = UniqueID()
+
+    let task: Task<Void, Error>
+}
+
+// MARK: - Active managers
+
+private extension LegacyNETunnelStrategy {
+    nonisolated var activeProfilesStream: AsyncStream<[Profile.ID: TunnelSnapshot]> {
+        let stream = managersSubject.subscribe()
+        let mappedStream: AsyncStream<[Profile.ID: TunnelSnapshot]>
+
+        if options.contains(.multiple) {
+            mappedStream = stream
+                .map {
+                    // active managers are those ranked > 0
+                    $0.filter {
+                        $0.value.rank > 0
+                    }
+                    .compactMapValues(\.asSnapshot)
+                }
+        } else {
+            mappedStream = stream
+                .map {
+                    // active manager is the max ranked
+                    let maxRank = $0.max {
+                        $0.value.rank < $1.value.rank
+                    }?.value.rank ?? 0
+
+                    // if max rank is 0, no manager is active
+                    guard maxRank > 0 else {
+                        return [:]
+                    }
+
+                    // return the max ranked manager
+                    let filtered = $0.filter {
+                        $0.value.rank == maxRank
+                    }
+                    // There might be a moment where 2 managers may be enabled at the same
+                    // time, e.g., while switching from one to another one. We should
+                    // tolerate this scenario.
+                    assert(filtered.count <= 2, "Max ranked manager must be at most two")
+                    return filtered.compactMapValues(\.asSnapshot)
+                }
+        }
+
+        return mappedStream.removeDuplicates()
+    }
+
+    func reloadAllManagers() async throws {
+        var removedManagers = allManagers
+
+        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+        allManagers = managers.reduce(into: [:]) {
+            guard $1.tunnelBundleIdentifier == bundleIdentifier else {
+                $1.removeFromPreferences()
+                return
+            }
+            guard let profileId = $1.tunnelProtocol?.profileId else {
+                $1.removeFromPreferences()
+                return
+            }
+            $0[profileId] = $1
+            removedManagers.removeValue(forKey: profileId)
+        }
+
+        // clean up coder data of removed managers
+        removedManagers.forEach {
+            try? coder.removeProfile(withId: $0.key)
+        }
+
+        logManagers()
+    }
+
+    func updateCurrentManagersIfNeeded(with manager: NETunnelProviderManager, profileId: Profile.ID) {
+
+        // deletion
+        if allManagers.keys.contains(profileId), manager.connection.status == .invalid {
+            allManagers.removeValue(forKey: profileId)
+        }
+        // update
+        else {
+            allManagers[profileId] = manager
+        }
+    }
+
+    func logManagers() {
+        if !allManagers.isEmpty {
+            pp_log(ctx, .os, .debug, "NETunnelStrategy.allManagers:")
+        } else {
+            pp_log(ctx, .os, .debug, "NETunnelStrategy.allManagers: none")
+        }
+        allManagers.values.forEach {
+            guard let profileId = $0.tunnelProtocol?.profileId else {
+                return
+            }
+            pp_log(ctx, .os, .debug, "\t\($0.localizedDescription ?? "")(\(profileId)): isEnabled=\($0.isEnabled), isOnDemandEnabled=\($0.isOnDemandEnabled), status=\($0.connection.status), rank=\($0.rank)")
+        }
+    }
+}
+
+private extension NETunnelProviderManager {
+    var rank: Int {
+#if os(iOS) || os(tvOS)
+        // only one profile at a time is enabled on iOS/tvOS
+        if isEnabled {
+            return isOnDemandEnabled ? .max : .max - 1
+        }
+#endif
+        if ![.disconnected, .invalid].contains(connection.status) {
+            return 2
+        }
+        if isOnDemandEnabled {
+            return 1
+        }
+        return 0
+    }
+}
+
+// MARK: - Profile ID
+
+private enum CustomProviderKey: String {
+    case profileId
+
+    var key: String {
+        "CustomProviderKey.\(rawValue)"
+    }
+}
+
+private extension NETunnelProviderManager {
+    var profileId: Profile.ID? {
+        tunnelProtocol?.profileId
+    }
+}
+
+private extension NETunnelProviderProtocol {
+    var profileId: UniqueID? {
+        get {
+            guard let uuidString = providerConfiguration?[CustomProviderKey.profileId.key] as? String else {
+                return nil
+            }
+            return UniqueID(uuidString: uuidString)
+        }
+        set {
+            var cfg = providerConfiguration ?? [:]
+            cfg[CustomProviderKey.profileId.key] = newValue?.uuidString
+            providerConfiguration = cfg
+        }
+    }
+}
+
+private extension NETunnelProviderManager {
+    var tunnelProtocol: NETunnelProviderProtocol? {
+        protocolConfiguration as? NETunnelProviderProtocol
+    }
+
+    var tunnelBundleIdentifier: String? {
+        tunnelProtocol?.providerBundleIdentifier
+    }
+}
+
+// MARK: - Helpers
+
+private extension NEVPNConnection {
+    func waitForDisconnection() async {
+        if status == .disconnected {
+            return
+        }
+        for await notification in NotificationCenter.default.notifications(named: .NEVPNStatusDidChange) {
+            guard let connection = notification.object as? NETunnelProviderSession,
+                  connection === self else {
+                continue
+            }
+            if [.disconnected, .invalid].contains(connection.status) {
+                return
+            }
+        }
+    }
+}
+
+extension NETunnelProviderManager: @retroactive @unchecked Sendable {
+}
+
+private extension NETunnelProviderManager {
+    var asSnapshot: TunnelSnapshot? {
+        guard let profileId else {
+            return nil
+        }
+        let status = connection.status.asTunnelStatus
+        let isEnabled = isEnabled && (isOnDemandEnabled || status != .inactive)
+        return TunnelSnapshot(
+            id: profileId,
+            isEnabled: isEnabled,
+            status: status,
+            onDemand: isEnabled && isOnDemandEnabled
+        )
+    }
+}
+
+private extension NEVPNStatus {
+    var asTunnelStatus: TunnelStatus {
+        switch self {
+        case .connecting, .reasserting:
+            return .activating
+
+        case .connected:
+            return .active
+
+        case .disconnecting:
+            return .deactivating
+
+        case .disconnected, .invalid:
+            return .inactive
+
+        @unknown default:
+            return .inactive
+        }
+    }
+}

--- a/Sources/PartoutOS/AppleNE/App/NETunnelManagerRepository.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelManagerRepository.swift
@@ -5,6 +5,7 @@
 import NetworkExtension
 
 /// Offers an API to manage the installed set of NETunnelProviderManager.
+@available(*, deprecated, message: "Used by LegacyNETunnelStrategy")
 public protocol NETunnelManagerRepository: Sendable {
     func fetch() async throws -> [NETunnelProviderManager]
 

--- a/Sources/PartoutOS/AppleNE/App/NETunnelPreferences.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelPreferences.swift
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+@preconcurrency import NetworkExtension
+
+/// The Network Extension preferences operations used by tunnel strategies.
+///
+/// Keeping these operations behind a value makes strategy behavior testable
+/// without reading or mutating the host's actual VPN preferences.
+struct NETunnelPreferences: @unchecked Sendable {
+    let loadAll: @Sendable () async throws -> [NETunnelProviderManager]
+
+    let load: @Sendable (NETunnelProviderManager) async throws -> Void
+
+    let save: @Sendable (NETunnelProviderManager) async throws -> Void
+
+    let remove: @Sendable (NETunnelProviderManager) async throws -> Void
+}
+
+extension NETunnelPreferences {
+    static let live = NETunnelPreferences(
+        loadAll: {
+            try await NETunnelProviderManager.loadAllFromPreferences()
+        },
+        load: {
+            try await $0.loadFromPreferences()
+        },
+        save: {
+            try await $0.saveToPreferences()
+        },
+        remove: {
+            try await $0.removeFromPreferences()
+        }
+    )
+}

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -534,7 +534,7 @@ private extension NETunnelStrategy {
             allManagers.removeValue(forKey: profileId)
         }
         // Update
-        else {
+        else if allManagers.keys.contains(profileId) {
             allManagers[profileId] = manager
         }
     }

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -543,6 +543,9 @@ private extension NETunnelStrategy {
     }
 
     func updateCurrentManagersIfNeeded(with manager: NETunnelProviderManager, profileId: Profile.ID) {
+        // IMPORTANT: It must be a tracked manager. We might receive notifications
+        // from a manager with the same profile ID but owned by a different user.
+        guard manager === allManagers[profileId] else { return }
         // Deletion
         if manager.connection.status == .invalid {
             allManagers.removeValue(forKey: profileId)

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -15,6 +15,8 @@ public actor NETunnelStrategy {
 
     private let bundleIdentifier: String
 
+    private let source: AsyncStream<ProfilesEvent>
+
     private let coder: NEProtocolCoder
 
     private let options: Set<Option>
@@ -31,7 +33,7 @@ public actor NETunnelStrategy {
 
     private var sourceTask: Task<Void, Never>?
 
-    private var pendingSaveTask: PendingSaveTask?
+    private var mutationTail: Task<Void, Never>?
 
     // TODO: #218/passepartout, support .multiple option after implementing in PTP
     public init(
@@ -45,6 +47,7 @@ public actor NETunnelStrategy {
         pp_log(ctx, .os, .info, "NETunnelStrategy.init()")
         self.ctx = ctx
         self.bundleIdentifier = bundleIdentifier
+        self.source = source
         self.coder = coder
 //        self.options = options
         self.fingerprint = fingerprint
@@ -58,15 +61,10 @@ public actor NETunnelStrategy {
             name: .NEVPNStatusDidChange,
             object: nil
         )
-
-        sourceTask = Task { [weak self] in
-            for await event in source {
-                await self?.onSourceEvent(event)
-            }
-        }
     }
 
     deinit {
+        sourceTask?.cancel()
         NotificationCenter.default.removeObserver(self)
     }
 }
@@ -75,42 +73,50 @@ public actor NETunnelStrategy {
 
 extension NETunnelStrategy: TunnelObservableStrategy {
     public func prepare(purge: Bool) async throws {
-        allManagers = try await reloadAllManagers()
+        guard sourceTask == nil else {
+            return
+        }
+        let source = self.source
+        sourceTask = Task { [weak self] in
+            for await event in source {
+                guard let self else { return }
+                await self.onSourceEvent(event)
+            }
+        }
     }
 
     public func install(_ profile: Profile, connect: Bool, options: Sendable?) async throws {
-        if connect, !self.options.contains(.multiple) {
-            await disconnectCurrentManagers()
+        try await withMutation { strategy in
+            if connect, !strategy.options.contains(.multiple) {
+                await strategy.disconnectCurrentManagers()
+            }
+            let nsOptions = options as? [String: NSObject]
+            try await strategy.performSave(profile, forConnecting: connect, options: nsOptions)
         }
-        let nsOptions = options as? [String: NSObject]
-        try await save(profile, forConnecting: connect, options: nsOptions)
     }
 
     public func uninstall(profileId: Profile.ID) async throws {
-        try await remove(profileId: profileId)
+        try await withMutation { strategy in
+            try await strategy.performRemove(profileId: profileId)
+        }
     }
 
     public func disconnect(from profileId: Profile.ID) async throws {
-        guard let manager = allManagers[profileId] else {
-            return
+        try await withMutation { strategy in
+            try await strategy.performDisconnect(from: profileId)
         }
-        try await saveAtomically(manager) {
-            $0.isOnDemandEnabled = false
-        }
-        // XXX: Mitigate races where the on-demand flag, despite saveToPreferences(),
-        // is not disabled yet, thus causing the tunnel to reconnect
-        try await Task.sleep(for: .milliseconds(200))
-        manager.connection.stopVPNTunnel()
-        await manager.connection.waitForDisconnection()
     }
 
     public func sendMessage(_ message: Data, to profileId: Profile.ID) async throws -> Data? {
-        guard let manager = allManagers[profileId],
-              manager.connection.status.asTunnelStatus != .inactive else {
-            return nil
+        let session = try await withMutation { strategy in
+            guard let manager = strategy.allManagers[profileId],
+                  manager.connection.status.asTunnelStatus != .inactive else {
+                return SendableProviderSession(nil)
+            }
+            try await manager.loadFromPreferences()
+            return SendableProviderSession(manager.connection as? NETunnelProviderSession)
         }
-        try await manager.loadFromPreferences()
-        guard let session = manager.connection as? NETunnelProviderSession else {
+        guard let session = session.value else {
             return nil
         }
         return try await withCheckedThrowingContinuation { continuation in
@@ -153,6 +159,25 @@ extension NETunnelStrategy: TunnelObservableStrategy {
 
 extension NETunnelStrategy {
     public func save(_ profile: Profile, forConnecting: Bool, options: [String: NSObject]?) async throws {
+        let options = SendableTunnelOptions(options)
+        try await withMutation { strategy in
+            try await strategy.performSave(
+                profile,
+                forConnecting: forConnecting,
+                options: options.value
+            )
+        }
+    }
+
+    public func remove(profileId: Profile.ID) async throws {
+        try await withMutation { strategy in
+            try await strategy.performRemove(profileId: profileId)
+        }
+    }
+}
+
+private extension NETunnelStrategy {
+    func performSave(_ profile: Profile, forConnecting: Bool, options: [String: NSObject]?) async throws {
         profile.log(.os, .notice, withPreamble: "Encoded profile:")
 
         let proto = try coder.protocolConfiguration(from: profile)
@@ -161,7 +186,7 @@ extension NETunnelStrategy {
         proto.profileId = profile.id
         proto.fingerprint = fingerprint(profile)
 
-        let manager = try await saveAtomically(profile.id) {
+        let manager = try await saveManager(profile.id) {
             $0.localizedDescription = profile.name
             $0.protocolConfiguration = proto
 
@@ -194,7 +219,7 @@ extension NETunnelStrategy {
         }
     }
 
-    public func remove(profileId: Profile.ID) async throws {
+    func performRemove(profileId: Profile.ID) async throws {
         guard let manager = allManagers[profileId] else {
             return
         }
@@ -207,18 +232,29 @@ extension NETunnelStrategy {
 
 private extension NETunnelStrategy {
     func onSourceEvent(_ event: ProfilesEvent) async {
+        do {
+            try await withMutation { strategy in
+                await strategy.performSourceEvent(event)
+            }
+        } catch is CancellationError {
+            pp_log(ctx, .os, .debug, "Cancelled source event")
+        } catch {
+            pp_log(ctx, .os, .error, "Unable to process source event: \(error)")
+        }
+    }
+
+    func performSourceEvent(_ event: ProfilesEvent) async {
         switch event {
         case .snapshot(let profiles):
-            await onSourceSnapshot(profiles)
+            await performSourceSnapshot(profiles)
         case .changes(let changes):
             for change in changes {
-                await onSourceChange(change)
+                await performSourceChange(change)
             }
         }
     }
 
-    // FIXME: ###, This is kind of okay because it runs in the background. Doing save() while this is still ongoing, however, runs interleaved and may interfere with data integrity.
-    func onSourceSnapshot(_ profiles: [Profile]) async {
+    func performSourceSnapshot(_ profiles: [Profile]) async {
         pp_log(ctx, .os, .debug, "Reconcile source snapshot: \(profiles.map(\.id))")
         var managers: [Profile.ID: NETunnelProviderManager]
         do {
@@ -228,80 +264,53 @@ private extension NETunnelStrategy {
             return
         }
 
-        // Copy to decouple
-        let ctx = self.ctx
-
-        // Clean up managers to begin with
-        let profileIds = profiles.map(\.id)
-        await withTaskGroup { group in
-            for pair in managers {
-                let manager = pair.value
-                // Delete managers without ID
-                guard let profileId = manager.profileId else {
-                    group.addTask {
-                        do {
-                            pp_log(ctx, .os, .info, "Removing externally deleted manager (unknown)...")
-                            try await manager.removeFromPreferences()
-                            managers.removeValue(forKey: pair.key)
-                        } catch {
-                            pp_log(ctx, .os, .error, "Unable to remove unknown manager: \(error)")
-                        }
-                    }
-                    continue
-                }
-                // Delete managers not backed by source
-                guard profileIds.contains(profileId) else {
-                    group.addTask {
-                        do {
-                            pp_log(ctx, .os, .info, "Removing externally deleted manager (\(profileId))...")
-                            try await manager.removeFromPreferences()
-                            managers.removeValue(forKey: pair.key)
-                        } catch {
-                            pp_log(ctx, .os, .error, "Unable to remove manager \(profileId): \(error)")
-                        }
-                    }
-                    continue
-                }
+        // Remove managers that are no longer backed by the source.
+        let profileIds = Set(profiles.map(\.id))
+        let staleManagers = managers.filter { !profileIds.contains($0.key) }
+        for (profileId, manager) in staleManagers {
+            do {
+                pp_log(ctx, .os, .info, "Removing externally deleted manager (\(profileId))...")
+                try await manager.removeFromPreferences()
+                managers.removeValue(forKey: profileId)
+            } catch {
+                pp_log(ctx, .os, .error, "Unable to remove manager \(profileId): \(error)")
             }
         }
 
-        // New saves are enqueued AFTER this task
+        // Publish retained managers before saving so updates reuse them.
+        allManagers = managers
+
         pp_log(ctx, .os, .info, "Saving \(profiles.count) profiles...")
         let startDate = Date()
         var actuallySaved = 0
-        await withTaskGroup { group in
-            for profile in profiles {
-                // If the profile is associated with a manager, ensure that
-                // it truly requires an update by comparing fingerprints
-                if let manager = managers[profile.id], let fp = manager.fingerprint {
-                    guard fp != fingerprint(profile) else {
-                        pp_log(ctx, .os, .debug, "Manager \(profile.id) is up-to-date (fingerprint matches)")
-                        actuallySaved += 1
-                        continue
-                    }
+        for profile in profiles {
+            // If the profile is associated with a manager, ensure that
+            // it truly requires an update by comparing fingerprints.
+            if let manager = managers[profile.id], let fp = manager.fingerprint {
+                guard fp != fingerprint(profile) else {
+                    pp_log(ctx, .os, .debug, "Manager \(profile.id) is up-to-date (fingerprint matches)")
+                    actuallySaved += 1
+                    continue
                 }
-                pp_log(ctx, .os, .info, "Manager \(profile.id) requires update (fingerprint differs)")
-                group.addTask {
-                    // Updating manager.fingerprint will prevent further reconciliations
-                    do {
-                        try await self.save(profile, forConnecting: false, options: [:])
-                        actuallySaved += 1
-                    } catch {
-                        pp_log(ctx, .os, .error, "Unable to save profile \(profile.id): \(error)")
-                    }
-                }
+            }
+            pp_log(ctx, .os, .info, "Manager \(profile.id) requires update (fingerprint differs)")
+            do {
+                try await performSave(profile, forConnecting: false, options: [:])
+                actuallySaved += 1
+            } catch {
+                pp_log(ctx, .os, .error, "Unable to save profile \(profile.id): \(error)")
             }
         }
         let elapsed = -startDate.timeIntervalSinceNow
         pp_log(ctx, .os, .info, "Saved \(actuallySaved)/\(profiles.count) profiles in: \(elapsed)")
     }
 
-    func onSourceChange(_ change: ProfilesEvent.Change) async {
+    func performSourceChange(_ change: ProfilesEvent.Change) async {
         switch change {
         case .upsert(let profile):
             pp_log(ctx, .os, .info, "Source upsert: \(profile.id)")
             do {
-                try await save(
+                try await performSave(
                     profile,
                     forConnecting: false,
                     options: [:]
@@ -312,7 +321,7 @@ private extension NETunnelStrategy {
         case .remove(let profileId):
             pp_log(ctx, .os, .info, "Source remove: \(profileId)")
             do {
-                try await remove(profileId: profileId)
+                try await performRemove(profileId: profileId)
             } catch {
                 pp_log(ctx, .os, .error, "Unable to remove profile \(profileId): \(error)")
             }
@@ -333,8 +342,11 @@ private extension NETunnelStrategy {
         }
 //        pp_log(ctx, .os, .debug, "NEVPNStatusDidChange: \(notification)")
         pp_log(ctx, .os, .debug, "NEVPNStatus(\(profileId)) -> \(connection.status.rawValue)")
-        Task {
-            await updateCurrentManagersIfNeeded(with: manager, profileId: profileId)
+        Task { [weak self] in
+            guard let self else { return }
+            try? await self.withMutation { strategy in
+                strategy.updateCurrentManagersIfNeeded(with: manager, profileId: profileId)
+            }
         }
     }
 }
@@ -342,85 +354,95 @@ private extension NETunnelStrategy {
 // MARK: - Concurrency
 
 private extension NETunnelStrategy {
-    func saveAtomically(
+    func withMutation<T: Sendable>(
+        _ operation: @escaping @Sendable (isolated NETunnelStrategy) async throws -> T
+    ) async throws -> T {
+        try await mutationTask(operation).value
+    }
+
+    func mutationTask<T: Sendable>(
+        _ operation: @escaping @Sendable (isolated NETunnelStrategy) async throws -> T
+    ) -> Task<T, Error> {
+        let previousTask = mutationTail
+        let task = Task { [weak self] in
+            await previousTask?.value
+            try Task.checkCancellation()
+            guard let self else {
+                throw CancellationError()
+            }
+            return try await operation(self)
+        }
+        mutationTail = Task {
+            _ = try? await task.value
+        }
+        return task
+    }
+
+    func saveManager(
         _ profileId: Profile.ID,
         block: @escaping @Sendable (NETunnelProviderManager) -> Void
     ) async throws -> NETunnelProviderManager {
-        try await saveAtomically(
-            self.allManagers[profileId] ?? NETunnelProviderManager(),
-            block: block
-        )
+        try await saveManager(allManagers[profileId] ?? NETunnelProviderManager(), block: block)
     }
 
     @discardableResult
-    func saveAtomically(
-        _ managerBlock: @escaping @autoclosure () -> NETunnelProviderManager,
+    func saveManager(
+        _ manager: NETunnelProviderManager,
         block: @escaping @Sendable (NETunnelProviderManager) -> Void
     ) async throws -> NETunnelProviderManager {
-        while let pendingSaveTask {
-            do {
-                try await pendingSaveTask.task.value
-                clearPendingSaveTask(pendingSaveTask)
-            } catch {
-                clearPendingSaveTask(pendingSaveTask)
-                throw error
-            }
-        }
-
-        let manager = managerBlock()
-        let pendingSaveTask = PendingSaveTask(task: Task { @Sendable in
-            try await manager.loadFromPreferences()
-            try Task.checkCancellation()
-            block(manager)
-            try Task.checkCancellation()
-            try await manager.saveToPreferences()
-        })
-        self.pendingSaveTask = pendingSaveTask
-
-        do {
-            try await pendingSaveTask.task.value
-            clearPendingSaveTask(pendingSaveTask)
-        } catch {
-            clearPendingSaveTask(pendingSaveTask)
-            throw error
-        }
+        try await manager.loadFromPreferences()
+        try Task.checkCancellation()
+        block(manager)
+        try Task.checkCancellation()
+        try await manager.saveToPreferences()
         return manager
     }
 
-    func clearPendingSaveTask(_ pendingSaveTask: PendingSaveTask) {
-        guard self.pendingSaveTask?.id == pendingSaveTask.id else {
+    func performDisconnect(from profileId: Profile.ID) async throws {
+        guard let manager = allManagers[profileId] else {
             return
         }
-        self.pendingSaveTask = nil
+        try await saveManager(manager) {
+            $0.isOnDemandEnabled = false
+        }
+        // XXX: Mitigate races where the on-demand flag, despite saveToPreferences(),
+        // is not disabled yet, thus causing the tunnel to reconnect.
+        try await Task.sleep(for: .milliseconds(200))
+        manager.connection.stopVPNTunnel()
+        await manager.connection.waitForDisconnection()
     }
 
     func disconnectCurrentManagers() async {
-        await withTaskGroup(of: Void.self) { group in
-            allManagers.forEach { pair in
-                let status = pair.value.connection.status.asTunnelStatus
-                guard status != .inactive || pair.value.isOnDemandEnabled == true else {
-                    return
-                }
-                group.addTask { [weak self] in
-                    guard let self else {
-                        return
-                    }
-                    pp_log(ctx, .os, .notice, "Disconnect from \(pair.key)...")
-                    do {
-                        try await disconnect(from: pair.key)
-                    } catch {
-                        pp_log(ctx, .os, .error, "Unable to disconnect from \(pair.key): \(error)")
-                    }
-                    pp_log(ctx, .os, .notice, "Disconnection of \(pair.key) complete!")
-                }
+        let profileIds = allManagers.compactMap { profileId, manager in
+            let status = manager.connection.status.asTunnelStatus
+            return status != .inactive || manager.isOnDemandEnabled ? profileId : nil
+        }
+        for profileId in profileIds {
+            pp_log(ctx, .os, .notice, "Disconnect from \(profileId)...")
+            do {
+                try await performDisconnect(from: profileId)
+            } catch {
+                pp_log(ctx, .os, .error, "Unable to disconnect from \(profileId): \(error)")
             }
+            pp_log(ctx, .os, .notice, "Disconnection of \(profileId) complete!")
         }
     }
 }
 
-private struct PendingSaveTask: Sendable {
-    let id = UniqueID()
-    let task: Task<Void, Error>
+private struct SendableTunnelOptions: @unchecked Sendable {
+    let value: [String: NSObject]?
+
+    init(_ value: [String: NSObject]?) {
+        self.value = value
+    }
+}
+
+private struct SendableProviderSession: @unchecked Sendable {
+    let value: NETunnelProviderSession?
+
+    init(_ value: NETunnelProviderSession?) {
+        self.value = value
+    }
 }
 
 // MARK: - Active managers
@@ -468,32 +490,23 @@ private extension NETunnelStrategy {
     }
 
     func reloadAllManagers() async throws -> [Profile.ID: NETunnelProviderManager] {
-        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-        defer {
-            logManagers()
-        }
-        return await withTaskGroup { group in
-            managers.reduce(into: [:]) { map, manager in
-                guard manager.tunnelBundleIdentifier == bundleIdentifier else {
-                    group.addTask {
-                        try? await manager.removeFromPreferences()
-                    }
-                    return
-                }
-                guard let profileId = manager.tunnelProtocol?.profileId else {
-                    group.addTask {
-                        try? await manager.removeFromPreferences()
-                    }
-                    return
-                }
-                map[profileId] = manager
+        let loadedManagers = try await NETunnelProviderManager.loadAllFromPreferences()
+        var managers: [Profile.ID: NETunnelProviderManager] = [:]
+        for manager in loadedManagers {
+            guard manager.tunnelBundleIdentifier == bundleIdentifier,
+                  let profileId = manager.tunnelProtocol?.profileId else {
+                try? await manager.removeFromPreferences()
+                continue
             }
+            managers[profileId] = manager
         }
+        logManagers(managers)
+        return managers
     }
 
     func updateCurrentManagersIfNeeded(with manager: NETunnelProviderManager, profileId: Profile.ID) {
         // Deletion
-        if allManagers.keys.contains(profileId), manager.connection.status == .invalid {
+        if manager.connection.status == .invalid {
             allManagers.removeValue(forKey: profileId)
         }
         // Update
@@ -502,13 +515,13 @@ private extension NETunnelStrategy {
         }
     }
 
-    func logManagers() {
-        if !allManagers.isEmpty {
+    func logManagers(_ managers: [Profile.ID: NETunnelProviderManager]) {
+        if !managers.isEmpty {
             pp_log(ctx, .os, .debug, "NETunnelStrategy.allManagers:")
         } else {
             pp_log(ctx, .os, .debug, "NETunnelStrategy.allManagers: none")
         }
-        allManagers.values.forEach {
+        managers.values.forEach {
             guard let profileId = $0.tunnelProtocol?.profileId else {
                 return
             }

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -625,9 +625,6 @@ private extension NEVPNConnection {
     }
 }
 
-extension NETunnelProviderManager: @retroactive @unchecked Sendable {
-}
-
 private extension NETunnelProviderManager {
     var asSnapshot: TunnelSnapshot? {
         guard let profileId else {

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -19,6 +19,8 @@ public actor NETunnelStrategy {
 
     private let coder: NEProtocolCoder
 
+    private let preferences: NETunnelPreferences
+
     private let options: Set<Option>
 
     private let fingerprint: @Sendable (Profile) -> String?
@@ -44,11 +46,30 @@ public actor NETunnelStrategy {
 //        options: Set<Option> = []
         fingerprint: @escaping @Sendable (Profile) -> String?
     ) {
+        self.init(
+            ctx,
+            bundleIdentifier: bundleIdentifier,
+            source: source,
+            coder: coder,
+            preferences: .live,
+            fingerprint: fingerprint
+        )
+    }
+
+    init(
+        _ ctx: PartoutLoggerContext,
+        bundleIdentifier: String,
+        source: AsyncStream<ProfilesEvent>,
+        coder: NEProtocolCoder,
+        preferences: NETunnelPreferences,
+        fingerprint: @escaping @Sendable (Profile) -> String?
+    ) {
         pp_log(ctx, .os, .info, "NETunnelStrategy.init()")
         self.ctx = ctx
         self.bundleIdentifier = bundleIdentifier
         self.source = source
         self.coder = coder
+        self.preferences = preferences
 //        self.options = options
         self.fingerprint = fingerprint
         options = []
@@ -113,7 +134,7 @@ extension NETunnelStrategy: TunnelObservableStrategy {
                   manager.connection.status.asTunnelStatus != .inactive else {
                 return SendableProviderSession(nil)
             }
-            try await manager.loadFromPreferences()
+            try await strategy.preferences.load(manager)
             return SendableProviderSession(manager.connection as? NETunnelProviderSession)
         }
         guard let session = session.value else {
@@ -223,7 +244,7 @@ private extension NETunnelStrategy {
         guard let manager = allManagers[profileId] else {
             return
         }
-        try await manager.removeFromPreferences()
+        try await preferences.remove(manager)
         allManagers.removeValue(forKey: profileId)
     }
 }
@@ -270,7 +291,7 @@ private extension NETunnelStrategy {
         for (profileId, manager) in staleManagers {
             do {
                 pp_log(ctx, .os, .info, "Removing externally deleted manager (\(profileId))...")
-                try await manager.removeFromPreferences()
+                try await preferences.remove(manager)
                 managers.removeValue(forKey: profileId)
             } catch {
                 pp_log(ctx, .os, .error, "Unable to remove manager \(profileId): \(error)")
@@ -390,11 +411,11 @@ private extension NETunnelStrategy {
         _ manager: NETunnelProviderManager,
         block: @escaping @Sendable (NETunnelProviderManager) -> Void
     ) async throws -> NETunnelProviderManager {
-        try await manager.loadFromPreferences()
+        try await preferences.load(manager)
         try Task.checkCancellation()
         block(manager)
         try Task.checkCancellation()
-        try await manager.saveToPreferences()
+        try await preferences.save(manager)
         return manager
     }
 
@@ -490,12 +511,12 @@ private extension NETunnelStrategy {
     }
 
     func reloadAllManagers() async throws -> [Profile.ID: NETunnelProviderManager] {
-        let loadedManagers = try await NETunnelProviderManager.loadAllFromPreferences()
+        let loadedManagers = try await preferences.loadAll()
         var managers: [Profile.ID: NETunnelProviderManager] = [:]
         for manager in loadedManagers {
             guard manager.tunnelBundleIdentifier == bundleIdentifier,
                   let profileId = manager.tunnelProtocol?.profileId else {
-                try? await manager.removeFromPreferences()
+                try? await preferences.remove(manager)
                 continue
             }
             managers[profileId] = manager

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -290,8 +290,7 @@ private extension NETunnelStrategy {
         let staleManagers = managers.filter { !profileIds.contains($0.key) }
         for (profileId, manager) in staleManagers {
             do {
-                pp_log(ctx, .os, .info, "Removing externally deleted manager (\(profileId))...")
-                try await preferences.remove(manager)
+                pp_log(ctx, .os, .info, "Ignore manager (unowned id: \(profileId))")
                 managers.removeValue(forKey: profileId)
             } catch {
                 pp_log(ctx, .os, .error, "Unable to remove manager \(profileId): \(error)")
@@ -514,9 +513,12 @@ private extension NETunnelStrategy {
         let loadedManagers = try await preferences.loadAll()
         var managers: [Profile.ID: NETunnelProviderManager] = [:]
         for manager in loadedManagers {
-            guard manager.tunnelBundleIdentifier == bundleIdentifier,
-                  let profileId = manager.tunnelProtocol?.profileId else {
-                try? await preferences.remove(manager)
+            guard manager.tunnelBundleIdentifier == bundleIdentifier else {
+                pp_log(ctx, .os, .info, "Ignore manager (different bundle: \(manager.tunnelBundleIdentifier.debugDescription))")
+                continue
+            }
+            guard let profileId = manager.tunnelProtocol?.profileId else {
+                pp_log(ctx, .os, .info, "Ignore manager (missing id)")
                 continue
             }
             managers[profileId] = manager

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -550,7 +550,7 @@ private extension NETunnelStrategy {
             allManagers.removeValue(forKey: profileId)
         }
         // Update
-        else if allManagers.keys.contains(profileId) {
+        else {
             allManagers[profileId] = manager
         }
     }

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -523,9 +523,17 @@ private extension NETunnelStrategy {
                 pp_log(ctx, .os, .info, "Ignore manager (different bundle: \(manager.tunnelBundleIdentifier.debugDescription))")
                 continue
             }
-            guard let profileId = manager.tunnelProtocol?.profileId else {
+            guard let proto = manager.tunnelProtocol as? NETunnelProviderProtocol else {
+                pp_log(ctx, .os, .info, "Ignore manager (wrong protocol type)")
+                continue
+            }
+            guard let profileId = proto.profileId else {
                 pp_log(ctx, .os, .info, "Discard manager (missing id)")
                 manager.removeFromPreferences(completionHandler: nil)
+                continue
+            }
+            guard coder.owns(proto, for: profileId) else {
+                pp_log(ctx, .os, .info, "Ignore manager (different owner)")
                 continue
             }
             managers[profileId] = manager

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 @preconcurrency import NetworkExtension
+import PartoutCore
 
 /// A tunnel strategy based on `NETunnelProviderManager`.
 public actor NETunnelStrategy {
@@ -18,7 +19,7 @@ public actor NETunnelStrategy {
 
     private let options: Set<Option>
 
-    private let title: @Sendable (Profile) -> String
+    private let fingerprint: @Sendable (Profile) -> String?
 
     private nonisolated let managersSubject: CurrentValueStream<[Profile.ID: NETunnelProviderManager]>
 
@@ -28,37 +29,41 @@ public actor NETunnelStrategy {
         }
     }
 
+    private var sourceTask: Task<Void, Never>?
+
     private var pendingSaveTask: PendingSaveTask?
 
     // TODO: #218/passepartout, support .multiple option after implementing in PTP
     public init(
         _ ctx: PartoutLoggerContext,
         bundleIdentifier: String,
+        source: AsyncStream<ProfilesEvent>,
         coder: NEProtocolCoder,
 //        options: Set<Option> = []
-        title: @escaping @Sendable (Profile) -> String
+        fingerprint: @escaping @Sendable (Profile) -> String?
     ) {
+        pp_log(ctx, .os, .info, "NETunnelStrategy.init()")
         self.ctx = ctx
         self.bundleIdentifier = bundleIdentifier
         self.coder = coder
 //        self.options = options
-        self.title = title
+        self.fingerprint = fingerprint
         options = []
         managersSubject = CurrentValueStream([:])
         allManagers = [:]
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(onVPNConfigurationChange),
-            name: .NEVPNConfigurationChange,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
             selector: #selector(onVPNStatus),
             name: .NEVPNStatusDidChange,
             object: nil
         )
+
+        sourceTask = Task { [weak self] in
+            for await event in source {
+                await self?.onSourceEvent(event)
+            }
+        }
     }
 
     deinit {
@@ -70,10 +75,7 @@ public actor NETunnelStrategy {
 
 extension NETunnelStrategy: TunnelObservableStrategy {
     public func prepare(purge: Bool) async throws {
-        try await reloadAllManagers()
-        if purge {
-            await coder.purge(managers: Array(allManagers.values))
-        }
+        allManagers = try await reloadAllManagers()
     }
 
     public func install(_ profile: Profile, connect: Bool, options: Sendable?) async throws {
@@ -147,61 +149,47 @@ extension NETunnelStrategy: TunnelObservableStrategy {
     }
 }
 
-// MARK: - NETunnelManagerRepository
+// MARK: - CRUD
 
-extension NETunnelStrategy: NETunnelManagerRepository {
-    public func fetch() async throws -> [NETunnelProviderManager] {
-        try await reloadAllManagers()
-        let managers = Array(allManagers.values)
-        await coder.purge(managers: managers)
-        return managers
-    }
-
-    public func save<O>(_ profile: Profile, forConnecting: Bool, options: O?) async throws {
+extension NETunnelStrategy {
+    public func save(_ profile: Profile, forConnecting: Bool, options: [String: NSObject]?) async throws {
         profile.log(.os, .notice, withPreamble: "Encoded profile:")
 
-        let proto = try coder.protocolConfiguration(from: profile, title: title)
+        let proto = try coder.protocolConfiguration(from: profile)
 
-        // store custom data on the side
+        // Store custom data on the side
         proto.profileId = profile.id
+        proto.fingerprint = fingerprint(profile)
 
-        let manager: NETunnelProviderManager
-        do {
-            manager = try await saveAtomically(profile.id) {
-                $0.localizedDescription = profile.name
-                $0.protocolConfiguration = proto
+        let manager = try await saveAtomically(profile.id) {
+            $0.localizedDescription = profile.name
+            $0.protocolConfiguration = proto
 
-                let shouldEnableOnDemand: Bool
-                if profile.isInteractive {
-                    shouldEnableOnDemand = false
-                } else if let onDemandModule = profile.firstModule(ofType: OnDemandModule.self, ifActive: true) {
-                    let rules = onDemandModule.neRules(self.ctx)
-                    if !rules.isEmpty {
-                        $0.onDemandRules = rules
-                    } else {
-                        $0.onDemandRules = [NEOnDemandRuleConnect()]
-                    }
-                    shouldEnableOnDemand = true
+            let shouldEnableOnDemand: Bool
+            if profile.isInteractive {
+                shouldEnableOnDemand = false
+            } else if let onDemandModule = profile.firstModule(ofType: OnDemandModule.self, ifActive: true) {
+                let rules = onDemandModule.neRules(self.ctx)
+                if !rules.isEmpty {
+                    $0.onDemandRules = rules
                 } else {
-                    shouldEnableOnDemand = false
+                    $0.onDemandRules = [NEOnDemandRuleConnect()]
                 }
-
-                // do not alter these two flags unless connecting explicitly
-                $0.isEnabled = forConnecting || $0.isEnabled
-                $0.isOnDemandEnabled = (forConnecting || $0.isOnDemandEnabled) && shouldEnableOnDemand
-            }
-        } catch {
-
-            // revert adds, retain updates
-            if allManagers[profile.id] == nil {
-                try? coder.removeProfile(withId: profile.id)
+                shouldEnableOnDemand = true
+            } else {
+                shouldEnableOnDemand = false
             }
 
-            throw error
+            // Do not alter these two flags unless connecting explicitly
+            $0.isEnabled = forConnecting || $0.isEnabled
+            $0.isOnDemandEnabled = (forConnecting || $0.isOnDemandEnabled) && shouldEnableOnDemand
         }
 
+        // Track the new/updated manager
+        allManagers[profile.id] = manager
+
+        // Initiate a connection if requested
         if forConnecting {
-            let options = options as? [String: NSObject]
             try manager.connection.startVPNTunnel(options: options)
         }
     }
@@ -212,35 +200,121 @@ extension NETunnelStrategy: NETunnelManagerRepository {
         }
         try await manager.removeFromPreferences()
         allManagers.removeValue(forKey: profileId)
-        try? coder.removeProfile(withId: profileId)
     }
+}
 
-    public nonisolated func profile(from manager: NETunnelProviderManager) throws -> Profile {
-        guard let proto = manager.tunnelProtocol else {
-            throw PartoutError(.decoding)
-        }
-        return try coder.profile(from: proto)
-    }
+// MARK: - Source events
 
-    public nonisolated var managersStream: AsyncStream<[Profile.ID: NETunnelProviderManager]> {
-        let stream = managersSubject.subscribe().dropFirst()
-        return AsyncStream { [weak self] continuation in
-            let task = Task { [weak self] in
-                for await value in stream {
-                    guard let self else {
-                        continuation.finish()
-                        return
-                    }
-                    guard !Task.isCancelled else {
-                        pp_log(self.ctx, .os, .debug, "Cancelled NETunnelStrategy.managersStream")
-                        break
-                    }
-                    continuation.yield(value)
-                }
-                continuation.finish()
+private extension NETunnelStrategy {
+    func onSourceEvent(_ event: ProfilesEvent) async {
+        switch event {
+        case .snapshot(let profiles):
+            await onSourceSnapshot(profiles)
+        case .changes(let changes):
+            for change in changes {
+                await onSourceChange(change)
             }
-            continuation.onTermination = { _ in
-                task.cancel()
+        }
+    }
+
+    // FIXME: ###, This is kind of okay because it runs in the background. Doing save() while this is still ongoing, however, runs interleaved and may interfere with data integrity.
+    func onSourceSnapshot(_ profiles: [Profile]) async {
+        pp_log(ctx, .os, .debug, "Reconcile source snapshot: \(profiles.map(\.id))")
+        var managers: [Profile.ID: NETunnelProviderManager]
+        do {
+            managers = try await reloadAllManagers()
+        } catch {
+            pp_log(ctx, .os, .fault, "Unable to reload managers: \(error)")
+            return
+        }
+
+        // Copy to decouple
+        let ctx = self.ctx
+
+        // Clean up managers to begin with
+        let profileIds = profiles.map(\.id)
+        await withTaskGroup { group in
+            for pair in managers {
+                let manager = pair.value
+                // Delete managers without ID
+                guard let profileId = manager.profileId else {
+                    group.addTask {
+                        do {
+                            pp_log(ctx, .os, .info, "Removing externally deleted manager (unknown)...")
+                            try await manager.removeFromPreferences()
+                            managers.removeValue(forKey: pair.key)
+                        } catch {
+                            pp_log(ctx, .os, .error, "Unable to remove unknown manager: \(error)")
+                        }
+                    }
+                    continue
+                }
+                // Delete managers not backed by source
+                guard profileIds.contains(profileId) else {
+                    group.addTask {
+                        do {
+                            pp_log(ctx, .os, .info, "Removing externally deleted manager (\(profileId))...")
+                            try await manager.removeFromPreferences()
+                            managers.removeValue(forKey: pair.key)
+                        } catch {
+                            pp_log(ctx, .os, .error, "Unable to remove manager \(profileId): \(error)")
+                        }
+                    }
+                    continue
+                }
+            }
+        }
+
+        // New saves are enqueued AFTER this task
+        pp_log(ctx, .os, .info, "Saving \(profiles.count) profiles...")
+        let startDate = Date()
+        var actuallySaved = 0
+        await withTaskGroup { group in
+            for profile in profiles {
+                // If the profile is associated with a manager, ensure that
+                // it truly requires an update by comparing fingerprints
+                if let manager = managers[profile.id], let fp = manager.fingerprint {
+                    guard fp != fingerprint(profile) else {
+                        pp_log(ctx, .os, .debug, "Manager \(profile.id) is up-to-date (fingerprint matches)")
+                        actuallySaved += 1
+                        continue
+                    }
+                }
+                pp_log(ctx, .os, .info, "Manager \(profile.id) requires update (fingerprint differs)")
+                group.addTask {
+                    // Updating manager.fingerprint will prevent further reconciliations
+                    do {
+                        try await self.save(profile, forConnecting: false, options: [:])
+                        actuallySaved += 1
+                    } catch {
+                        pp_log(ctx, .os, .error, "Unable to save profile \(profile.id): \(error)")
+                    }
+                }
+            }
+        }
+        let elapsed = -startDate.timeIntervalSinceNow
+        pp_log(ctx, .os, .info, "Saved \(actuallySaved)/\(profiles.count) profiles in: \(elapsed)")
+    }
+
+    func onSourceChange(_ change: ProfilesEvent.Change) async {
+        switch change {
+        case .upsert(let profile):
+            pp_log(ctx, .os, .info, "Source upsert: \(profile.id)")
+            do {
+                try await save(
+                    profile,
+                    forConnecting: false,
+                    options: [:]
+                )
+            } catch {
+                pp_log(ctx, .os, .error, "Unable to save profile \(profile.id): \(error)")
+            }
+        case .remove(let profileId):
+            pp_log(ctx, .os, .info, "Source remove: \(profileId)")
+            do {
+                try await remove(profileId: profileId)
+            } catch {
+                pp_log(ctx, .os, .error, "Unable to remove profile \(profileId): \(error)")
             }
         }
     }
@@ -249,25 +323,6 @@ extension NETunnelStrategy: NETunnelManagerRepository {
 // MARK: - Notifications
 
 private extension NETunnelStrategy {
-
-    @objc
-    nonisolated func onVPNConfigurationChange(_ notification: Notification) {
-        guard let manager = notification.object as? NETunnelProviderManager,
-              manager.tunnelBundleIdentifier == bundleIdentifier,
-              let profileId = manager.tunnelProtocol?.profileId else {
-            return
-        }
-
-        pp_log(ctx, .os, .debug, "NEVPNConfigurationChange(\(profileId)): \(notification)")
-        Task {
-            do {
-                try await reloadAllManagers()
-            } catch {
-                pp_log(ctx, .os, .error, "Unable to reload managers: \(error)")
-            }
-        }
-    }
-
     @objc
     nonisolated func onVPNStatus(_ notification: Notification) {
         guard let connection = notification.object as? NETunnelProviderSession,
@@ -276,7 +331,6 @@ private extension NETunnelStrategy {
               let profileId = manager.tunnelProtocol?.profileId else {
             return
         }
-
 //        pp_log(ctx, .os, .debug, "NEVPNStatusDidChange: \(notification)")
         pp_log(ctx, .os, .debug, "NEVPNStatus(\(profileId)) -> \(connection.status.rawValue)")
         Task {
@@ -366,7 +420,6 @@ private extension NETunnelStrategy {
 
 private struct PendingSaveTask: Sendable {
     let id = UniqueID()
-
     let task: Task<Void, Error>
 }
 
@@ -380,7 +433,7 @@ private extension NETunnelStrategy {
         if options.contains(.multiple) {
             mappedStream = stream
                 .map {
-                    // active managers are those ranked > 0
+                    // Active managers are those ranked > 0
                     $0.filter {
                         $0.value.rank > 0
                     }
@@ -389,17 +442,17 @@ private extension NETunnelStrategy {
         } else {
             mappedStream = stream
                 .map {
-                    // active manager is the max ranked
+                    // Active manager is the max ranked
                     let maxRank = $0.max {
                         $0.value.rank < $1.value.rank
                     }?.value.rank ?? 0
 
-                    // if max rank is 0, no manager is active
+                    // If max rank is 0, no manager is active
                     guard maxRank > 0 else {
                         return [:]
                     }
 
-                    // return the max ranked manager
+                    // Return the max ranked manager
                     let filtered = $0.filter {
                         $0.value.rank == maxRank
                     }
@@ -414,38 +467,36 @@ private extension NETunnelStrategy {
         return mappedStream.removeDuplicates()
     }
 
-    func reloadAllManagers() async throws {
-        var removedManagers = allManagers
-
+    func reloadAllManagers() async throws -> [Profile.ID: NETunnelProviderManager] {
         let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-        allManagers = managers.reduce(into: [:]) {
-            guard $1.tunnelBundleIdentifier == bundleIdentifier else {
-                $1.removeFromPreferences()
-                return
-            }
-            guard let profileId = $1.tunnelProtocol?.profileId else {
-                $1.removeFromPreferences()
-                return
-            }
-            $0[profileId] = $1
-            removedManagers.removeValue(forKey: profileId)
+        defer {
+            logManagers()
         }
-
-        // clean up coder data of removed managers
-        removedManagers.forEach {
-            try? coder.removeProfile(withId: $0.key)
+        return await withTaskGroup { group in
+            managers.reduce(into: [:]) { map, manager in
+                guard manager.tunnelBundleIdentifier == bundleIdentifier else {
+                    group.addTask {
+                        try? await manager.removeFromPreferences()
+                    }
+                    return
+                }
+                guard let profileId = manager.tunnelProtocol?.profileId else {
+                    group.addTask {
+                        try? await manager.removeFromPreferences()
+                    }
+                    return
+                }
+                map[profileId] = manager
+            }
         }
-
-        logManagers()
     }
 
     func updateCurrentManagersIfNeeded(with manager: NETunnelProviderManager, profileId: Profile.ID) {
-
-        // deletion
+        // Deletion
         if allManagers.keys.contains(profileId), manager.connection.status == .invalid {
             allManagers.removeValue(forKey: profileId)
         }
-        // update
+        // Update
         else {
             allManagers[profileId] = manager
         }
@@ -469,7 +520,7 @@ private extension NETunnelStrategy {
 private extension NETunnelProviderManager {
     var rank: Int {
 #if os(iOS) || os(tvOS)
-        // only one profile at a time is enabled on iOS/tvOS
+        // Only one profile at a time is enabled on iOS/tvOS
         if isEnabled {
             return isOnDemandEnabled ? .max : .max - 1
         }
@@ -484,10 +535,11 @@ private extension NETunnelProviderManager {
     }
 }
 
-// MARK: - Profile ID
+// MARK: - Profile metadata
 
 private enum CustomProviderKey: String {
     case profileId
+    case fingerprint
 
     var key: String {
         "CustomProviderKey.\(rawValue)"
@@ -497,6 +549,10 @@ private enum CustomProviderKey: String {
 private extension NETunnelProviderManager {
     var profileId: Profile.ID? {
         tunnelProtocol?.profileId
+    }
+
+    var fingerprint: String? {
+        tunnelProtocol?.fingerprint
     }
 }
 
@@ -511,6 +567,17 @@ private extension NETunnelProviderProtocol {
         set {
             var cfg = providerConfiguration ?? [:]
             cfg[CustomProviderKey.profileId.key] = newValue?.uuidString
+            providerConfiguration = cfg
+        }
+    }
+
+    var fingerprint: String? {
+        get {
+            providerConfiguration?[CustomProviderKey.fingerprint.key] as? String
+        }
+        set {
+            var cfg = providerConfiguration ?? [:]
+            cfg[CustomProviderKey.fingerprint.key] = newValue
             providerConfiguration = cfg
         }
     }
@@ -569,16 +636,12 @@ private extension NEVPNStatus {
         switch self {
         case .connecting, .reasserting:
             return .activating
-
         case .connected:
             return .active
-
         case .disconnecting:
             return .deactivating
-
         case .disconnected, .invalid:
             return .inactive
-
         @unknown default:
             return .inactive
         }

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -287,14 +287,13 @@ private extension NETunnelStrategy {
 
         // Remove managers that are no longer backed by the source.
         let profileIds = Set(profiles.map(\.id))
-        let staleManagers = managers.filter { !profileIds.contains($0.key) }
-        for (profileId, manager) in staleManagers {
-            do {
-                pp_log(ctx, .os, .info, "Ignore manager (unowned id: \(profileId))")
-                managers.removeValue(forKey: profileId)
-            } catch {
-                pp_log(ctx, .os, .error, "Unable to remove manager \(profileId): \(error)")
+        managers = managers.filter {
+            let profileId = $0.key
+            guard profileIds.contains(profileId) else {
+                pp_log(ctx, .os, .debug, "Ignore manager (unowned id: \(profileId))")
+                return false
             }
+            return true
         }
 
         // Publish retained managers before saving so updates reuse them.
@@ -520,20 +519,20 @@ private extension NETunnelStrategy {
         var managers: [Profile.ID: NETunnelProviderManager] = [:]
         for manager in loadedManagers {
             guard manager.tunnelBundleIdentifier == bundleIdentifier else {
-                pp_log(ctx, .os, .info, "Ignore manager (different bundle: \(manager.tunnelBundleIdentifier.debugDescription))")
+                pp_log(ctx, .os, .debug, "Ignore manager (different bundle: \(manager.tunnelBundleIdentifier.debugDescription))")
                 continue
             }
-            guard let proto = manager.tunnelProtocol as? NETunnelProviderProtocol else {
-                pp_log(ctx, .os, .info, "Ignore manager (wrong protocol type)")
+            guard let proto = manager.tunnelProtocol else {
+                pp_log(ctx, .os, .debug, "Ignore manager (wrong protocol type)")
                 continue
             }
             guard let profileId = proto.profileId else {
-                pp_log(ctx, .os, .info, "Discard manager (missing id)")
+                pp_log(ctx, .os, .debug, "Discard manager (missing id)")
                 manager.removeFromPreferences(completionHandler: nil)
                 continue
             }
             guard coder.owns(proto, for: profileId) else {
-                pp_log(ctx, .os, .info, "Ignore manager (different owner)")
+                pp_log(ctx, .os, .debug, "Ignore manager (different owner)")
                 continue
             }
             managers[profileId] = manager

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -516,6 +516,7 @@ private extension NETunnelStrategy {
 
     func reloadAllManagers() async throws -> [Profile.ID: NETunnelProviderManager] {
         let loadedManagers = try await preferences.loadAll()
+        pp_log(ctx, .os, .debug, "All managers (\(loadedManagers.count)): \(loadedManagers.compactMap(\.localizedDescription))")
         var managers: [Profile.ID: NETunnelProviderManager] = [:]
         for manager in loadedManagers {
             guard manager.tunnelBundleIdentifier == bundleIdentifier else {

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -377,7 +377,12 @@ private extension NETunnelStrategy {
     func withMutation<T: Sendable>(
         _ operation: @escaping @Sendable (isolated NETunnelStrategy) async throws -> T
     ) async throws -> T {
-        try await mutationTask(operation).value
+        let task = mutationTask(operation)
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
     func mutationTask<T: Sendable>(

--- a/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/PartoutOS/AppleNE/App/NETunnelStrategy.swift
@@ -518,7 +518,8 @@ private extension NETunnelStrategy {
                 continue
             }
             guard let profileId = manager.tunnelProtocol?.profileId else {
-                pp_log(ctx, .os, .info, "Ignore manager (missing id)")
+                pp_log(ctx, .os, .info, "Discard manager (missing id)")
+                manager.removeFromPreferences(completionHandler: nil)
                 continue
             }
             managers[profileId] = manager

--- a/Sources/PartoutOS/AppleNE/Serialization/KeychainNEProtocolCoder.swift
+++ b/Sources/PartoutOS/AppleNE/Serialization/KeychainNEProtocolCoder.swift
@@ -38,6 +38,20 @@ public struct KeychainNEProtocolCoder: NEProtocolCoder {
         self.legacyOptions = legacyOptions
     }
 
+    public func owns(_ protocolConfiguration: NETunnelProviderProtocol, for profileId: Profile.ID) -> Bool {
+        guard let managerReference = protocolConfiguration.passwordReference else {
+            return false
+        }
+        do {
+            let currentReference = try keychain.passwordReference(
+                for: profileId.uuidString
+            )
+            return managerReference == currentReference
+        } catch {
+            return false
+        }
+    }
+
     public func protocolConfiguration(from profile: Profile) throws -> NETunnelProviderProtocol {
         let passwordReference: Data
 

--- a/Sources/PartoutOS/AppleNE/Serialization/KeychainNEProtocolCoder.swift
+++ b/Sources/PartoutOS/AppleNE/Serialization/KeychainNEProtocolCoder.swift
@@ -6,6 +6,14 @@ import NetworkExtension
 
 /// ``NEProtocolCoder`` encoding to and from a keychain.
 public struct KeychainNEProtocolCoder: NEProtocolCoder {
+    public struct LegacyOptions: Sendable {
+        public let title: @Sendable (Profile) -> String
+
+        public init(title: @escaping @Sendable (Profile) -> String) {
+            self.title = title
+        }
+    }
+
     private let ctx: PartoutLoggerContext
 
     private let tunnelBundleIdentifier: String
@@ -14,21 +22,39 @@ public struct KeychainNEProtocolCoder: NEProtocolCoder {
 
     private let keychain: Keychain
 
-    public init(_ ctx: PartoutLoggerContext, tunnelBundleIdentifier: String, coder: ProfileCoder, keychain: Keychain) {
+    private let legacyOptions: LegacyOptions?
+
+    public init(
+        _ ctx: PartoutLoggerContext,
+        tunnelBundleIdentifier: String,
+        coder: ProfileCoder,
+        keychain: Keychain,
+        legacyOptions: LegacyOptions? = nil
+    ) {
         self.ctx = ctx
         self.tunnelBundleIdentifier = tunnelBundleIdentifier
         self.coder = coder
         self.keychain = keychain
+        self.legacyOptions = legacyOptions
     }
 
-    public func protocolConfiguration(from profile: Profile, title: (Profile) -> String) throws -> NETunnelProviderProtocol {
-        let encoded = try coder.string(fromProfile: profile)
+    public func protocolConfiguration(from profile: Profile) throws -> NETunnelProviderProtocol {
+        let passwordReference: Data
 
-        let passwordReference = try keychain.set(
-            password: encoded,
-            for: profile.id.uuidString,
-            label: title(profile)
-        )
+        // Legacy had side-effect, actively writes to keychain
+        if let legacyOptions {
+            let encoded = try coder.string(fromProfile: profile)
+            passwordReference = try keychain.set(
+                password: encoded,
+                for: profile.id.uuidString,
+                metadata: [
+                    .label(legacyOptions.title(profile))
+                ]
+            )
+        } else {
+            // Going forward, rely on external reference
+            passwordReference = try keychain.passwordReference(for: profile.id.uuidString)
+        }
 
         let proto = NETunnelProviderProtocol()
         proto.providerBundleIdentifier = tunnelBundleIdentifier
@@ -47,48 +73,5 @@ public struct KeychainNEProtocolCoder: NEProtocolCoder {
         }
         let encoded = try keychain.password(forReference: passwordReference)
         return try coder.profile(fromString: encoded)
-    }
-
-    public func removeProfile(withId profileId: Profile.ID) throws {
-        keychain.removePassword(for: profileId.uuidString)
-    }
-
-    public func purge(managers: [NETunnelProviderManager]) async {
-
-        // remove those managers (plus their keychain entry) we cannot decode a profile from
-        var managersToRemove: [NETunnelProviderManager] = []
-        var keychainToRetain: [Data] = []
-        managers.forEach {
-            do {
-                guard let proto = $0.protocolConfiguration as? NETunnelProviderProtocol else {
-                    throw PartoutError(.decoding)
-                }
-                _ = try profile(from: proto)
-                if let item = $0.protocolConfiguration?.passwordReference {
-                    keychainToRetain.append(item)
-                }
-            } catch {
-                pp_log(ctx, .os, .error, "Unable to decode profile, will delete NE manager '\($0.localizedDescription ?? "")': \(error)")
-                managersToRemove.append($0)
-            }
-        }
-        for manager in managersToRemove {
-            if let ref = manager.protocolConfiguration?.passwordReference {
-                keychain.removePassword(forReference: ref)
-            }
-            try? await manager.removeFromPreferences()
-        }
-
-        // remove keychain entries that do not belong to any active manager
-        do {
-            let entries = try keychain.allPasswordReferences()
-            entries.forEach {
-                if !keychainToRetain.contains($0) {
-                    keychain.removePassword(forReference: $0)
-                }
-            }
-        } catch {
-            pp_log(ctx, .os, .error, "Unable to fetch keychain items: \(error)")
-        }
     }
 }

--- a/Sources/PartoutOS/AppleNE/Serialization/NEProtocolCoder.swift
+++ b/Sources/PartoutOS/AppleNE/Serialization/NEProtocolCoder.swift
@@ -9,6 +9,9 @@ public typealias NEProtocolCoder = NEProtocolEncoder & NEProtocolDecoder
 
 /// Encodes a `Profile` for use in Network Extension.
 public protocol NEProtocolEncoder: Sendable {
+    /// Checks ownership of a `NETunnelProviderProtocol` for a given profile.
+    func owns(_ protocolConfiguration: NETunnelProviderProtocol, for profileId: Profile.ID) -> Bool
+
     /// Encodes a `Profile` into a `NETunnelProviderProtocol`.
     /// - Parameters:
     ///   - profile: The profile to encode.

--- a/Sources/PartoutOS/AppleNE/Serialization/NEProtocolCoder.swift
+++ b/Sources/PartoutOS/AppleNE/Serialization/NEProtocolCoder.swift
@@ -9,33 +9,35 @@ public typealias NEProtocolCoder = NEProtocolEncoder & NEProtocolDecoder
 
 /// Encodes a `Profile` for use in Network Extension.
 public protocol NEProtocolEncoder: Sendable {
-
     /// Encodes a `Profile` into a `NETunnelProviderProtocol`.
     /// - Parameters:
     ///   - profile: The profile to encode.
-    ///   - title: The title as function of the profile.
     /// - Returns: A `NETunnelProviderProtocol` for use with `NETunnelProviderManager`.
-    func protocolConfiguration(from profile: Profile, title: (Profile) -> String) throws -> NETunnelProviderProtocol
+    func protocolConfiguration(from profile: Profile) throws -> NETunnelProviderProtocol
 
-    /// Removes a profile from the underlying storage.
-    /// - Parameters:
-    ///   - profileId: The ID of the profile to remove.
+    @available(*, deprecated)
     func removeProfile(withId profileId: Profile.ID) throws
 
-    /// Purges stale data from existing profiles.
-    /// - Parameters:
-    ///   - managers: The list of `NETunnelProviderManager` to review for potentially stale data.
+    @available(*, deprecated)
     func purge(managers: [NETunnelProviderManager]) async
 }
 
 /// Decodes a `Profile` for use in Network Extension.
 public protocol NEProtocolDecoder: Sendable {
-
     /// Decodes a `Profile` from a `NETunnelProviderProtocol`.
     /// - Parameters:
     ///   - protocolConfiguration: The `NETunnelProviderProtocol` to decode.
     /// - Returns: The decoded profile.
     func profile(from protocolConfiguration: NETunnelProviderProtocol) throws -> Profile
+}
+
+@available(*, deprecated)
+extension NEProtocolEncoder {
+    public func removeProfile(withId profileId: Profile.ID) throws {
+    }
+
+    public func purge(managers: [NETunnelProviderManager]) async {
+    }
 }
 
 let NEProtocolCoderServerAddress = "127.0.0.1"

--- a/Sources/PartoutOS/AppleNE/Serialization/ProviderNEProtocolCoder.swift
+++ b/Sources/PartoutOS/AppleNE/Serialization/ProviderNEProtocolCoder.swift
@@ -22,7 +22,7 @@ public struct ProviderNEProtocolCoder: NEProtocolCoder {
         self.coder = coder
     }
 
-    public func protocolConfiguration(from profile: Profile, title: (Profile) -> String) throws -> NETunnelProviderProtocol {
+    public func protocolConfiguration(from profile: Profile) throws -> NETunnelProviderProtocol {
         let encoded = try coder.string(fromProfile: profile)
 
         let proto = NETunnelProviderProtocol()
@@ -41,12 +41,6 @@ public struct ProviderNEProtocolCoder: NEProtocolCoder {
             throw PartoutError(.decoding)
         }
         return try coder.profile(fromString: encoded)
-    }
-
-    public func removeProfile(withId profileId: Profile.ID) throws {
-    }
-
-    public func purge(managers: [NETunnelProviderManager]) {
     }
 }
 

--- a/Sources/PartoutOS/AppleNE/Serialization/ProviderNEProtocolCoder.swift
+++ b/Sources/PartoutOS/AppleNE/Serialization/ProviderNEProtocolCoder.swift
@@ -22,6 +22,11 @@ public struct ProviderNEProtocolCoder: NEProtocolCoder {
         self.coder = coder
     }
 
+    public func owns(_ protocolConfiguration: NETunnelProviderProtocol, for profileId: Profile.ID) -> Bool {
+        // FIXME: ###
+        true
+    }
+
     public func protocolConfiguration(from profile: Profile) throws -> NETunnelProviderProtocol {
         let encoded = try coder.string(fromProfile: profile)
 

--- a/Sources/PartoutOS/AppleNE/Serialization/ProviderNEProtocolCoder.swift
+++ b/Sources/PartoutOS/AppleNE/Serialization/ProviderNEProtocolCoder.swift
@@ -12,19 +12,25 @@ public struct ProviderNEProtocolCoder: NEProtocolCoder {
 
     private let coder: ProfileCoder
 
+    private let uid: Int
+
     public init(
         _ ctx: PartoutLoggerContext,
         tunnelBundleIdentifier: String,
-        coder: ProfileCoder
+        coder: ProfileCoder,
+        uid: Int
     ) {
         self.ctx = ctx
         self.tunnelBundleIdentifier = tunnelBundleIdentifier
         self.coder = coder
+        self.uid = uid
     }
 
     public func owns(_ protocolConfiguration: NETunnelProviderProtocol, for profileId: Profile.ID) -> Bool {
-        // FIXME: ###
-        true
+        // Best-effort, UID was introduced later. Assume owned if UID is missing.
+        guard let cfg = protocolConfiguration.providerConfiguration else { return true }
+        guard let protoUID = cfg[Self.uidKey] as? Int else { return true }
+        return protoUID == uid
     }
 
     public func protocolConfiguration(from profile: Profile) throws -> NETunnelProviderProtocol {
@@ -32,7 +38,10 @@ public struct ProviderNEProtocolCoder: NEProtocolCoder {
 
         let proto = NETunnelProviderProtocol()
         proto.providerBundleIdentifier = tunnelBundleIdentifier
-        proto.providerConfiguration = [Self.providerKey: encoded]
+        proto.providerConfiguration = [
+            Self.profileKey: encoded,
+            Self.uidKey: uid
+        ]
         proto.serverAddress = NEProtocolCoderServerAddress
         proto.disconnectOnSleep = profile.disconnectsOnSleep
 #if !os(tvOS)
@@ -42,7 +51,7 @@ public struct ProviderNEProtocolCoder: NEProtocolCoder {
     }
 
     public func profile(from protocolConfiguration: NETunnelProviderProtocol) throws -> Profile {
-        guard let encoded = protocolConfiguration.providerConfiguration?[Self.providerKey] as? String else {
+        guard let encoded = protocolConfiguration.providerConfiguration?[Self.profileKey] as? String else {
             throw PartoutError(.decoding)
         }
         return try coder.profile(fromString: encoded)
@@ -50,7 +59,6 @@ public struct ProviderNEProtocolCoder: NEProtocolCoder {
 }
 
 extension ProviderNEProtocolCoder {
-    static var providerKey: String {
-        "Profile"
-    }
+    static let profileKey = "Profile"
+    static let uidKey = "UID"
 }

--- a/Tests/PartoutOSTests/Apple/AppleKeychainTests.swift
+++ b/Tests/PartoutOSTests/Apple/AppleKeychainTests.swift
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import Foundation
+import PartoutCore
+import PartoutOS
+import Testing
+
+struct AppleKeychainTests {
+    @Test
+    func givenExistingEntry_whenUpdatingPassword_thenPreservesPersistentReference() throws {
+        let sut = AppleKeychain(.global, group: nil)
+        let username = "AppleKeychainTests.\(UUID().uuidString)"
+        defer {
+            sut.removePassword(for: username)
+        }
+
+        let originalReference = try sut.set(password: "original", for: username)
+        let updatedReference = try sut.set(password: "updated", for: username)
+
+        #expect(updatedReference == originalReference)
+        #expect(try sut.password(forReference: originalReference) == "updated")
+    }
+}

--- a/Tests/PartoutOSTests/AppleNE/NEProtocolCoderTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NEProtocolCoderTests.swift
@@ -45,7 +45,7 @@ struct NEProtocolCoderTests {
 
         let proto = try sut.protocolConfiguration(from: profile)
 
-        #expect(proto.providerConfiguration?[ProviderNEProtocolCoder.providerKey] as? String != nil)
+        #expect(proto.providerConfiguration?[ProviderNEProtocolCoder.profileKey] as? String != nil)
         #expect(proto.passwordReference == nil)
     }
 
@@ -124,7 +124,8 @@ private extension NEProtocolCoderTests {
                 ProviderNEProtocolCoder(
                     .global,
                     tunnelBundleIdentifier: bundleIdentifier,
-                    coder: coder
+                    coder: coder,
+                    uid: 100
                 ),
                 keychain
             )

--- a/Tests/PartoutOSTests/AppleNE/NEProtocolCoderTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NEProtocolCoderTests.swift
@@ -20,7 +20,7 @@ struct NEProtocolCoderTests {
             coder: coder
         )
 
-        let proto = try sut.protocolConfiguration(from: profile, title: \.name)
+        let proto = try sut.protocolConfiguration(from: profile)
         #expect(proto.providerBundleIdentifier == bundleIdentifier)
         #expect(proto.providerConfiguration?[ProviderNEProtocolCoder.providerKey] as? String != nil)
 
@@ -39,7 +39,7 @@ struct NEProtocolCoderTests {
             keychain: MockKeychain()
         )
 
-        let proto = try sut.protocolConfiguration(from: profile, title: \.name)
+        let proto = try sut.protocolConfiguration(from: profile)
         #expect(proto.providerBundleIdentifier == bundleIdentifier)
         #expect(proto.providerConfiguration == nil)
 
@@ -67,7 +67,7 @@ private extension NEProtocolCoderTests {
 }
 
 private final class MockKeychain: Keychain {
-    func set(password: String, for username: String, label: String?) throws -> Data {
+    func set(password: String, for username: String, metadata: [KeychainMetadata]?) throws -> Data {
         guard let reference = password.data(using: .utf8) else {
             throw PartoutError(.encoding)
         }

--- a/Tests/PartoutOSTests/AppleNE/NEProtocolCoderTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NEProtocolCoderTests.swift
@@ -4,47 +4,102 @@
 
 #if canImport(NetworkExtension)
 
+import Foundation
+import NetworkExtension
 @testable import PartoutOS
 import Testing
 
 struct NEProtocolCoderTests {
-    let registry = Registry(withKnown: true)
+    private let registry = Registry(withKnown: true)
 
-    @Test
-    func givenProfile_whenEncodeToProvider_thenDecodes() throws {
+    @Test(arguments: CoderKind.allCases)
+    func roundTripPreservesProfileAndCommonProtocolFields(_ kind: CoderKind) throws {
         let profile = try newProfile()
-        let coder = CodingRegistry(registry: registry)
-        let sut = ProviderNEProtocolCoder(
-            .global,
-            tunnelBundleIdentifier: bundleIdentifier,
-            coder: coder
-        )
+        let (sut, _) = try makeCoder(kind, containing: profile)
 
         let proto = try sut.protocolConfiguration(from: profile)
-        #expect(proto.providerBundleIdentifier == bundleIdentifier)
-        #expect(proto.providerConfiguration?[ProviderNEProtocolCoder.providerKey] as? String != nil)
 
-        let decodedProfile = try sut.profile(from: proto)
-        #expect(decodedProfile == profile)
+        #expect(proto.providerBundleIdentifier == bundleIdentifier)
+        #expect(proto.serverAddress == NEProtocolCoderServerAddress)
+        #expect(proto.disconnectOnSleep)
+#if !os(tvOS)
+        #expect(proto.includeAllNetworks)
+#endif
+        #expect(try sut.profile(from: proto) == profile)
+    }
+
+    @Test(arguments: CoderKind.allCases)
+    func malformedProtocolIsRejected(_ kind: CoderKind) throws {
+        let profile = try newProfile()
+        let (sut, _) = try makeCoder(kind, containing: profile)
+
+        #expect(throws: PartoutError.self) {
+            try sut.profile(from: NETunnelProviderProtocol())
+        }
     }
 
     @Test
-    func givenProfile_whenEncodeToKeychain_thenDecodes() throws {
+    func providerCoderStoresProfileOnlyInProviderConfiguration() throws {
+        let profile = try newProfile()
+        let (sut, _) = try makeCoder(.provider, containing: profile)
+
+        let proto = try sut.protocolConfiguration(from: profile)
+
+        #expect(proto.providerConfiguration?[ProviderNEProtocolCoder.providerKey] as? String != nil)
+        #expect(proto.passwordReference == nil)
+    }
+
+    @Test
+    func currentKeychainCoderUsesExternalReferenceWithoutWriting() throws {
+        let profile = try newProfile()
+        let (sut, keychain) = try makeCoder(.keychain, containing: profile)
+        let expectedReference = keychain.reference(for: profile.id.uuidString)
+
+        let proto = try sut.protocolConfiguration(from: profile)
+
+        #expect(proto.providerConfiguration == nil)
+        #expect(proto.passwordReference == expectedReference)
+        #expect(keychain.setCalls.isEmpty)
+        #expect(keychain.referenceLookups == [profile.id.uuidString])
+    }
+
+    @Test
+    func currentKeychainCoderPropagatesMissingExternalReference() throws {
+        let profile = try newProfile()
+        let sut = KeychainNEProtocolCoder(
+            .global,
+            tunnelBundleIdentifier: bundleIdentifier,
+            coder: CodingRegistry(registry: registry),
+            keychain: MockKeychain()
+        )
+
+        #expect(throws: PartoutError.self) {
+            try sut.protocolConfiguration(from: profile)
+        }
+    }
+
+    @Test
+    func legacyKeychainCoderWritesEncodedProfileWithTitleMetadata() throws {
         let profile = try newProfile()
         let coder = CodingRegistry(registry: registry)
+        let keychain = MockKeychain()
         let sut = KeychainNEProtocolCoder(
             .global,
             tunnelBundleIdentifier: bundleIdentifier,
             coder: coder,
-            keychain: MockKeychain()
+            keychain: keychain,
+            legacyOptions: .init(title: { "VPN: \($0.name)" })
         )
 
         let proto = try sut.protocolConfiguration(from: profile)
-        #expect(proto.providerBundleIdentifier == bundleIdentifier)
-        #expect(proto.providerConfiguration == nil)
+        let call = try #require(keychain.setCalls.first)
 
-        let decodedProfile = try sut.profile(from: proto)
-        #expect(decodedProfile == profile)
+        #expect(keychain.setCalls.count == 1)
+        #expect(call.username == profile.id.uuidString)
+        #expect(try coder.profile(fromString: call.password) == profile)
+        #expect(call.label == "VPN: \(profile.name)")
+        #expect(proto.passwordReference == keychain.reference(for: profile.id.uuidString))
+        #expect(try sut.profile(from: proto) == profile)
     }
 }
 
@@ -55,9 +110,41 @@ private extension NEProtocolCoderTests {
         "com.example.MyTunnel"
     }
 
+    func makeCoder(
+        _ kind: CoderKind,
+        containing profile: Profile
+    ) throws -> (any NEProtocolCoder, MockKeychain) {
+        let coder = CodingRegistry(registry: registry)
+        let encoded = try coder.string(fromProfile: profile)
+        let keychain = MockKeychain(passwords: [profile.id.uuidString: encoded])
+
+        switch kind {
+        case .provider:
+            return (
+                ProviderNEProtocolCoder(
+                    .global,
+                    tunnelBundleIdentifier: bundleIdentifier,
+                    coder: coder
+                ),
+                keychain
+            )
+        case .keychain:
+            return (
+                KeychainNEProtocolCoder(
+                    .global,
+                    tunnelBundleIdentifier: bundleIdentifier,
+                    coder: coder,
+                    keychain: keychain
+                ),
+                keychain
+            )
+        }
+    }
+
     func newProfile() throws -> Profile {
         var builder = Profile.Builder()
         builder.name = "foobar"
+        builder.behavior = ProfileBehavior(disconnectsOnSleep: true, includesAllNetworks: true)
         builder.modules.append(try DNSModule.Builder(servers: ["2.4.2.4"]).build())
         builder.modules.append(try HTTPProxyModule.Builder(address: "1.1.1.1", port: 1080, pacURLString: "http://proxy.pac").build())
         builder.modules.append(IPModule.Builder(ipv4: .init(subnet: try .init("1.2.3.4", 16))).build())
@@ -66,39 +153,103 @@ private extension NEProtocolCoderTests {
     }
 }
 
-private final class MockKeychain: Keychain {
-    func set(password: String, for username: String, metadata: [KeychainMetadata]?) throws -> Data {
-        guard let reference = password.data(using: .utf8) else {
-            throw PartoutError(.encoding)
+enum CoderKind: CaseIterable, CustomTestStringConvertible, Sendable {
+    case provider
+    case keychain
+
+    var testDescription: String {
+        switch self {
+        case .provider: "provider"
+        case .keychain: "keychain"
         }
-        return reference
+    }
+}
+
+private final class MockKeychain: Keychain, @unchecked Sendable {
+    struct SetCall: Sendable {
+        let password: String
+        let username: String
+        let label: String?
+    }
+
+    private let lock = NSLock()
+    private var passwords: [String: String]
+    private var mutableSetCalls: [SetCall] = []
+    private var mutableReferenceLookups: [String] = []
+
+    init(passwords: [String: String] = [:]) {
+        self.passwords = passwords
+    }
+
+    var setCalls: [SetCall] {
+        lock.withLock { mutableSetCalls }
+    }
+
+    var referenceLookups: [String] {
+        lock.withLock { mutableReferenceLookups }
+    }
+
+    func reference(for username: String) -> Data {
+        Data("reference:\(username)".utf8)
+    }
+
+    func set(password: String, for username: String, metadata: [KeychainMetadata]?) throws -> Data {
+        let label = metadata?.compactMap { entry -> String? in
+            guard case .label(let value) = entry else { return nil }
+            return value
+        }.first
+        lock.withLock {
+            passwords[username] = password
+            mutableSetCalls.append(SetCall(password: password, username: username, label: label))
+        }
+        return reference(for: username)
     }
 
     func removePassword(for username: String) -> Bool {
-        fatalError("Unused")
+        lock.withLock { passwords.removeValue(forKey: username) != nil }
     }
 
     func removePassword(forReference reference: Data) -> Bool {
-        fatalError("Unused")
+        guard let username = username(from: reference) else { return false }
+        return removePassword(for: username)
     }
 
     func password(for username: String) throws -> String {
-        fatalError("Unused")
+        try lock.withLock {
+            guard let password = passwords[username] else {
+                throw PartoutError(.keychainItemNotFound)
+            }
+            return password
+        }
     }
 
     func passwordReference(for username: String) throws -> Data {
-        fatalError("Unused")
+        try lock.withLock {
+            guard passwords[username] != nil else {
+                throw PartoutError(.keychainItemNotFound)
+            }
+            mutableReferenceLookups.append(username)
+        }
+        return reference(for: username)
     }
 
     func allPasswordReferences() throws -> [Data] {
-        fatalError("Unused")
+        lock.withLock { passwords.keys.map(reference(for:)) }
     }
 
     func password(forReference reference: Data) throws -> String {
-        guard let string = String(data: reference, encoding: .utf8) else {
+        guard let username = username(from: reference) else {
             throw PartoutError(.decoding)
         }
-        return string
+        return try password(for: username)
+    }
+
+    private func username(from reference: Data) -> String? {
+        guard let value = String(data: reference, encoding: .utf8),
+              value.hasPrefix("reference:") else {
+            return nil
+        }
+        return String(value.dropFirst("reference:".count))
     }
 }
 #endif

--- a/Tests/PartoutOSTests/AppleNE/NETunnelStrategyTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NETunnelStrategyTests.swift
@@ -105,11 +105,9 @@ struct NETunnelStrategySnapshotTests {
         try await strategy.prepare(purge: false)
         try await strategy.prepare(purge: false)
         continuation.yield(.snapshot([matching, changed, missingFingerprint, new]))
-        await store.waitForActionCount(9)
+        await store.waitForActionCount(7)
 
-        await #expect(throws: PreferenceFailure.self) {
-            try await strategy.uninstall(profileId: staleWithFailedRemoval)
-        }
+        try await strategy.uninstall(profileId: staleWithFailedRemoval)
         try await strategy.uninstall(profileId: matching.id)
         continuation.finish()
 
@@ -119,8 +117,8 @@ struct NETunnelStrategySnapshotTests {
         #expect(actions.filter(\.isLoadAll).count == 1)
         #expect(Set(savedIds) == [changed.id, missingFingerprint.id, new.id])
         #expect(!savedIds.contains(matching.id))
-        #expect(removedIds.filter { $0 == stale }.count == 1)
-        #expect(removedIds.filter { $0 == staleWithFailedRemoval }.count == 2)
+        #expect(!removedIds.contains(stale))
+        #expect(!removedIds.contains(staleWithFailedRemoval))
         #expect(removedIds.filter { $0 == matching.id }.count == 1)
     }
 

--- a/Tests/PartoutOSTests/AppleNE/NETunnelStrategyTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NETunnelStrategyTests.swift
@@ -170,7 +170,8 @@ private var protocolCoder: ProviderNEProtocolCoder {
     ProviderNEProtocolCoder(
         .global,
         tunnelBundleIdentifier: bundleIdentifier,
-        coder: CodingRegistry(registry: Registry(withKnown: true))
+        coder: CodingRegistry(registry: Registry(withKnown: true)),
+        uid: 100
     )
 }
 

--- a/Tests/PartoutOSTests/AppleNE/NETunnelStrategyTests.swift
+++ b/Tests/PartoutOSTests/AppleNE/NETunnelStrategyTests.swift
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+#if canImport(NetworkExtension)
+
+import Foundation
+@preconcurrency import NetworkExtension
+@testable import PartoutOS
+import Testing
+
+struct NETunnelStrategyContractTests {
+    @Test(arguments: TunnelStrategyKind.allCases)
+    func saveConfiguresAndPersistsManager(_ kind: TunnelStrategyKind) async throws {
+        let store = MockTunnelPreferences(isEnabledOnLoad: false)
+        let profile = try Profile.Builder(name: "My profile").build()
+        let strategy = makeStrategy(kind, preferences: store.preferences)
+
+        try await strategy.install(profile, connect: false, options: nil)
+
+        let actions = await store.actions
+        let manager = try #require(await store.savedManagers.first)
+        let proto = try #require(manager.protocolConfiguration as? NETunnelProviderProtocol)
+        #expect(actions == [.load(nil), .save(profile.id)])
+        #expect(manager.localizedDescription == profile.name)
+        #expect(proto.providerBundleIdentifier == bundleIdentifier)
+        #expect(proto.profileId == profile.id)
+        #expect(!manager.isEnabled)
+        #expect(!manager.isOnDemandEnabled)
+    }
+
+    @Test(arguments: TunnelStrategyKind.allCases)
+    func unknownProfileOperationsAreNoOps(_ kind: TunnelStrategyKind) async throws {
+        let store = MockTunnelPreferences()
+        let strategy = makeStrategy(kind, preferences: store.preferences)
+        let profileId = Profile.ID()
+
+        try await strategy.uninstall(profileId: profileId)
+        try await strategy.disconnect(from: profileId)
+        let response = try await strategy.sendMessage(Data(), to: profileId)
+
+        #expect(response == nil)
+        #expect(await store.actions.isEmpty)
+    }
+
+    @Test(arguments: TunnelStrategyKind.allCases)
+    func activeProfilesStartsEmpty(_ kind: TunnelStrategyKind) async throws {
+        let strategy = makeStrategy(kind, preferences: MockTunnelPreferences().preferences)
+        var iterator = strategy.didUpdateActiveProfiles.makeAsyncIterator()
+
+        #expect(await iterator.next()?.isEmpty == true)
+    }
+
+    @Test(arguments: TunnelStrategyKind.allCases)
+    func preparedManagerIsPublishedAndCanBeUninstalled(_ kind: TunnelStrategyKind) async throws {
+        let profile = try Profile.Builder(name: "loaded").build()
+        let store = MockTunnelPreferences(
+            managers: [makeManager(profileId: profile.id, fingerprint: profile.name)]
+        )
+        let strategy = try await makePreparedStrategy(
+            kind,
+            profile: profile,
+            store: store
+        )
+
+        try await strategy.uninstall(profileId: profile.id)
+
+        #expect(await store.actions == [.loadAll, .remove(profile.id)])
+    }
+}
+
+struct NETunnelStrategySnapshotTests {
+    @Test
+    func snapshotReconcilesStaleAndChangedManagersAndContinuesAfterFailures() async throws {
+        let matching = try Profile.Builder(name: "matching").build()
+        let changed = try Profile.Builder(name: "changed").build()
+        let missingFingerprint = try Profile.Builder(name: "missing-fingerprint").build()
+        let new = try Profile.Builder(name: "new").build()
+        let stale = Profile.ID()
+        let staleWithFailedRemoval = Profile.ID()
+
+        let store = MockTunnelPreferences(
+            managers: [
+                makeManager(profileId: matching.id, fingerprint: matching.name),
+                makeManager(profileId: changed.id, fingerprint: "old"),
+                makeManager(profileId: missingFingerprint.id, fingerprint: nil),
+                makeManager(profileId: stale, fingerprint: "stale"),
+                makeManager(profileId: staleWithFailedRemoval, fingerprint: "stale-failure")
+            ],
+            saveFailures: [changed.id],
+            removeFailures: [staleWithFailedRemoval]
+        )
+        let (source, continuation) = AsyncStream.makeStream(of: ProfilesEvent.self)
+        let strategy = NETunnelStrategy(
+            .global,
+            bundleIdentifier: bundleIdentifier,
+            source: source,
+            coder: protocolCoder,
+            preferences: store.preferences,
+            fingerprint: {
+                $0.id == missingFingerprint.id ? nil : $0.name
+            }
+        )
+
+        try await strategy.prepare(purge: false)
+        try await strategy.prepare(purge: false)
+        continuation.yield(.snapshot([matching, changed, missingFingerprint, new]))
+        await store.waitForActionCount(9)
+
+        await #expect(throws: PreferenceFailure.self) {
+            try await strategy.uninstall(profileId: staleWithFailedRemoval)
+        }
+        try await strategy.uninstall(profileId: matching.id)
+        continuation.finish()
+
+        let actions = await store.actions
+        let savedIds = actions.compactMap(\.savedProfileId)
+        let removedIds = actions.compactMap(\.removedProfileId)
+        #expect(actions.filter(\.isLoadAll).count == 1)
+        #expect(Set(savedIds) == [changed.id, missingFingerprint.id, new.id])
+        #expect(!savedIds.contains(matching.id))
+        #expect(removedIds.filter { $0 == stale }.count == 1)
+        #expect(removedIds.filter { $0 == staleWithFailedRemoval }.count == 2)
+        #expect(removedIds.filter { $0 == matching.id }.count == 1)
+    }
+
+    @Test
+    func slowSnapshotDelaysFollowingSaveWithoutInterleaving() async throws {
+        let snapshotProfile = try Profile.Builder(name: "snapshot").build()
+        let explicitProfile = try Profile.Builder(name: "explicit").build()
+        let loadAllGate = PreferenceGate()
+        let store = MockTunnelPreferences(loadAllGate: loadAllGate)
+        let (source, continuation) = AsyncStream.makeStream(of: ProfilesEvent.self)
+        let strategy = NETunnelStrategy(
+            .global,
+            bundleIdentifier: bundleIdentifier,
+            source: source,
+            coder: protocolCoder,
+            preferences: store.preferences,
+            fingerprint: { $0.name }
+        )
+
+        try await strategy.prepare(purge: false)
+        continuation.yield(.snapshot([snapshotProfile]))
+        await loadAllGate.waitUntilEntered()
+
+        let saveTask = Task {
+            try await strategy.save(explicitProfile, forConnecting: false, options: nil)
+        }
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(await store.actions == [.loadAll])
+
+        await loadAllGate.open()
+        try await saveTask.value
+        continuation.finish()
+
+        #expect(await store.actions == [
+            .loadAll,
+            .load(nil), .save(snapshotProfile.id),
+            .load(nil), .save(explicitProfile.id)
+        ])
+    }
+}
+
+// MARK: - Strategy factories
+
+private let bundleIdentifier = "com.example.MyTunnel"
+
+private var protocolCoder: ProviderNEProtocolCoder {
+    ProviderNEProtocolCoder(
+        .global,
+        tunnelBundleIdentifier: bundleIdentifier,
+        coder: CodingRegistry(registry: Registry(withKnown: true))
+    )
+}
+
+enum TunnelStrategyKind: CaseIterable, CustomTestStringConvertible, Sendable {
+    case current
+    case legacy
+
+    var testDescription: String {
+        switch self {
+        case .current: "current"
+        case .legacy: "legacy"
+        }
+    }
+}
+
+private func makeStrategy(
+    _ kind: TunnelStrategyKind,
+    preferences: NETunnelPreferences
+) -> any TunnelObservableStrategy {
+    switch kind {
+    case .current:
+        return NETunnelStrategy(
+            .global,
+            bundleIdentifier: bundleIdentifier,
+            source: AsyncStream { $0.finish() },
+            coder: protocolCoder,
+            preferences: preferences,
+            fingerprint: { $0.name }
+        )
+    case .legacy:
+        return LegacyNETunnelStrategy(
+            .global,
+            bundleIdentifier: bundleIdentifier,
+            coder: protocolCoder,
+            preferences: preferences
+        )
+    }
+}
+
+private func makePreparedStrategy(
+    _ kind: TunnelStrategyKind,
+    profile: Profile,
+    store: MockTunnelPreferences
+) async throws -> any TunnelObservableStrategy {
+    switch kind {
+    case .current:
+        let (source, continuation) = AsyncStream.makeStream(of: ProfilesEvent.self)
+        let strategy = NETunnelStrategy(
+            .global,
+            bundleIdentifier: bundleIdentifier,
+            source: source,
+            coder: protocolCoder,
+            preferences: store.preferences,
+            fingerprint: { $0.name }
+        )
+        try await strategy.prepare(purge: false)
+        continuation.yield(.snapshot([profile]))
+        continuation.finish()
+        await store.waitForActionCount(1)
+        return strategy
+    case .legacy:
+        let strategy = LegacyNETunnelStrategy(
+            .global,
+            bundleIdentifier: bundleIdentifier,
+            coder: protocolCoder,
+            preferences: store.preferences
+        )
+        try await strategy.prepare(purge: false)
+        return strategy
+    }
+}
+
+// MARK: - Preferences mock
+
+private enum PreferenceFailure: Error {
+    case save
+    case remove
+}
+
+private enum PreferenceAction: Equatable, Sendable {
+    case loadAll
+    case load(Profile.ID?)
+    case save(Profile.ID?)
+    case remove(Profile.ID?)
+
+    var isLoadAll: Bool {
+        guard case .loadAll = self else { return false }
+        return true
+    }
+
+    var savedProfileId: Profile.ID? {
+        guard case .save(let profileId) = self else { return nil }
+        return profileId
+    }
+
+    var removedProfileId: Profile.ID? {
+        guard case .remove(let profileId) = self else { return nil }
+        return profileId
+    }
+}
+
+private actor MockTunnelPreferences {
+    private let managers: [NETunnelProviderManager]
+    private let isEnabledOnLoad: Bool?
+    private let loadAllGate: PreferenceGate?
+    private let saveFailures: Set<Profile.ID>
+    private let removeFailures: Set<Profile.ID>
+    private var actionCountContinuations: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    private(set) var actions: [PreferenceAction] = []
+    private(set) var savedManagers: [NETunnelProviderManager] = []
+
+    init(
+        managers: [NETunnelProviderManager] = [],
+        isEnabledOnLoad: Bool? = nil,
+        loadAllGate: PreferenceGate? = nil,
+        saveFailures: Set<Profile.ID> = [],
+        removeFailures: Set<Profile.ID> = []
+    ) {
+        self.managers = managers
+        self.isEnabledOnLoad = isEnabledOnLoad
+        self.loadAllGate = loadAllGate
+        self.saveFailures = saveFailures
+        self.removeFailures = removeFailures
+    }
+
+    nonisolated var preferences: NETunnelPreferences {
+        NETunnelPreferences(
+            loadAll: { [weak self] in
+                guard let self else { throw CancellationError() }
+                return await self.performLoadAll()
+            },
+            load: { [weak self] manager in
+                guard let self else { throw CancellationError() }
+                await self.performLoad(manager)
+            },
+            save: { [weak self] manager in
+                guard let self else { throw CancellationError() }
+                try await self.performSave(manager)
+            },
+            remove: { [weak self] manager in
+                guard let self else { throw CancellationError() }
+                try await self.performRemove(manager)
+            }
+        )
+    }
+
+    func waitForActionCount(_ count: Int) async {
+        guard actions.count < count else { return }
+        await withCheckedContinuation {
+            actionCountContinuations.append((count, $0))
+        }
+    }
+
+    private func performLoadAll() async -> [NETunnelProviderManager] {
+        record(.loadAll)
+        if let loadAllGate {
+            await loadAllGate.wait()
+        }
+        return managers
+    }
+
+    private func performLoad(_ manager: NETunnelProviderManager) {
+        record(.load(manager.profileId))
+        if let isEnabledOnLoad {
+            manager.isEnabled = isEnabledOnLoad
+        }
+    }
+
+    private func performSave(_ manager: NETunnelProviderManager) throws {
+        let profileId = manager.profileId
+        savedManagers.append(manager)
+        record(.save(profileId))
+        if let profileId, saveFailures.contains(profileId) {
+            throw PreferenceFailure.save
+        }
+    }
+
+    private func performRemove(_ manager: NETunnelProviderManager) throws {
+        let profileId = manager.profileId
+        record(.remove(profileId))
+        if let profileId, removeFailures.contains(profileId) {
+            throw PreferenceFailure.remove
+        }
+    }
+
+    private func record(_ action: PreferenceAction) {
+        actions.append(action)
+        var remaining: [(Int, CheckedContinuation<Void, Never>)] = []
+        for (count, continuation) in actionCountContinuations {
+            if actions.count >= count {
+                continuation.resume()
+            } else {
+                remaining.append((count, continuation))
+            }
+        }
+        actionCountContinuations = remaining
+    }
+}
+
+private actor PreferenceGate {
+    private var isOpen = false
+    private var isEntered = false
+    private var entryContinuations: [CheckedContinuation<Void, Never>] = []
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        isEntered = true
+        entryContinuations.forEach { $0.resume() }
+        entryContinuations.removeAll()
+        guard !isOpen else { return }
+        await withCheckedContinuation {
+            continuations.append($0)
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !isEntered else { return }
+        await withCheckedContinuation {
+            entryContinuations.append($0)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
+    }
+}
+
+// MARK: - Manager metadata
+
+private let profileIdKey = "CustomProviderKey.profileId"
+private let fingerprintKey = "CustomProviderKey.fingerprint"
+
+private func makeManager(profileId: Profile.ID, fingerprint: String?) -> NETunnelProviderManager {
+    let proto = NETunnelProviderProtocol()
+    proto.providerBundleIdentifier = bundleIdentifier
+    var providerConfiguration: [String: Any] = [profileIdKey: profileId.uuidString]
+    providerConfiguration[fingerprintKey] = fingerprint
+    proto.providerConfiguration = providerConfiguration
+    let manager = NETunnelProviderManager()
+    manager.protocolConfiguration = proto
+    return manager
+}
+
+private extension NETunnelProviderManager {
+    var profileId: Profile.ID? {
+        guard let proto = protocolConfiguration as? NETunnelProviderProtocol,
+              let uuidString = proto.providerConfiguration?[profileIdKey] as? String else {
+            return nil
+        }
+        return Profile.ID(uuidString: uuidString)
+    }
+}
+
+private extension NETunnelProviderProtocol {
+    var profileId: Profile.ID? {
+        guard let uuidString = providerConfiguration?[profileIdKey] as? String else {
+            return nil
+        }
+        return Profile.ID(uuidString: uuidString)
+    }
+}
+#endif


### PR DESCRIPTION
Assume that the source of truth for profiles is external, not the NE managers. It can be the keychain, Core Data, or whatever, as long as the source emits a proper set of ProfilesEvent. The managers become a mere, reproducible, non-sensitive projection of the profiles. This approach simplifies reloads and notifications dramatically, not to mention how it no longer needs destructive clean-ups.

The NETunnelStrategy class is updated in place, with LegacyNETunnelStrategy still around for near-equivalent former behavior (except for being non-destructive).

The new strategy:

- Receives both snapshots and incremental changes from the external source (AsyncStream).
- Adds a .fingerprint meta field to the NETunnelProviderManager objects.
- Reconciles managers and profiles on full snapshots by comparing fingerprints. Mismatched fingerprints cause a new save. Matching fingerprints are a no-op.
- Saves or deletes managers on incremental changes.
- Serializes all snapshot or incremental mutations. This may cause a slowdown on the first snapshot if many managers bear no fingerprints.
- Checks protocolConfiguration ownership to disambiguate same profile IDs (possible in multi-user).
- Handles connections and disconnections like before.
- Ignores rather than deletes unowned/malformed managers (draft clean-up policy later if necessary).
- Bridges Network Extension API through NETunnelPreferences closures for testability.

Minor refactors to NEProtocolCoder implementations:

- Drop the title closure from NEProtocolCoder because it's a keychain storage concern (external to the library)
- Unless legacy, KeychainNEProtocolCoder now assumes that the password reference already exists
- LegacyOptions retains side-effect in KeychainNEProtocolCoder, which in fact carries the title closure to write to the keychain

Minor changes to AppleKeychain:

- Return empty references rather than throwing not found
- Generalize item metadata (label and comment)
- Update metadata even if password is unchanged
- Test password reference behavior

Fixes #145 naturally because profiles are not deleted in the first place.