### PR TITLE
Core: Make environment callbacks set-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run Zig tests with all vendors
         env:
           ARTIFACTS_DIR: ${{ steps.build_xcframework.outputs.artifacts_dir }}
-        run: ci/test-zig-apple-vendors.sh "$ARTIFACTS_DIR"
+        run: ci/run-tests.sh --apple-vendors "$ARTIFACTS_DIR"
       - name: Run Swift tests with built XCFramework
         run: |
           package_pattern='^nativeTarget = \.remote\("[^"]+", checksum: "[0-9a-f]{64}"\)$'
@@ -95,8 +95,7 @@ jobs:
           sed -i '' -E "s/$package_pattern/nativeTarget = .local/" Package.swift
           trap 'git restore -- Package.swift' EXIT
 
-          swift test
-          (cd cross/apple-legacy && swift test)
+          ci/run-swift-tests.sh
 
           git restore -- Package.swift
           trap - EXIT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
       - "**/*.md"
       - "scripts/*.sh"
       - "scripts/*.ps1"
-      - "**/*.kt" # For now
 
 concurrency:
   group: ${{ github.ref }}
@@ -27,6 +26,9 @@ jobs:
           - job_name: Run Zig tests
             runner: ubuntu-latest
             suite: zig
+          - job_name: Run Kotlin tests
+            runner: ubuntu-latest
+            suite: kotlin
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
     steps:
@@ -37,12 +39,17 @@ jobs:
           access-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Swift tests
         if: matrix.suite == 'swift'
-        run: |
-          swift test
-          cd cross/apple-legacy && swift test
+        run: ci/run-swift-tests.sh
       - uses: mlugg/setup-zig@v2
         if: matrix.suite == 'zig'
       - name: Run Zig tests
         if: matrix.suite == 'zig'
-        run: |
-          zig build test -Dopenvpn=true -Dwireguard=true
+        run: ci/run-tests.sh
+      - uses: actions/setup-java@v5
+        if: matrix.suite == 'kotlin'
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Run Kotlin tests
+        if: matrix.suite == 'kotlin'
+        run: ci/run-kotlin-tests.sh

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,6 @@
       "args": [
         "build",
         "coverage",
-        "-Dembed-c=true",
         "-Dopenvpn=true",
         "-Dwireguard=true"
       ],

