### PR TITLE
NE: Keep tunnel settings on shutdown

### DIFF
--- a/cross/apple-legacy/Sources/PartoutOS/NETunnelController.swift
+++ b/cross/apple-legacy/Sources/PartoutOS/NETunnelController.swift
@@ -42,12 +42,7 @@ public final class NETunnelController: TunnelController {
     }
 
     public func clearTunnelSettings(withKillSwitch: Bool) async {
-        do {
-            pp_log_id(profile.id, .os, .info, "Clear tunnel settings (kill switch = \(withKillSwitch))")
-            try await provider?.clearTunnelSettings(withKillSwitch: withKillSwitch)
-        } catch {
-            pp_log_id(profile.id, .os, .error, "Unable to clear tunnel settings: \(error)")
-        }
+        // Do nothing, retain the routes to avoid temporary leaks
     }
 
     public func setReasserting(_ reasserting: Bool) {

--- a/cross/apple/Sources/PartoutRuntime/PartoutTunnelController.swift
+++ b/cross/apple/Sources/PartoutRuntime/PartoutTunnelController.swift
@@ -90,12 +90,7 @@ final class PartoutTunnelController: Sendable {
     }
 
     func clearTunnelSettings(withKillSwitch: Bool) async {
-        do {
-            pp_log(ctx, .runtime, .info, "Clear tunnel settings (kill switch = \(withKillSwitch))")
-            try await provider?.clearTunnelSettings(withKillSwitch: withKillSwitch)
-        } catch {
-            pp_log(ctx, .runtime, .error, "Unable to clear tunnel settings: \(error)")
-        }
+        // Do nothing, retain the routes to avoid temporary leaks
     }
 
     func setReasserting(_ reasserting: Bool) {


### PR DESCRIPTION
Avoid leaks on temporary unreachability.