### PR TITLE
OpenVPN/Zig: Improve parser tolerance

### DIFF
--- a/src/openvpn/internal/logging.zig
+++ b/src/openvpn/internal/logging.zig
@@ -207,19 +207,26 @@ pub fn pushReply(
     allocator: std.mem.Allocator,
     value: anytype,
 ) ![]const u8 {
+    return pushReplyString(allocator, value.original);
+}
+
+pub fn pushReplyString(
+    allocator: std.mem.Allocator,
+    string: []const u8,
+) ![]const u8 {
     const marker = "auth-token ";
-    const start = std.mem.indexOf(u8, value.original, marker) orelse
-        return allocator.dupe(u8, value.original);
-    const value_start = start + marker.len;
-    const value_end = std.mem.indexOfScalarPos(
+    const start = std.mem.indexOf(u8, string, marker) orelse
+        return allocator.dupe(u8, string);
+    const string_start = start + marker.len;
+    const string_end = std.mem.indexOfScalarPos(
         u8,
-        value.original,
-        value_start,
+        string,
+        string_start,
         ',',
-    ) orelse value.original.len;
+    ) orelse string.len;
     return std.mem.concat(allocator, u8, &.{
-        value.original[0..start],
+        string[0..start],
         "auth-token",
-        value.original[value_end..],
+        string[string_end..],
     });
 }

--- a/src/openvpn/internal/session_negotiator.zig
+++ b/src/openvpn/internal/session_negotiator.zig
@@ -13,6 +13,7 @@ const control_serializers_mod = @import("control_serializers.zig");
 const crypto_mod = @import("crypto.zig");
 const data_mod = @import("data.zig");
 const helpers_mod = @import("helpers.zig");
+const logging_mod = @import("logging.zig");
 const packet_mod = @import("packet.zig");
 const processing_mod = @import("processing.zig");
 const push_mod = @import("push.zig");