--- a/ci/run-kotlin-tests.sh
+++ b/ci/run-kotlin-tests.sh
@@ -21,6 +21,16 @@ if [[ -z $kotlinc && -x /Applications/Android\ Studio.app/Contents/plugins/Kotli
 fi
 [[ -x $kotlinc ]] || fail "missing required tool: kotlinc"
 
+while [[ -L $kotlinc ]]; do
+    kotlinc_dir=$(cd "$(dirname "$kotlinc")" && pwd -P)
+    kotlinc_target=$(readlink "$kotlinc")
+    case $kotlinc_target in
+        /*) kotlinc=$kotlinc_target ;;
+        *) kotlinc="$kotlinc_dir/$kotlinc_target" ;;
+    esac
+done
+kotlinc=$(cd "$(dirname "$kotlinc")" && pwd -P)/$(basename "$kotlinc")
+
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 repo_root=$(cd "$script_dir/.." && pwd -P)
 android_home=${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}

--- a/ci/run-kotlin-tests.sh
+++ b/ci/run-kotlin-tests.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+    echo "run-kotlin-tests.sh: $*" >&2
+    exit 1
+}
+
+[[ $# -eq 0 ]] || fail "usage: $0"
+for tool in java curl unzip; do
+    command -v "$tool" >/dev/null 2>&1 || fail "missing required tool: $tool"
+done
+
+kotlinc=${KOTLINC:-}
+if [[ -z $kotlinc ]] && command -v kotlinc >/dev/null 2>&1; then
+    kotlinc=$(command -v kotlinc)
+fi
+if [[ -z $kotlinc && -x /Applications/Android\ Studio.app/Contents/plugins/Kotlin/kotlinc/bin/kotlinc ]]; then
+    kotlinc=/Applications/Android\ Studio.app/Contents/plugins/Kotlin/kotlinc/bin/kotlinc
+fi
+[[ -x $kotlinc ]] || fail "missing required tool: kotlinc"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(cd "$script_dir/.." && pwd -P)
+android_home=${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}
+android_platform=${ANDROID_PLATFORM:-36}
+android_jar="$android_home/platforms/android-$android_platform/android.jar"
+[[ -f $android_jar ]] || fail "missing Android platform JAR: $android_jar"
+
+kotlin_home=$(cd "$(dirname "$kotlinc")/.." && pwd -P)
+serialization_plugin=
+for candidate in \
+    "$kotlin_home/lib/kotlinx-serialization-compiler-plugin.jar" \
+    "$kotlin_home/lib/kotlin-serialization-compiler-plugin.jar"; do
+    if [[ -f $candidate ]]; then
+        serialization_plugin=$candidate
+        break
+    fi
+done
+[[ -n $serialization_plugin ]] || fail "missing Kotlin serialization compiler plugin"
+
+work_dir=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/partout-kotlin.XXXXXX")
+trap 'rm -rf "$work_dir"' EXIT
+dependencies_dir="$work_dir/dependencies"
+mkdir -p "$dependencies_dir"
+
+download() {
+    local url=$1
+    local output=$2
+    curl --fail --location --silent --show-error "$url" --output "$output"
+}
+
+add_jar() {
+    local repository=$1
+    local path=$2
+    local filename=${path##*/}
+    local output="$dependencies_dir/$filename"
+    download "$repository/$path" "$output"
+    classpath="$classpath:$output"
+}
+
+add_aar() {
+    local path=$1
+    local name=${path##*/}
+    local output="$dependencies_dir/$name"
+    local extracted="$dependencies_dir/${name%.aar}"
+    download "https://dl.google.com/dl/android/maven2/$path" "$output"
+    mkdir -p "$extracted"
+    unzip -qq "$output" classes.jar -d "$extracted"
+    classpath="$classpath:$extracted/classes.jar"
+}
+
+classpath=$android_jar
+google_maven=https://dl.google.com/dl/android/maven2
+maven_central=https://repo.maven.apache.org/maven2
+add_aar androidx/core/core/1.16.0/core-1.16.0.aar
+add_aar androidx/core/core-ktx/1.16.0/core-ktx-1.16.0.aar
+add_aar androidx/annotation/annotation-experimental/1.4.1/annotation-experimental-1.4.1.aar
+add_jar "$google_maven" androidx/annotation/annotation-jvm/1.9.1/annotation-jvm-1.9.1.jar
+add_jar "$google_maven" androidx/collection/collection-jvm/1.5.0/collection-jvm-1.5.0.jar
+add_jar "$maven_central" org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.9.0/kotlinx-coroutines-core-jvm-1.9.0.jar
+add_jar "$maven_central" org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.jar
+add_jar "$maven_central" org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.jar
+
+sources=()
+while IFS= read -r source; do
+    sources[${#sources[@]}]=$source
+done < <(find "$repo_root/cross/android" -type f -name '*.kt' | sort)
+[[ ${#sources[@]} -gt 0 ]] || fail "no Kotlin sources found"
+
+"$kotlinc" \
+    "${sources[@]}" \
+    -classpath "$classpath" \
+    -Xplugin="$serialization_plugin" \
+    -jvm-target 21 \
+    -d "$work_dir/classes"

--- a/ci/run-swift-tests.sh
+++ b/ci/run-swift-tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+    echo "run-swift-tests.sh: $*" >&2
+    exit 1
+}
+
+[[ $# -eq 0 ]] || fail "usage: $0"
+command -v swift >/dev/null 2>&1 || fail "missing required tool: swift"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(cd "$script_dir/.." && pwd -P)
+
+cd "$repo_root"
+swift test
+(cd cross/apple-legacy && swift test)

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+    echo "run-tests.sh: $*" >&2
+    exit 1
+}
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(cd "$script_dir/.." && pwd -P)
+
+if [[ $# -eq 2 && $1 == --apple-vendors ]]; then
+    exec "$script_dir/test-zig-apple-vendors.sh" "$2"
+fi
+[[ $# -eq 0 ]] || fail "usage: $0 [--apple-vendors <prebuilts-directory>]"
+
+command -v zig >/dev/null 2>&1 || fail "missing required tool: zig"
+
+cd "$repo_root"
+exec zig build test -Dopenvpn=true -Dwireguard=true

--- a/cross/android/io/partout/NativeTunnelControllerJNI.kt
+++ b/cross/android/io/partout/NativeTunnelControllerJNI.kt
@@ -24,6 +24,7 @@ interface NativeTunnelControllerJNI {
     fun setTunnel(infoJSON: String): Int
     fun configureSockets(fds: IntArray)
     fun onSnapshot(snapshotJSON: String)
+    fun setEnvironmentValue(key: String, value: String?)
     fun clearTunnel(killSwitch: Boolean)
     fun cancelTunnel(errorCode: String?)
 }

--- a/cross/android/io/partout/vpn/PartoutTunnelController.kt
+++ b/cross/android/io/partout/vpn/PartoutTunnelController.kt
@@ -52,6 +52,7 @@ internal class PartoutTunnelController(
     // JNI interactions with Native (Swift)
     private var nativeDelegate: Long = 0
     private var isNativeCancelled = false
+    private val environment = mutableMapOf<String, String>()
 
     // Network observers
     private val reachabilityObserver = ReachabilityObserver(service)
@@ -201,6 +202,16 @@ internal class PartoutTunnelController(
         return@synchronized
     }
 
+    override fun setEnvironmentValue(key: String, value: String?) = synchronized(lock) {
+        Log.d(logTag, "setEnvironmentValue($key, ${if (value != null) "value" else "null"})")
+        if (value != null) {
+            environment[key] = value
+        } else {
+            environment.remove(key)
+        }
+        return@synchronized
+    }
+
     override fun clearTunnel(killSwitch: Boolean) = synchronized(lock) {
         if (isNativeCancelled) { return@synchronized }
 
@@ -271,7 +282,7 @@ internal class PartoutTunnelController(
 
     override fun getEnvironmentValue(key: String): String? = synchronized(lock) {
         Log.d(logTag, "getEnvironmentValue($key)")
-        return getNativeEnvironmentValue(nativeDelegate, key)
+        return environment[key]
     }
     //endregion
 
@@ -287,7 +298,6 @@ internal class PartoutTunnelController(
     // Signatures in tun_android.c MUST MATCH!
     private external fun onNativeReachabilityUpdate(delegate: Long, networkHandle: Long)
     private external fun onNativeBetterPathUpdate(delegate: Long)
-    private external fun getNativeEnvironmentValue(delegate: Long, key: String): String?
 
     private fun NetworkInfo.reachabilitySelection(): ReachabilitySelection {
         val currentNetwork = bestNetworks().firstOrNull()

--- a/cross/apple-legacy/Sources/PartoutLegacyCore/Connection/NativeTunnelController.swift
+++ b/cross/apple-legacy/Sources/PartoutLegacyCore/Connection/NativeTunnelController.swift
@@ -93,13 +93,6 @@ public final class NativeTunnelController: TunnelController, Sendable {
             },
             on_better_path: { ctx in
                 ctx?.toSelf.onBetterPath()
-            },
-            environment_value: { ctx, key in
-                guard let data = ctx?.toSelf.environmentData(forKey: String(cString: key)),
-                      let json = String(data: data, encoding: .utf8) else {
-                    return nil
-                }
-                return pp_dup(json)
             }
         )
         fnt.set_delegate(ref, &delegate)

--- a/cross/apple/Sources/PartoutCore/Apple/UserDefaultsEnvironment.swift
+++ b/cross/apple/Sources/PartoutCore/Apple/UserDefaultsEnvironment.swift
@@ -22,6 +22,17 @@ public final class UserDefaultsEnvironment: TunnelEnvironment, @unchecked Sendab
         defaults.data(forKey: key.rawKey(prefix: prefix))
     }
 
+    public func setEnvironmentData(_ value: Data?, forKey key: String) {
+        let fullKey = key.rawKey(prefix: prefix)
+        if let value {
+            defaults.set(value, forKey: fullKey)
+            pp_log_id(profileId, .core, .debug, "UserDefaultsEnvironment.set(\(fullKey))")
+        } else {
+            defaults.removeObject(forKey: fullKey)
+            pp_log_id(profileId, .core, .debug, "UserDefaultsEnvironment.remove(\(fullKey))")
+        }
+    }
+
     public func setEnvironmentValue<T>(_ value: T, forKey key: TunnelEnvironmentKey<T>) where T: Encodable {
         let fullKey = key.keyString.rawKey(prefix: prefix)
         do {

--- a/cross/apple/Sources/PartoutCore/Connection/SharedTunnelEnvironment.swift
+++ b/cross/apple/Sources/PartoutCore/Connection/SharedTunnelEnvironment.swift
@@ -22,6 +22,12 @@ public final class SharedTunnelEnvironment: TunnelEnvironment, @unchecked Sendab
         }
     }
 
+    public func setEnvironmentData(_ value: Data?, forKey key: String) {
+        queue.sync {
+            values[key] = value
+        }
+    }
+
     public func setEnvironmentValue<T>(_ value: T, forKey key: TunnelEnvironmentKey<T>) where T: Encodable {
         queue.sync {
             do {

--- a/cross/apple/Sources/PartoutCore/Connection/TunnelEnvironment.swift
+++ b/cross/apple/Sources/PartoutCore/Connection/TunnelEnvironment.swift
@@ -18,6 +18,9 @@ public protocol TunnelEnvironmentReader: Sendable {
 
 /// Able to edit an environment.
 public protocol TunnelEnvironmentWriter: Sendable {
+    /// Stores raw JSON data, or removes the key when the value is nil.
+    func setEnvironmentData(_ value: Data?, forKey key: String)
+
     func setEnvironmentValue<T>(_ value: T, forKey key: TunnelEnvironmentKey<T>) where T: Encodable
 
     func removeEnvironmentValue(forKey key: String)

--- a/cross/apple/Sources/PartoutRuntime/PartoutProviderRuntime.swift
+++ b/cross/apple/Sources/PartoutRuntime/PartoutProviderRuntime.swift
@@ -29,8 +29,14 @@ public final class PartoutProviderRuntime: Sendable {
     ) throws {
         ctx = PartoutLoggerContext(profile.id)
         self.profile = profile
-        environment = UserDefaultsEnvironment(profileId: profile.id, defaults: defaults)
-        controller = PartoutTunnelController(ctx, provider: provider, options: options)
+        let environment = UserDefaultsEnvironment(profileId: profile.id, defaults: defaults)
+        self.environment = environment
+        controller = PartoutTunnelController(
+            ctx,
+            provider: provider,
+            options: options,
+            environment: environment
+        )
         messageHandler = DefaultMessageHandler(ctx, environment: environment)
         self.options = options
         self.logsPrivateData = logsPrivateData

--- a/cross/apple/Sources/PartoutRuntime/PartoutTunnelController.swift
+++ b/cross/apple/Sources/PartoutRuntime/PartoutTunnelController.swift
@@ -11,6 +11,7 @@ final class PartoutTunnelController: Sendable {
     nonisolated(unsafe)
     private weak var provider: NEPacketTunnelProvider?
     private let options: TunnelControllerOptions
+    private let environment: any TunnelEnvironmentWriter
     private let networkMonitor: NetworkMonitor
 
     private let delegateLock = SemaphoreMutex()
@@ -19,11 +20,13 @@ final class PartoutTunnelController: Sendable {
     init(
         _ ctx: PartoutLoggerContext,
         provider: NEPacketTunnelProvider,
-        options: TunnelControllerOptions
+        options: TunnelControllerOptions,
+        environment: any TunnelEnvironmentWriter
     ) {
         self.ctx = ctx
         self.provider = provider
         self.options = options
+        self.environment = environment
 
         networkMonitor = NetworkMonitor(ctx)
 
@@ -80,6 +83,10 @@ final class PartoutTunnelController: Sendable {
         }
         // The runtime already handles the connection events
         // to keep the tunnel environment up to date
+    }
+
+    func setEnvironmentData(_ value: Data?, forKey key: String) {
+        environment.setEnvironmentData(value, forKey: key)
     }
 
     func clearTunnelSettings(withKillSwitch: Bool) async {
@@ -218,6 +225,20 @@ extension PartoutTunnelController {
             }
         }
 
+        static func setEnvironmentValue(
+            _ ref: UnsafeMutableRawPointer?,
+            key: UnsafePointer<CChar>?,
+            value: UnsafePointer<CChar>?
+        ) {
+            guard let controller = controller(from: ref), let key else {
+                return
+            }
+            let data = value.map {
+                Data(String(cString: $0).utf8)
+            }
+            controller.setEnvironmentData(data, forKey: String(cString: key))
+        }
+
         static func clearTunnel(_ ref: UnsafeMutableRawPointer?, killSwitch: Bool) {
             guard let controller = controller(from: ref) else {
                 return
@@ -301,6 +322,15 @@ public func pp_swift_tun_ctrl_report_snapshot(
     _ snapshotJSON: UnsafePointer<CChar>?
 ) {
     PartoutTunnelController.Bindings.reportSnapshot(ref, snapshotJSON: snapshotJSON)
+}
+
+@c(pp_swift_tun_ctrl_set_environment_value)
+public func pp_swift_tun_ctrl_set_environment_value(
+    _ ref: UnsafeMutableRawPointer?,
+    _ key: UnsafePointer<CChar>?,
+    _ value: UnsafePointer<CChar>?
+) {
+    PartoutTunnelController.Bindings.setEnvironmentValue(ref, key: key, value: value)
 }
 
 @c(pp_swift_tun_ctrl_clear_tunnel)

--- a/src/c/portable/include/portable/tun.h
+++ b/src/c/portable/include/portable/tun.h
@@ -49,7 +49,6 @@ typedef struct {
     void *_Nullable ctx;
     void (*on_reachability)(void *_Nullable ctx, const pp_reachability *reachability);
     void (*on_better_path)(void *_Nullable ctx);
-    char *_Nullable (*_Nonnull environment_value)(void *_Nullable ctx, const char *key);
 } pp_tun_ctrl_delegate;
 
 typedef struct {

--- a/src/c/portable/include/portable/tun.h
+++ b/src/c/portable/include/portable/tun.h
@@ -63,6 +63,9 @@ typedef struct {
                               size_t fds_len);
     void (*report_snapshot)(void *_Nullable ref,
                             const char *snapshot_json);
+    void (*set_environment_value)(void *_Nullable ref,
+                                  const char *key,
+                                  const char *_Nullable value);
     void (*clear_tunnel)(void *_Nullable ref, bool kill_switch);
     void (*cancel_tunnel)(void *_Nullable ref,
                           const char *_Nullable error_message);

--- a/src/c/portable/tun_android.c
+++ b/src/c/portable/tun_android.c
@@ -388,21 +388,4 @@ Java_io_partout_vpn_PartoutTunnelController_onNativeBetterPathUpdate(JNIEnv *env
     ctrl_delegate->on_better_path(ctrl_delegate->ctx);
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_partout_vpn_PartoutTunnelController_getNativeEnvironmentValue(JNIEnv *env,
-                                                                      jobject thiz,
-                                                                      jlong delegate,
-                                                                      jstring key) {
-    (void)thiz;
-    pp_tun_ctrl_delegate *ctrl_delegate = (pp_tun_ctrl_delegate *)(intptr_t)delegate;
-    if (!ctrl_delegate || !ctrl_delegate->ctx) return NULL;
-    const char *c_key = (*env)->GetStringUTFChars(env, key, NULL);
-    char *c_value = ctrl_delegate->environment_value(ctrl_delegate->ctx, c_key);
-    (*env)->ReleaseStringUTFChars(env, key, c_key);
-    if (!c_value) return NULL;
-    jstring value = (*env)->NewStringUTF(env, c_value);
-    pp_free(c_value);
-    return value;
-}
-
 #endif

--- a/src/c/portable/tun_android.c
+++ b/src/c/portable/tun_android.c
@@ -84,6 +84,10 @@ static const kotlin_sig sig_ctrl_onSnapshot = {
     "onSnapshot",
     "(Ljava/lang/String;)V"
 };
+static const kotlin_sig sig_ctrl_setEnvironmentValue = {
+    "setEnvironmentValue",
+    "(Ljava/lang/String;Ljava/lang/String;)V"
+};
 static const kotlin_sig sig_ctrl_clearTunnel = {
     "clearTunnel",
     "(Z)V"
@@ -283,6 +287,56 @@ cleanup:
     PP_JNI_DETACH(env);
 }
 
+static void pp_tun_ctrl_set_environment_value(void *ref, const char *key, const char *value) {
+    assert(ref);
+    assert(key);
+
+    PP_JNI_ATTACH_OR_RETURN_VOID(env);
+
+    jclass cls = NULL;
+    jmethodID method = NULL;
+    jstring j_key = NULL;
+    jstring j_value = NULL;
+
+    cls = (*env)->GetObjectClass(env, ref);
+    if (cls == NULL) {
+        pp_clog(PPLogLevelFault, "tun_android: ctrl_set_environment_value(), NULL cls");
+        goto cleanup;
+    }
+    method = (*env)->GetMethodID(
+        env,
+        cls,
+        sig_ctrl_setEnvironmentValue.name,
+        sig_ctrl_setEnvironmentValue.signature
+    );
+    if (method == NULL) {
+        pp_clog(PPLogLevelFault, "tun_android: ctrl_set_environment_value(), NULL method");
+        goto cleanup;
+    }
+    j_key = (*env)->NewStringUTF(env, key);
+    if (j_key == NULL) {
+        pp_clog(PPLogLevelFault, "tun_android: ctrl_set_environment_value(), NULL key");
+        goto cleanup;
+    }
+    j_value = value ? (*env)->NewStringUTF(env, value) : NULL;
+    if (value && j_value == NULL) {
+        pp_clog(PPLogLevelFault, "tun_android: ctrl_set_environment_value(), NULL value");
+        goto cleanup;
+    }
+    (*env)->CallVoidMethod(env, ref, method, j_key, j_value);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        pp_clog(PPLogLevelFault, "tun_android: ctrl_set_environment_value(), Kotlin exception");
+    }
+
+cleanup:
+    if (j_value != NULL) (*env)->DeleteLocalRef(env, j_value);
+    if (j_key != NULL) (*env)->DeleteLocalRef(env, j_key);
+    if (cls != NULL) (*env)->DeleteLocalRef(env, cls);
+    PP_JNI_DETACH(env);
+}
+
 // Balance with pp_tun_ctrl_set_tunnel
 static void pp_tun_ctrl_clear_tunnel(void *jni_ref, bool kill_switch) {
     pp_clog_v(PPLogLevelDebug, "tun_android: ctrl_clear_tunnel(%p)", jni_ref);
@@ -355,6 +409,7 @@ pp_tun_ctrl_fnt pp_tun_ctrl_fnt_current(void) {
         .set_tunnel = pp_tun_ctrl_set_tunnel,
         .configure_sockets = pp_tun_ctrl_configure_sockets,
         .report_snapshot = pp_tun_ctrl_report_snapshot,
+        .set_environment_value = pp_tun_ctrl_set_environment_value,
         .clear_tunnel = pp_tun_ctrl_clear_tunnel,
         .cancel_tunnel = pp_tun_ctrl_cancel_tunnel
     };

--- a/src/c/portable/tun_darwin.c
+++ b/src/c/portable/tun_darwin.c
@@ -248,6 +248,9 @@ typedef bool (*pp_swift_tun_ctrl_configure_sockets_fn)(void *_Nullable ref,
                                                        size_t fds_len);
 typedef void (*pp_swift_tun_ctrl_report_snapshot_fn)(void *_Nullable ref,
                                                      const char *_Nullable snapshot_json);
+typedef void (*pp_swift_tun_ctrl_set_environment_value_fn)(void *_Nullable ref,
+                                                           const char *_Nullable key,
+                                                           const char *_Nullable value);
 typedef void (*pp_swift_tun_ctrl_clear_tunnel_fn)(void *_Nullable ref,
                                                   bool kill_switch);
 typedef void (*pp_swift_tun_ctrl_cancel_tunnel_fn)(void *_Nullable ref,
@@ -266,6 +269,7 @@ PP_SWIFT_TUN_CTRL_SYMBOL(pp_swift_tun_ctrl_set_delegate, "pp_swift_tun_ctrl_set_
 PP_SWIFT_TUN_CTRL_SYMBOL(pp_swift_tun_ctrl_set_tunnel, "pp_swift_tun_ctrl_set_tunnel", pp_swift_tun_ctrl_set_tunnel_fn)
 PP_SWIFT_TUN_CTRL_SYMBOL(pp_swift_tun_ctrl_configure_sockets, "pp_swift_tun_ctrl_configure_sockets", pp_swift_tun_ctrl_configure_sockets_fn)
 PP_SWIFT_TUN_CTRL_SYMBOL(pp_swift_tun_ctrl_report_snapshot, "pp_swift_tun_ctrl_report_snapshot", pp_swift_tun_ctrl_report_snapshot_fn)
+PP_SWIFT_TUN_CTRL_SYMBOL(pp_swift_tun_ctrl_set_environment_value, "pp_swift_tun_ctrl_set_environment_value", pp_swift_tun_ctrl_set_environment_value_fn)
 PP_SWIFT_TUN_CTRL_SYMBOL(pp_swift_tun_ctrl_clear_tunnel, "pp_swift_tun_ctrl_clear_tunnel", pp_swift_tun_ctrl_clear_tunnel_fn)
 PP_SWIFT_TUN_CTRL_SYMBOL(pp_swift_tun_ctrl_cancel_tunnel, "pp_swift_tun_ctrl_cancel_tunnel", pp_swift_tun_ctrl_cancel_tunnel_fn)
 
@@ -304,6 +308,12 @@ static void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {
     swift(ref, snapshot_json);
 }
 
+static void pp_tun_ctrl_set_environment_value(void *ref, const char *key, const char *value) {
+    const pp_swift_tun_ctrl_set_environment_value_fn swift = pp_swift_tun_ctrl_set_environment_value();
+    if (!swift) return;
+    swift(ref, key, value);
+}
+
 static void pp_tun_ctrl_clear_tunnel(void *ref, bool kill_switch) {
     pp_clog_v(PPLogLevelInfo, "tun_darwin: ctrl_clear_tunnel(%p)", ref);
     const pp_swift_tun_ctrl_clear_tunnel_fn swift = pp_swift_tun_ctrl_clear_tunnel();
@@ -324,6 +334,7 @@ pp_tun_ctrl_fnt pp_tun_ctrl_fnt_current(void) {
         .set_tunnel = pp_tun_ctrl_set_tunnel,
         .configure_sockets = pp_tun_ctrl_configure_sockets,
         .report_snapshot = pp_tun_ctrl_report_snapshot,
+        .set_environment_value = pp_tun_ctrl_set_environment_value,
         .clear_tunnel = pp_tun_ctrl_clear_tunnel,
         .cancel_tunnel = pp_tun_ctrl_cancel_tunnel
     };

--- a/src/c/portable/tun_linux.c
+++ b/src/c/portable/tun_linux.c
@@ -133,6 +133,12 @@ static void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {
     (void)snapshot_json;
 }
 
+static void pp_tun_ctrl_set_environment_value(void *ref, const char *key, const char *value) {
+    (void)ref;
+    (void)key;
+    (void)value;
+}
+
 static void pp_tun_ctrl_clear_tunnel(void *ref, bool kill_switch) {
     (void)ref;
     (void)kill_switch;
@@ -151,6 +157,7 @@ pp_tun_ctrl_fnt pp_tun_ctrl_fnt_current(void) {
         .set_tunnel = pp_tun_ctrl_set_tunnel,
         .configure_sockets = pp_tun_ctrl_configure_sockets,
         .report_snapshot = pp_tun_ctrl_report_snapshot,
+        .set_environment_value = pp_tun_ctrl_set_environment_value,
         .clear_tunnel = pp_tun_ctrl_clear_tunnel,
         .cancel_tunnel = pp_tun_ctrl_cancel_tunnel
     };

--- a/src/c/portable/tun_windows.c
+++ b/src/c/portable/tun_windows.c
@@ -240,6 +240,12 @@ static void pp_tun_ctrl_report_snapshot(void *ref, const char *snapshot_json) {
     (void)snapshot_json;
 }
 
+static void pp_tun_ctrl_set_environment_value(void *ref, const char *key, const char *value) {
+    (void)ref;
+    (void)key;
+    (void)value;
+}
+
 static void pp_tun_ctrl_clear_tunnel(void *ref, bool kill_switch) {
     (void)ref;
     (void)kill_switch;
@@ -258,6 +264,7 @@ pp_tun_ctrl_fnt pp_tun_ctrl_fnt_current(void) {
         .set_tunnel = pp_tun_ctrl_set_tunnel,
         .configure_sockets = pp_tun_ctrl_configure_sockets,
         .report_snapshot = pp_tun_ctrl_report_snapshot,
+        .set_environment_value = pp_tun_ctrl_set_environment_value,
         .clear_tunnel = pp_tun_ctrl_clear_tunnel,
         .cancel_tunnel = pp_tun_ctrl_cancel_tunnel
     };

--- a/src/net/platform.zig
+++ b/src/net/platform.zig
@@ -277,6 +277,7 @@ const platform_tunnel_controller_vtable = TunnelController.VTable{
     .set_tunnel_settings = ctrlSetTunnelSettings,
     .configure_sockets = ctrlConfigureSockets,
     .report_snapshot = ctrlReportSnapshot,
+    .set_environment_value = ctrlSetEnvironmentValue,
     .clear_tunnel_settings = ctrlClearTunnelSettings,
     .set_reasserting = ctrlSetReasserting,
     .cancel_tunnel_connection = ctrlCancelTunnelConnection,
@@ -323,6 +324,30 @@ fn ctrlReportSnapshot(ptr: ?*anyopaque, snapshot: api.TunnelSnapshot) void {
     };
     defer allocator.free(c_snapshot);
     self.fnt.report_snapshot.?(self.ref, c_snapshot.ptr);
+}
+
+fn ctrlSetEnvironmentValue(ptr: ?*anyopaque, key: []const u8, value: ?[]const u8) void {
+    const self: *Platform = @ptrCast(@alignCast(ptr.?));
+    const allocator = std.heap.c_allocator;
+
+    var c_key: util.TemporaryCString = .{};
+    c_key.init(allocator, key) catch {
+        log.write(.err, "Unable to encode environment key");
+        return;
+    };
+    defer c_key.deinit();
+
+    if (value) |raw_value| {
+        var c_value: util.TemporaryCString = .{};
+        c_value.init(allocator, raw_value) catch {
+            log.write(.err, "Unable to encode environment value");
+            return;
+        };
+        defer c_value.deinit();
+        self.fnt.set_environment_value.?(self.ref, c_key.ptr(), c_value.ptr());
+    } else {
+        self.fnt.set_environment_value.?(self.ref, c_key.ptr(), null);
+    }
 }
 
 fn ctrlClearTunnelSettings(ptr: ?*anyopaque, with_kill_switch: bool) void {

--- a/src/net/platform.zig
+++ b/src/net/platform.zig
@@ -32,25 +32,12 @@ const TunWrapper = io.TunWrapper;
 pub const Platform = struct {
     pub const FunctionTable = c.pp_tun_ctrl_fnt;
 
-    pub const EnvironmentValueBlock = struct {
-        ptr: ?*anyopaque = null,
-        get: *const fn (?*anyopaque, []const u8) ?[]const u8,
-
-        fn call(self: EnvironmentValueBlock, key: []const u8) ?[]const u8 {
-            return self.get(self.ptr, key);
-        }
-    };
-
     pub const Options = struct {
         /// The optional reference to forward C calls to (e.g. JNI).
         ref: ?*anyopaque = null,
 
         /// The tunnel controller implementation.
         fnt: ?FunctionTable = null,
-
-        /// Requests a value from the tunnel environment.
-        /// ZIGME: Delete this and from pp_tun_ctrl_delegate
-        environment_value: ?EnvironmentValueBlock = null,
 
         /// The socket buffer size.
         socket_buf_size: c_int = 1024 * 1024,
@@ -61,7 +48,6 @@ pub const Platform = struct {
     ref: ?*anyopaque,
     fnt: FunctionTable,
     dns: PlatformDNS,
-    environment_value: ?EnvironmentValueBlock,
     socket_buf_size: c_int,
 
     //#endregion
@@ -96,7 +82,6 @@ pub const Platform = struct {
             .ref = ref_copy,
             .fnt = options.fnt orelse c.pp_tun_ctrl_fnt_current(),
             .dns = .{},
-            .environment_value = options.environment_value,
             .socket_buf_size = options.socket_buf_size,
         };
     }
@@ -106,7 +91,6 @@ pub const Platform = struct {
             .ctx = self,
             .on_reachability = cOnReachability,
             .on_better_path = cOnBetterPath,
-            .environment_value = cEnvironmentValue,
         };
         if (self.ref) |ref| {
             log.writef(.debug, "Platform: Set delegate ({*})", .{ref});
@@ -285,16 +269,6 @@ pub const Platform = struct {
             return error.SocketConfiguration;
         }
     }
-
-    //#region Environment
-
-    fn environmentValue(self: *const Platform, key: []const u8) ?[]const u8 {
-        log.writef(.debug, "Get tunnel environment: {s}", .{key});
-        const block = self.environment_value orelse return null;
-        return block.call(key);
-    }
-
-    //#endregion
 };
 
 //#region Tunnel controller
@@ -459,15 +433,6 @@ fn cOnReachability(ctx: ?*anyopaque, reachability: [*c]const ReachabilityInfo) c
 fn cOnBetterPath(ctx: ?*anyopaque) callconv(.c) void {
     const self: *Platform = @ptrCast(@alignCast(ctx orelse return));
     self.notifyBetterPath();
-}
-
-fn cEnvironmentValue(ctx: ?*anyopaque, key: [*c]const u8) callconv(.c) [*c]u8 {
-    const self: *Platform = @ptrCast(@alignCast(ctx orelse return null));
-    if (key == null) return null;
-    const key_z: [*:0]const u8 = @ptrCast(key);
-    const value = self.environmentValue(std.mem.span(key_z)) orelse return null;
-    const c_value = std.heap.c_allocator.dupeSentinel(u8, value, 0) catch return null;
-    return c_value.ptr;
 }
 
 //#endregion

--- a/src/net/sandbox.zig
+++ b/src/net/sandbox.zig
@@ -50,6 +50,7 @@ pub const TunnelController = struct {
         set_tunnel_settings: *const fn (?*anyopaque, api.TunnelRemoteInfoWrapper) Error!?TunWrapper,
         configure_sockets: *const fn (?*anyopaque, []const io.SocketDescriptor) Error!void,
         report_snapshot: *const fn (?*anyopaque, api.TunnelSnapshot) void,
+        set_environment_value: *const fn (?*anyopaque, []const u8, ?[]const u8) void,
         clear_tunnel_settings: *const fn (?*anyopaque, bool) void,
         set_reasserting: *const fn (?*anyopaque, bool) void,
         cancel_tunnel_connection: *const fn (?*anyopaque, ?api.PartoutErrorCode) void,
@@ -65,6 +66,12 @@ pub const TunnelController = struct {
 
     pub fn reportSnapshot(self: TunnelController, snapshot: api.TunnelSnapshot) void {
         self.vtable.report_snapshot(self.ptr, snapshot);
+    }
+
+    /// Sets a JSON-encoded environment value, or removes it when null.
+    /// The key and value are borrowed for the duration of the call.
+    pub fn setEnvironmentValue(self: TunnelController, key: []const u8, value: ?[]const u8) void {
+        self.vtable.set_environment_value(self.ptr, key, value);
     }
 
     pub fn clearTunnelSettings(self: TunnelController, with_kill_switch: bool) void {

--- a/src/openvpn/connection.zig
+++ b/src/openvpn/connection.zig
@@ -24,6 +24,7 @@ const Session = session_mod.Session;
 const SessionDelegate = session_mod.SessionDelegate;
 const SessionError = errors_mod.SessionError;
 const TLSConstants = constants_mod.TLS;
+const server_configuration_environment_key = "OpenVPN.serverConfiguration";
 
 pub fn createConnection(
     ptr: ?*anyopaque,
@@ -224,6 +225,7 @@ const OpenVPNConnection = struct {
         self.current_session = session;
         self.events = events;
 
+        self.clearServerConfiguration();
         _ = self.sendStatus(.connecting, events);
         const descriptor = self.setupLink() catch |err| {
             log.writef(.fault, "Unable to create link: {s}", .{@errorName(err)});
@@ -452,6 +454,7 @@ const OpenVPNConnection = struct {
         log.write(.notice, "Remote options:");
         openvpn_log.logConfiguration(remote_options, false);
         const events = self.events orelse return;
+        self.reportServerConfiguration(remote_options);
 
         const builder = NetworkSettingsBuilder.init(
             &self.configuration,
@@ -511,6 +514,7 @@ const OpenVPNConnection = struct {
         self.controller.clearTunnelSettings(false);
         self.status = .disconnected;
         self.events = null;
+        self.clearServerConfiguration();
         events.last_error(events.ctx, code);
         self.requestCancellation(events, code);
     }
@@ -534,6 +538,7 @@ const OpenVPNConnection = struct {
                     log.writef(.info, "Report link failure: {s}", .{@errorName(err)});
                     self.status = .disconnected;
                     self.events = null;
+                    self.clearServerConfiguration();
                     self.requestCancellation(events, code);
                     return;
                 }
@@ -567,7 +572,24 @@ const OpenVPNConnection = struct {
         log.writef(.info, "Report link status: {s}", .{new_status.raw()});
         self.status = new_status;
         events.status(events.ctx, new_status);
+        if (new_status == .disconnected) self.clearServerConfiguration();
         return true;
+    }
+
+    fn reportServerConfiguration(
+        self: *OpenVPNConnection,
+        configuration: *const api.OpenVPNConfiguration,
+    ) void {
+        const value = core.util.encodeJsonValue(self.allocator, configuration) catch {
+            log.write(.err, "Unable to encode server configuration");
+            return;
+        };
+        defer self.allocator.free(value);
+        self.controller.setEnvironmentValue(server_configuration_environment_key, value);
+    }
+
+    fn clearServerConfiguration(self: *OpenVPNConnection) void {
+        self.controller.setEnvironmentValue(server_configuration_environment_key, null);
     }
 
     fn clearTunnel(self: *OpenVPNConnection) void {

--- a/src/openvpn/connection.zig
+++ b/src/openvpn/connection.zig
@@ -24,7 +24,10 @@ const Session = session_mod.Session;
 const SessionDelegate = session_mod.SessionDelegate;
 const SessionError = errors_mod.SessionError;
 const TLSConstants = constants_mod.TLS;
-const server_configuration_environment_key = "OpenVPN.serverConfiguration";
+
+const EnvironmentKeys = struct {
+    const server_configuration = "OpenVPN.serverConfiguration";
+};
 
 pub fn createConnection(
     ptr: ?*anyopaque,
@@ -585,11 +588,11 @@ const OpenVPNConnection = struct {
             return;
         };
         defer self.allocator.free(value);
-        self.controller.setEnvironmentValue(server_configuration_environment_key, value);
+        self.controller.setEnvironmentValue(EnvironmentKeys.server_configuration, value);
     }
 
     fn clearServerConfiguration(self: *OpenVPNConnection) void {
-        self.controller.setEnvironmentValue(server_configuration_environment_key, null);
+        self.controller.setEnvironmentValue(EnvironmentKeys.server_configuration, null);
     }
 
     fn clearTunnel(self: *OpenVPNConnection) void {

--- a/src/testing/mock.zig
+++ b/src/testing/mock.zig
@@ -422,6 +422,7 @@ const noop_controller_vtable = net.TunnelController.VTable{
     .set_tunnel_settings = noopSetTunnelSettings,
     .configure_sockets = noopConfigureSockets,
     .report_snapshot = noopReportSnapshot,
+    .set_environment_value = noopSetEnvironmentValue,
     .clear_tunnel_settings = noopClearTunnelSettings,
     .set_reasserting = noopSetReasserting,
     .cancel_tunnel_connection = noopCancelTunnelConnection,
@@ -434,6 +435,8 @@ fn noopSetTunnelSettings(_: ?*anyopaque, _: api.TunnelRemoteInfoWrapper) net.Tun
 fn noopConfigureSockets(_: ?*anyopaque, _: []const net_io.SocketDescriptor) net.TunnelController.Error!void {}
 
 fn noopReportSnapshot(_: ?*anyopaque, _: api.TunnelSnapshot) void {}
+
+fn noopSetEnvironmentValue(_: ?*anyopaque, _: []const u8, _: ?[]const u8) void {}
 
 fn noopClearTunnelSettings(_: ?*anyopaque, _: bool) void {}
 
@@ -681,6 +684,8 @@ pub const MockTunnelController = struct {
     clear_tunnel_settings_count: usize = 0,
     configure_sockets_count: usize = 0,
     report_snapshot_count: usize = 0,
+    set_environment_value_count: usize = 0,
+    remove_environment_value_count: usize = 0,
     snapshot_block: ?*SnapshotBlock = null,
     last_settings_info: ?api.TunnelRemoteInfoWrapper = null,
     last_settings: ?LastTunnelSettings = null,
@@ -700,6 +705,7 @@ const mock_controller_vtable = net.TunnelController.VTable{
     .set_tunnel_settings = mockSetTunnelSettings,
     .configure_sockets = mockConfigureSockets,
     .report_snapshot = mockReportSnapshot,
+    .set_environment_value = mockSetEnvironmentValue,
     .clear_tunnel_settings = mockClearTunnelSettings,
     .set_reasserting = mockSetReasserting,
     .cancel_tunnel_connection = mockCancelTunnelConnection,
@@ -729,6 +735,15 @@ fn mockReportSnapshot(ptr: ?*anyopaque, snapshot: api.TunnelSnapshot) void {
         }
     }
     _ = snapshot;
+}
+
+fn mockSetEnvironmentValue(ptr: ?*anyopaque, _: []const u8, value: ?[]const u8) void {
+    const self: *MockTunnelController = @ptrCast(@alignCast(ptr.?));
+    if (value != null) {
+        self.set_environment_value_count += 1;
+    } else {
+        self.remove_environment_value_count += 1;
+    }
 }
 
 fn mockClearTunnelSettings(ptr: ?*anyopaque, with_kill_switch: bool) void {

--- a/tests/net/platform.zig
+++ b/tests/net/platform.zig
@@ -21,6 +21,10 @@ const socketOptions = platform_source.testing.socketOptions;
 const TunnelCommitRecorder = struct {
     calls: usize = 0,
     received_settings_only_info: bool = false,
+    environment_set_calls: usize = 0,
+    environment_remove_calls: usize = 0,
+    received_environment_key: bool = false,
+    received_environment_value: bool = false,
 };
 
 export fn pp_swift_tun_ctrl_set_tunnel(
@@ -39,6 +43,25 @@ export fn pp_swift_tun_ctrl_set_tunnel(
     return true;
 }
 
+export fn pp_swift_tun_ctrl_set_environment_value(
+    ref: ?*anyopaque,
+    key: ?[*:0]const u8,
+    value: ?[*:0]const u8,
+) void {
+    const recorder: *TunnelCommitRecorder = @ptrCast(@alignCast(ref orelse return));
+    recorder.received_environment_key = std.mem.eql(u8, std.mem.span(key orelse return), "test.key");
+    if (value) |raw_value| {
+        recorder.environment_set_calls += 1;
+        recorder.received_environment_value = std.mem.eql(
+            u8,
+            std.mem.span(raw_value),
+            "{\"enabled\":true}",
+        );
+    } else {
+        recorder.environment_remove_calls += 1;
+    }
+}
+
 test "platform commits settings when no virtual device is required" {
     // Relies on external Swift bindings layout from tun_darwin.c
     if (builtin.os.tag != .macos) return error.SkipZigTest;
@@ -52,6 +75,23 @@ test "platform commits settings when no virtual device is required" {
     try std.testing.expect(tun == null);
     try std.testing.expectEqual(@as(usize, 1), recorder.calls);
     try std.testing.expect(recorder.received_settings_only_info);
+}
+
+test "platform forwards environment values and removals" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+
+    var recorder = TunnelCommitRecorder{};
+    var platform = try Platform.init(.{ .ref = &recorder });
+    defer platform.deinit();
+
+    const controller = platform.tunnelController();
+    controller.setEnvironmentValue("test.key", "{\"enabled\":true}");
+    controller.setEnvironmentValue("test.key", null);
+
+    try std.testing.expectEqual(@as(usize, 1), recorder.environment_set_calls);
+    try std.testing.expectEqual(@as(usize, 1), recorder.environment_remove_calls);
+    try std.testing.expect(recorder.received_environment_key);
+    try std.testing.expect(recorder.received_environment_value);
 }
 
 test "platform socket factory returns current reachability" {

--- a/tests/wireguard/connection.zig
+++ b/tests/wireguard/connection.zig
@@ -707,6 +707,7 @@ const fake_controller_vtable = sandbox.TunnelController.VTable{
     .set_tunnel_settings = fakeSetTunnelSettings,
     .configure_sockets = fakeConfigureSockets,
     .report_snapshot = fakeReportSnapshot,
+    .set_environment_value = fakeSetEnvironmentValue,
     .clear_tunnel_settings = fakeClearTunnelSettings,
     .set_reasserting = fakeSetReasserting,
     .cancel_tunnel_connection = fakeCancelTunnelConnection,
@@ -726,6 +727,8 @@ fn fakeConfigureSockets(ptr: ?*anyopaque, descriptors: []const io.SocketDescript
 }
 
 fn fakeReportSnapshot(_: ?*anyopaque, _: api.TunnelSnapshot) void {}
+
+fn fakeSetEnvironmentValue(_: ?*anyopaque, _: []const u8, _: ?[]const u8) void {}
 
 fn fakeClearTunnelSettings(ptr: ?*anyopaque, _: bool) void {
     const self: *FakeController = @ptrCast(@alignCast(ptr.?));


### PR DESCRIPTION
Drop the extra layer for getting environment values because the storage lives outside Zig code. The library emits set calls, but the storage is at the native layer (Swift and Kotlin).