### PR TITLE
CI: Release Swift-only version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,14 @@
 # Release flow:
-# - Trigger on a version change in master, or by manual dispatch.
-# - Read the version from src/version.zig and reject an existing tag.
-# - Download all vendor prebuilts and build the full monolithic XCFramework.
-# - Run Zig tests with all vendors: OpenSSL, MbedTLS, etc.
-# - Verify the built XCFramework is selected locally and run both Swift test suites.
-# - Update Package.swift's remote version and checksum.
-# - Create a signed commit, then create a signed tag that points to it.
-# - Atomically push the commit to master and push the matching tag.
-# - Publish the XCFramework archive with dSYMs, checksum, and prebuilts version.
+# - Trigger on a Swift or native version change in master, or by manual dispatch.
+# - Use the Swift version for the Git tag and GitHub release.
+# - Compare the native version with Package.swift's published artifact version.
+# - For a native release, build and test the XCFramework, then update
+#   Package.swift with its version and checksum.
+# - For a Swift-only release, test against the existing published XCFramework.
+# - Create a signed tag and atomically push the release commit and tag.
+# - Publish XCFramework assets only for native releases.
 #
-# Consequently, both master and the version tag contain a Package.swift that
-# references the matching release.
+# Consequently, Swift-only releases may reference an older native release.
 # Assumption: master is kept unchanged while this workflow is running. If it
 # advances, the non-forcing atomic push fails without updating either ref.
 
@@ -22,6 +20,7 @@ on:
       - master
     paths:
       - src/version.zig
+      - cross/apple/Sources/PartoutCore/Version.swift
   workflow_dispatch:
 
 concurrency:
@@ -38,7 +37,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+
+      - name: Resolve release
+        id: release
+        run: ci/resolve-release.sh
+
       - name: Import GPG key
+        if: steps.release.outputs.mode != 'none'
         uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_KEY }}
@@ -46,29 +51,14 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_tag_gpgsign: true
-      - name: Set up Zig
-        uses: mlugg/setup-zig@v2
-      - name: Parse version
-        id: parse_version
-        env:
-          VERSION_SOURCE: src/version.zig
-        run: |
-          if [[ "$GITHUB_REF_TYPE" != "branch" || "$GITHUB_REF_NAME" != "master" ]]; then
-            echo "::error::Releases must run from master"
-            exit 1
-          fi
 
-          version=$(sed -nE 's/^pub const number = "([^"]+)";$/\1/p' "$VERSION_SOURCE")
-          test -n "$version"
-          [[ "$version" =~ ^[0-9A-Za-z.+-]+$ ]]
-          if git ls-remote --exit-code --tags \
-            origin "refs/tags/$version" >/dev/null 2>&1; then
-            echo "::error::Tag $version already exists"
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Set up Zig
+        if: steps.release.outputs.mode == 'native'
+        uses: mlugg/setup-zig@v2
+
       - name: Build XCFramework
-        id: build_xcframework
+        if: steps.release.outputs.mode == 'native'
+        id: xcframework
         run: |
           xcframework="$GITHUB_WORKSPACE/PartoutNative.xcframework"
           artifacts_dir="$RUNNER_TEMP/prebuilts-artifacts"
@@ -85,27 +75,43 @@ jobs:
           echo "checksum_file=$checksum_file" >> "$GITHUB_OUTPUT"
           echo "prebuilts_version_file=$prebuilts_version_file" >> "$GITHUB_OUTPUT"
           echo "artifacts_dir=$artifacts_dir" >> "$GITHUB_OUTPUT"
-      - name: Run Zig tests with all vendors
-        env:
-          ARTIFACTS_DIR: ${{ steps.build_xcframework.outputs.artifacts_dir }}
-        run: ci/run-tests.sh --apple-vendors "$ARTIFACTS_DIR"
-      - name: Run Swift tests with built XCFramework
-        run: |
-          test -d PartoutNative.xcframework
-          swift package dump-package |
-            grep -F '"path" : "PartoutNative.xcframework"'
 
-          ci/run-swift-tests.sh
-      - name: Update Swift package reference
+      - name: Run Zig tests with all vendors
+        if: steps.release.outputs.mode == 'native'
         env:
-          VERSION: ${{ steps.parse_version.outputs.version }}
-          CHECKSUM_FILE: ${{ steps.build_xcframework.outputs.checksum_file }}
+          ARTIFACTS_DIR: ${{ steps.xcframework.outputs.artifacts_dir }}
+        run: ci/run-tests.sh --apple-vendors "$ARTIFACTS_DIR"
+
+      - name: Run Swift tests
+        if: steps.release.outputs.mode != 'none'
+        env:
+          MODE: ${{ steps.release.outputs.mode }}
+          NATIVE_VERSION: ${{ steps.release.outputs.native_version }}
+        run: |
+          if [[ "$MODE" == native ]]; then
+            test -d PartoutNative.xcframework
+            swift package dump-package |
+              grep -F '"path" : "PartoutNative.xcframework"'
+          else
+            test ! -d PartoutNative.xcframework
+            swift package dump-package |
+              grep -F "releases/download/$NATIVE_VERSION/PartoutNative.xcframework.zip"
+          fi
+          ci/run-swift-tests.sh
+
+      - name: Update Swift package reference
+        if: steps.release.outputs.mode == 'native'
+        env:
+          VERSION: ${{ steps.release.outputs.native_version }}
+          CHECKSUM_FILE: ${{ steps.xcframework.outputs.checksum_file }}
         run: |
           ci/update-swift-package.sh "$VERSION" "$CHECKSUM_FILE"
           git verify-commit HEAD
-      - name: Sign and push release commit and tag
+
+      - name: Sign and push release tag
+        if: steps.release.outputs.mode != 'none'
         env:
-          VERSION: ${{ steps.parse_version.outputs.version }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           git tag -s "$VERSION" HEAD -m "$VERSION"
           test "$(git rev-list -n 1 "$VERSION")" = "$(git rev-parse HEAD)"
@@ -113,18 +119,23 @@ jobs:
           git push --atomic origin \
             "HEAD:refs/heads/master" \
             "refs/tags/$VERSION"
+
       - name: Publish release
+        if: steps.release.outputs.mode != 'none'
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.parse_version.outputs.version }}
-          ARCHIVE: ${{ steps.build_xcframework.outputs.archive }}
-          CHECKSUM_FILE: ${{ steps.build_xcframework.outputs.checksum_file }}
-          PREBUILTS_VERSION_FILE: ${{ steps.build_xcframework.outputs.prebuilts_version_file }}
+          MODE: ${{ steps.release.outputs.mode }}
+          VERSION: ${{ steps.release.outputs.version }}
+          ARCHIVE: ${{ steps.xcframework.outputs.archive }}
+          CHECKSUM_FILE: ${{ steps.xcframework.outputs.checksum_file }}
+          PREBUILTS_VERSION_FILE: ${{ steps.xcframework.outputs.prebuilts_version_file }}
         run: |
-          gh release create "$VERSION" \
-            "$ARCHIVE" \
-            "$CHECKSUM_FILE" \
-            "$PREBUILTS_VERSION_FILE" \
+          assets=()
+          if [[ "$MODE" == native ]]; then
+            assets=("$ARCHIVE" "$CHECKSUM_FILE" "$PREBUILTS_VERSION_FILE")
+          fi
+
+          gh release create "$VERSION" "${assets[@]}" \
             --verify-tag \
             --title "$VERSION" \
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Resolve release
         id: release
         run: ci/resolve-release.sh
+        # Outputs: mode, version, native_version
 
       - name: Import GPG key
         if: steps.release.outputs.mode != 'none'

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,9 @@ let nativeTarget: PartoutNativeTarget
 if FileManager.default.fileExists(atPath: localNativeURL.path) {
     nativeTarget = .local
 } else {
-    nativeTarget = .remote("0.161.3", checksum: "dea8ebbc13999059afd1401e4efdefdc0b17f6529411d0904accc051664f486f")
+    let version = "0.161.3"
+    let checksum = "dea8ebbc13999059afd1401e4efdefdc0b17f6529411d0904accc051664f486f"
+    nativeTarget = .remote(version, checksum: checksum)
 }
 
 let partoutNative: Target = .partoutNative(nativeTarget)

--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,7 @@ let nativeTarget: PartoutNativeTarget
 if FileManager.default.fileExists(atPath: localNativeURL.path) {
     nativeTarget = .local
 } else {
-    let version = "0.161.3"
-    let checksum = "dea8ebbc13999059afd1401e4efdefdc0b17f6529411d0904accc051664f486f"
-    nativeTarget = .remote(version, checksum: checksum)
+    nativeTarget = .remote("0.161.3", checksum: "dea8ebbc13999059afd1401e4efdefdc0b17f6529411d0904accc051664f486f")
 }
 
 let partoutNative: Target = .partoutNative(nativeTarget)