@@ -531,6 +532,15 @@ pub const Negotiator = struct {
         else
             try self.allocator.dupe(u8, message);
         defer self.allocator.free(complete_message);
+
+        const loggable_message = logging_mod.pushReplyString(
+            self.allocator,
+            complete_message,
+        ) catch null;
+        if (loggable_message) |value| {
+            defer self.allocator.free(value);
+            log.writef(.info, "Attempt to parse PUSH_REPLY: \"{s}\"", .{value});
+        }
 
         var reply = PushReply.parse(self.allocator, complete_message) catch |err| {
             if (err != error.ContinuationPushReply) return err;

--- a/src/openvpn/parser.zig
+++ b/src/openvpn/parser.zig
@@ -609,6 +609,9 @@ const Builder = struct {
         components: []const []const u8,
     ) ParseError!void {
         if (components.len < 2) return;
+        if (components.len > 3 and
+            std.ascii.eqlIgnoreCase(components[1], "remote_host") and
+            std.ascii.eqlIgnoreCase(components[3], "net_gateway")) return;
         const mask = if (components.len > 2) components[2] else "255.255.255.255";
         const prefix = ipv4MaskPrefix(mask) orelse return error.MalformedOption;
         const destination = try std.fmt.allocPrint(allocator, "{s}/{d}", .{ components[1], prefix });

--- a/src/openvpn/parser.zig
+++ b/src/openvpn/parser.zig
@@ -362,7 +362,7 @@ const Builder = struct {
         }
         if (std.ascii.eqlIgnoreCase(option, "cipher")) {
             if (components.items.len < 2) return error.MalformedOption;
-            self.legacy_cipher = util.parseRawIgnoreCase(api.OpenVPNCipher, components.items[1]) orelse return error.UnsupportedConfiguration;
+            self.legacy_cipher = util.parseRawIgnoreCase(api.OpenVPNCipher, components.items[1]);
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "data-ciphers") or std.ascii.eqlIgnoreCase(option, "ncp-ciphers")) {
@@ -372,18 +372,14 @@ const Builder = struct {
             while (ciphers.next()) |cipher| {
                 const is_optional = std.mem.startsWith(u8, cipher, "?");
                 const name = if (is_optional) cipher[1..] else cipher;
-                const parsed_cipher = util.parseRawIgnoreCase(api.OpenVPNCipher, name) orelse {
-                    if (is_optional) continue;
-                    return error.UnsupportedConfiguration;
-                };
+                const parsed_cipher = util.parseRawIgnoreCase(api.OpenVPNCipher, name) orelse continue;
                 try self.data_ciphers.append(allocator, parsed_cipher);
             }
-            if (self.data_ciphers.items.len == 0) return error.UnsupportedConfiguration;
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "data-ciphers-fallback")) {
             if (components.items.len < 2) return error.MalformedOption;
-            self.data_ciphers_fallback = util.parseRawIgnoreCase(api.OpenVPNCipher, components.items[1]) orelse return error.UnsupportedConfiguration;
+            self.data_ciphers_fallback = util.parseRawIgnoreCase(api.OpenVPNCipher, components.items[1]);
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "auth")) {
@@ -402,7 +398,7 @@ const Builder = struct {
         }
         if (std.ascii.eqlIgnoreCase(option, "compress")) {
             self.configuration.compression_framing = .compress;
-            if (components.items.len == 1) {
+            if (components.items.len != 2) {
                 self.configuration.compression_algorithm = .disabled;
             } else if (std.ascii.eqlIgnoreCase(components.items[1], "stub")) {
                 self.configuration.compression_algorithm = .disabled;
@@ -418,7 +414,7 @@ const Builder = struct {
         }
         if (std.ascii.eqlIgnoreCase(option, "key-direction")) {
             if (components.items.len == 2) {
-                self.tls_key_direction = parseDirection(components.items[1]) orelse return error.MalformedOption;
+                self.tls_key_direction = parseDirection(components.items[1]);
             }
             return;
         }
@@ -447,7 +443,8 @@ const Builder = struct {
         }
         if (std.ascii.eqlIgnoreCase(option, "port")) {
             if (components.items.len != 2) return error.MalformedOption;
-            self.default_port = std.fmt.parseInt(u16, components.items[1], 10) catch return error.MalformedOption;
+            if (std.fmt.parseInt(u16, components.items[1], 10) catch null) |port|
+                self.default_port = port;
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "remote")) {
@@ -478,7 +475,7 @@ const Builder = struct {
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "tun-mtu")) {
-            if (components.items.len == 2) self.configuration.mtu = std.fmt.parseInt(i32, components.items[1], 10) catch return error.MalformedOption;
+            if (components.items.len == 2) self.configuration.mtu = std.fmt.parseInt(i32, components.items[1], 10) catch null;
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "static-challenge")) {
@@ -490,7 +487,7 @@ const Builder = struct {
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "peer-id")) {
-            if (components.items.len == 2) self.configuration.peer_id = std.fmt.parseInt(u32, components.items[1], 10) catch return error.MalformedOption;
+            if (components.items.len == 2) self.configuration.peer_id = std.fmt.parseInt(u32, components.items[1], 10) catch null;
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "topology")) {
@@ -520,13 +517,21 @@ const Builder = struct {
         }
         if (std.ascii.eqlIgnoreCase(option, "route-gateway")) {
             if (components.items.len > 1) {
-                self.route_gateway4_argument_count = components.items.len - 1;
-                try replaceAddress(allocator, &self.configuration.route_gateway4, components.items[1]);
+                replaceAddress(allocator, &self.configuration.route_gateway4, components.items[1]) catch |err| switch (err) {
+                    error.MalformedOption => return,
+                    else => return err,
+                };
+                self.route_gateway4_argument_count = 1;
             }
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "route-ipv6-gateway")) {
-            if (components.items.len > 1) try replaceAddress(allocator, &self.configuration.route_gateway6, components.items[1]);
+            if (components.items.len > 1) {
+                replaceAddress(allocator, &self.configuration.route_gateway6, components.items[1]) catch |err| switch (err) {
+                    error.MalformedOption => return,
+                    else => return err,
+                };
+            }
             return;
         }
         if (std.ascii.eqlIgnoreCase(option, "dhcp-option")) {
@@ -619,7 +624,7 @@ const Builder = struct {
         var parsed_destination = (try api.Subnet.parseRawAlloc(allocator, destination)) orelse return error.MalformedOption;
         errdefer parsed_destination.deinit(allocator);
         var gateway = if (components.len > 3 and !std.ascii.eqlIgnoreCase(components[3], "vpn_gateway"))
-            (try api.Address.parseRawAlloc(allocator, components[3])) orelse return error.MalformedOption
+            try api.Address.parseRawAlloc(allocator, components[3])
         else
             null;
         errdefer if (gateway) |*value| value.deinit(allocator);
@@ -640,7 +645,7 @@ const Builder = struct {
         var destination = (try api.Subnet.parseRawAlloc(allocator, components[1])) orelse return error.MalformedOption;
         errdefer destination.deinit(allocator);
         var gateway = if (components.len > 2 and !std.ascii.eqlIgnoreCase(components[2], "vpn_gateway"))
-            (try api.Address.parseRawAlloc(allocator, components[2])) orelse return error.MalformedOption
+            try api.Address.parseRawAlloc(allocator, components[2])
         else
             null;
         errdefer if (gateway) |*value| value.deinit(allocator);
@@ -666,9 +671,10 @@ const Builder = struct {
             try util.appendOwned(allocator, &self.search_domains, components[2]);
         } else if (std.ascii.eqlIgnoreCase(key, "PROXY_HTTP") or std.ascii.eqlIgnoreCase(key, "PROXY_HTTPS")) {
             if (components.len != 4) return error.MalformedOption;
+            const port = std.fmt.parseInt(u16, components[3], 10) catch return;
             const endpoint = api.Endpoint{
                 .address = try allocator.dupe(u8, components[2]),
-                .port = std.fmt.parseInt(u16, components[3], 10) catch return error.MalformedOption,
+                .port = port,
                 .owned = true,
             };
             if (std.ascii.eqlIgnoreCase(key, "PROXY_HTTP")) {

--- a/src/openvpn/parser.zig
+++ b/src/openvpn/parser.zig
@@ -517,7 +517,7 @@ const Builder = struct {
         }
         if (std.ascii.eqlIgnoreCase(option, "route-gateway")) {
             if (components.items.len > 1) {
-                replaceAddress(allocator, &self.configuration.route_gateway4, components.items[1]) catch |err| switch (err) {
+                replaceIPAddress(allocator, &self.configuration.route_gateway4, components.items[1], .v4) catch |err| switch (err) {
                     error.MalformedOption => return,
                     else => return err,
                 };
@@ -527,7 +527,7 @@ const Builder = struct {
         }
         if (std.ascii.eqlIgnoreCase(option, "route-ipv6-gateway")) {
             if (components.items.len > 1) {
-                replaceAddress(allocator, &self.configuration.route_gateway6, components.items[1]) catch |err| switch (err) {
+                replaceIPAddress(allocator, &self.configuration.route_gateway6, components.items[1], .v6) catch |err| switch (err) {
                     error.MalformedOption => return,
                     else => return err,
                 };
@@ -623,10 +623,17 @@ const Builder = struct {
         defer allocator.free(destination);
         var parsed_destination = (try api.Subnet.parseRawAlloc(allocator, destination)) orelse return error.MalformedOption;
         errdefer parsed_destination.deinit(allocator);
-        var gateway = if (components.len > 3 and !std.ascii.eqlIgnoreCase(components[3], "vpn_gateway"))
-            try api.Address.parseRawAlloc(allocator, components[3])
-        else
-            null;
+        var gateway: ?api.Address = null;
+        if (components.len > 3 and !std.ascii.eqlIgnoreCase(components[3], "vpn_gateway")) {
+            var candidate = (try api.Address.parseRawAlloc(allocator, components[3])) orelse null;
+            if (candidate) |*value| {
+                if (value.family == .v4) {
+                    gateway = value.*;
+                } else {
+                    value.deinit(allocator);
+                }
+            }
+        }
         errdefer if (gateway) |*value| value.deinit(allocator);
         const route = api.Route{
             .destination = parsed_destination,
@@ -644,10 +651,17 @@ const Builder = struct {
         if (std.mem.indexOfScalar(u8, components[1], '/') == null) return error.MalformedOption;
         var destination = (try api.Subnet.parseRawAlloc(allocator, components[1])) orelse return error.MalformedOption;
         errdefer destination.deinit(allocator);
-        var gateway = if (components.len > 2 and !std.ascii.eqlIgnoreCase(components[2], "vpn_gateway"))
-            try api.Address.parseRawAlloc(allocator, components[2])
-        else
-            null;
+        var gateway: ?api.Address = null;
+        if (components.len > 2 and !std.ascii.eqlIgnoreCase(components[2], "vpn_gateway")) {
+            var candidate = (try api.Address.parseRawAlloc(allocator, components[2])) orelse null;
+            if (candidate) |*value| {
+                if (value.family == .v6) {
+                    gateway = value.*;
+                } else {
+                    value.deinit(allocator);
+                }
+            }
+        }
         errdefer if (gateway) |*value| value.deinit(allocator);
         const route = api.Route{
             .destination = destination,

--- a/tests/openvpn/internal/logging.zig
+++ b/tests/openvpn/internal/logging.zig
@@ -24,6 +24,17 @@ const CapturingLogger = struct {
     }
 };
 
+test "pushReplyString strips auth tokens" {
+    const allocator = std.testing.allocator;
+    const message = "PUSH_REPLY,ping 10,auth-token somethingsecret,cipher AES-256-GCM";
+    const loggable = try openvpn_logging.pushReplyString(allocator, message);
+    defer allocator.free(loggable);
+    try std.testing.expectEqualStrings(
+        "PUSH_REPLY,ping 10,auth-token,cipher AES-256-GCM",
+        loggable,
+    );
+}
+
 test "logConfiguration accepts empty sensitive strings" {
     const configuration = api.OpenVPNConfiguration{
         .checks_san_host = true,

--- a/tests/openvpn/internal/push.zig
+++ b/tests/openvpn/internal/push.zig
@@ -122,6 +122,38 @@ test "PUSH_REPLY parses routes and IPv6 DNS" {
     );
 }
 
+test "PUSH_REPLY ignores the remote host net gateway bypass route" {
+    const allocator = std.testing.allocator;
+    var reply = (try push.PushReply.parse(
+        allocator,
+        "PUSH_REPLY,route-gateway 10.242.0.1,sndbuf 0,rcvbuf 0,ping 45,ping-restart 180,route 192.168.138.0 255.255.255.0,route 192.168.20.0 255.255.255.0,route 192.168.10.0 255.255.255.0,route 10.100.11.0 255.255.255.0,topology subnet,route remote_host 255.255.255.255 net_gateway,dhcp-option DNS 192.168.138.253,dhcp-option DOMAIN sos.lan,ifconfig 10.242.128.101 255.255.0.0,peer-id 1,cipher AES-256-GCM",
+    )).?;
+    defer reply.deinit(allocator);
+
+    try std.testing.expectEqual(@as(?f64, 45), reply.options.keep_alive_interval);
+    try std.testing.expectEqual(@as(?f64, 180), reply.options.keep_alive_timeout);
+    try std.testing.expectEqualStrings("10.242.0.1", reply.options.route_gateway4.?.raw);
+    try std.testing.expectEqualStrings(
+        "10.242.128.101",
+        reply.options.ipv4.?.subnets[0].address.raw,
+    );
+    try std.testing.expectEqual(@as(u8, 16), reply.options.ipv4.?.subnets[0].prefix_length);
+    const expected_routes = [_][]const u8{
+        "192.168.138.0",
+        "192.168.20.0",
+        "192.168.10.0",
+        "10.100.11.0",
+    };
+    try std.testing.expectEqual(expected_routes.len, reply.options.routes4.?.len);
+    for (expected_routes, reply.options.routes4.?) |expected, route| {
+        try std.testing.expectEqualStrings(expected, route.destination.?.address.raw);
+    }
+    try std.testing.expectEqualStrings("192.168.138.253", reply.options.dns_servers.?[0]);
+    try std.testing.expectEqualStrings("sos.lan", reply.options.dns_domain.?);
+    try std.testing.expectEqual(@as(?u32, 1), reply.options.peer_id);
+    try std.testing.expectEqual(api.OpenVPNCipher.aes256gcm, reply.options.cipher.?);
+}
+
 test "PUSH_REPLY validates compression framing and algorithms" {
     const allocator = std.testing.allocator;
     var lzo = (try push.PushReply.parse(

--- a/tests/openvpn/parser.zig
+++ b/tests/openvpn/parser.zig
@@ -93,13 +93,23 @@ test "OpenVPNParser parses cipher and digest values case-insensitively" {
     defer fallback.deinit(allocator);
     try std.testing.expectEqual(api.OpenVPNCipher.aes192cbc, fallback.cipher.?);
 
-    try std.testing.expectError(
-        error.UnsupportedConfiguration,
-        OpenVPNParser.parse(
-            allocator,
-            "data-ciphers CHACHA20-POLY1305:aes-256-gcm",
-        ),
+    var with_unsupported = try OpenVPNParser.parse(
+        allocator,
+        "data-ciphers CHACHA20-POLY1305:aes-256-gcm",
     );
+    defer with_unsupported.deinit(allocator);
+    try std.testing.expectEqualSlices(
+        api.OpenVPNCipher,
+        &.{.aes256gcm},
+        with_unsupported.data_ciphers.?,
+    );
+
+    var unknown = try OpenVPNParser.parse(allocator,
+        \\cipher UNKNOWN
+        \\data-ciphers-fallback UNKNOWN
+    );
+    defer unknown.deinit(allocator);
+    try std.testing.expect(unknown.cipher == null);
 }
 
 test "OpenVPNParser follows OpenVPN optional data cipher semantics" {
@@ -127,14 +137,23 @@ test "OpenVPNParser follows OpenVPN optional data cipher semantics" {
         legacy_alias.data_ciphers.?,
     );
 
-    try std.testing.expectError(
-        error.UnsupportedConfiguration,
-        OpenVPNParser.parse(allocator, "data-ciphers CHACHA20-POLY1305:AES-256-GCM"),
+    var required_unknown = try OpenVPNParser.parse(
+        allocator,
+        "data-ciphers CHACHA20-POLY1305:AES-256-GCM",
     );
-    try std.testing.expectError(
-        error.UnsupportedConfiguration,
-        OpenVPNParser.parse(allocator, "data-ciphers ?CHACHA20-POLY1305:?BF-CBC"),
+    defer required_unknown.deinit(allocator);
+    try std.testing.expectEqualSlices(
+        api.OpenVPNCipher,
+        &.{.aes256gcm},
+        required_unknown.data_ciphers.?,
     );
+
+    var all_unknown = try OpenVPNParser.parse(
+        allocator,
+        "data-ciphers ?CHACHA20-POLY1305:?BF-CBC",
+    );
+    defer all_unknown.deinit(allocator);
+    try std.testing.expect(all_unknown.data_ciphers == null);
 }
 
 test "OpenVPNParser gives explicit data cipher fallback order-independent precedence" {
@@ -396,6 +415,39 @@ test "OpenVPNParser ignores incomplete route and gateway directives" {
     try std.testing.expect(configuration.routes6 == null);
     try std.testing.expect(configuration.route_gateway4 == null);
     try std.testing.expect(configuration.route_gateway6 == null);
+}
+
+test "OpenVPNParser ignores optional values Swift cannot convert" {
+    const allocator = std.testing.allocator;
+    var configuration = try OpenVPNParser.parse(allocator,
+        \\compress stub trailing
+        \\key-direction 2
+        \\port 99999
+        \\remote vpn.example.com
+        \\tun-mtu 999999999999999999999
+        \\peer-id 999999999999999999999
+        \\route 192.0.2.0 255.255.255.0 net_gateway
+        \\route-ipv6 2001:db8::/64 net_gateway
+        \\route-gateway dhcp trailing
+        \\route-ipv6-gateway net_gateway
+        \\dhcp-option PROXY_HTTP proxy.example 99999
+    );
+    defer configuration.deinit(allocator);
+
+    try std.testing.expectEqual(
+        api.OpenVPNCompressionAlgorithm.disabled,
+        configuration.compression_algorithm.?,
+    );
+    try std.testing.expectEqual(@as(u16, 1194), configuration.remotes.?[0].proto.port);
+    try std.testing.expect(configuration.mtu == null);
+    try std.testing.expect(configuration.peer_id == null);
+    try std.testing.expect(configuration.route_gateway4 == null);
+    try std.testing.expect(configuration.route_gateway6 == null);
+    try std.testing.expect(configuration.http_proxy == null);
+    try std.testing.expectEqual(@as(usize, 1), configuration.routes4.?.len);
+    try std.testing.expect(configuration.routes4.?[0].gateway == null);
+    try std.testing.expectEqual(@as(usize, 1), configuration.routes6.?.len);
+    try std.testing.expect(configuration.routes6.?[0].gateway == null);
 }
 
 test "OpenVPNParser builds subnet IPv4 and IPv6 settings from push directives" {


### PR DESCRIPTION
- Preserve the explicit remote_host … net_gateway ignore.
- Ignore unsupported cipher values as Swift does.
- Tolerate failed optional conversions for key direction, port, MTU, peer ID, and proxy port.
- Ignore symbolic/invalid route gateways and enforce IPv4/IPv6 families.
- Preserve fatal errors for genuinely unsupported options such as compression algorithms and digests.