--- a/ci/resolve-release.sh
+++ b/ci/resolve-release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+    echo "::error::$*" >&2
+    exit 1
+}
+
+[[ $# -eq 0 ]] || fail "usage: $0"
+[[ ${GITHUB_REF_TYPE:-} == branch && ${GITHUB_REF_NAME:-} == master ]] ||
+    fail "Releases must run from master"
+[[ -n ${GITHUB_OUTPUT:-} ]] || fail "GITHUB_OUTPUT is not set"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(cd "$script_dir/.." && pwd -P)
+cd "$repo_root"
+
+swift_version=$(sed -nE \
+    's/^[[:space:]]*public static let version = "([^"]+)"$/\1/p' \
+    cross/apple/Sources/PartoutCore/Version.swift)
+native_version=$(sed -nE \
+    's/^pub const number = "([^"]+)";$/\1/p' \
+    src/version.zig)
+artifact_version=$(sed -nE \
+    's/^[[:space:]]*nativeTarget = \.remote\("([^"]+)", checksum: "[0-9a-f]{64}"\)$/\1/p' \
+    Package.swift)
+
+for version in "$swift_version" "$native_version" "$artifact_version"; do
+    [[ $version =~ ^[0-9A-Za-z.+-]+$ ]] || fail "Invalid release version"
+done
+
+mode=swift
+if [[ $native_version != "$artifact_version" ]]; then
+    [[ $swift_version == "$native_version" ]] ||
+        fail "Native releases require matching Swift and native versions"
+    mode=native
+fi
+
+tag_status=0
+git ls-remote --exit-code --tags \
+    origin "refs/tags/$swift_version" >/dev/null 2>&1 || tag_status=$?
+if [[ $tag_status -eq 0 ]]; then
+    [[ ${GITHUB_EVENT_NAME:-} != workflow_dispatch ]] ||
+        fail "Tag $swift_version already exists"
+    echo "::notice::Tag $swift_version already exists; nothing to release"
+    mode=none
+elif [[ $tag_status -ne 2 ]]; then
+    fail "Unable to query tag $swift_version"
+fi
+
+echo "mode=$mode" >> "$GITHUB_OUTPUT"
+echo "version=$swift_version" >> "$GITHUB_OUTPUT"
+echo "native_version=$native_version" >> "$GITHUB_OUTPUT"

--- a/cross/apple/Sources/PartoutCore/Version.swift
+++ b/cross/apple/Sources/PartoutCore/Version.swift
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+extension PartoutCore {
+    /// The version of the Swift package. It may differ from the native runtime version.
+    public static let version = "0.161.3"
+}

--- a/scripts/bump-swift.sh
+++ b/scripts/bump-swift.sh
@@ -3,38 +3,28 @@
 set -euo pipefail
 
 fail() {
-    echo "bump.sh: $*" >&2
+    echo "bump-swift.sh: $*" >&2
     exit 1
 }
 
 version="${1:-}"
 [[ $# -eq 1 ]] || fail "usage: $0 <version>"
-
 [[ $version =~ ^[0-9A-Za-z.+-]+$ ]] || fail "invalid version: $version"
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-zig_constants="$root/src/version.zig"
 swift_constants="$root/cross/apple/Sources/PartoutCore/Version.swift"
-
-zig_pattern='^pub const number = "[^"]+";$'
-if [[ $(grep -Ec "$zig_pattern" "$zig_constants") -ne 1 ]]; then
-    fail "expected exactly one Zig version constant in $zig_constants"
-fi
-
 swift_pattern='^([[:space:]]*)public static let version = "[^"]+"$'
+
 if [[ $(grep -Ec "$swift_pattern" "$swift_constants") -ne 1 ]]; then
     fail "expected exactly one Swift version constant in $swift_constants"
 fi
 
-sed -i '' -E "s/$zig_pattern/pub const number = \"$version\";/" "$zig_constants"
 sed -i '' -E \
     "s/$swift_pattern/\\1public static let version = \"$version\"/" \
     "$swift_constants"
 
-grep -Fxq "pub const number = \"$version\";" "$zig_constants" ||
-    fail "failed to update $zig_constants"
 grep -Eq "^[[:space:]]*public static let version = \"$version\"$" \
     "$swift_constants" || fail "failed to update $swift_constants"
 
-git -C "$root" add "$zig_constants" "$swift_constants"
-git -C "$root" commit -m "Bump version"
+git -C "$root" add "$swift_constants"
+git -C "$root" commit -m "Bump Swift version"


### PR DESCRIPTION
If Swift code needs a patch without updating the Zig library, we should allow drifting of the Swift version. In that case, we make a new Swift-only release without generating new XCFramework artifacts.