### PR TITLE
ABI: Enrich payloads of import errors

### DIFF
--- a/cross/android/io/partout/abi/PartoutException.kt
+++ b/cross/android/io/partout/abi/PartoutException.kt
@@ -5,6 +5,8 @@
 package io.partout.abi
 
 import io.partout.models.ABIErrorPayload
+import io.partout.models.ParseErrorInfo
+import io.partout.models.PartoutErrorCode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -13,13 +15,25 @@ class PartoutException(
     val code: Int,
     json: JsonElement?
 ) : RuntimeException("ABI call failed (code=$code): $json") {
-    val payload: ABIErrorPayload?
+    val errorCode: PartoutErrorCode
+    val userInfo: JsonElement?
+    val arguments: List<String>
 
     init {
-        payload = json?.let {
+        val payload = json?.let {
             runCatching {
                 Json.decodeFromJsonElement<ABIErrorPayload>(json)
             }.getOrNull()
         }
+        errorCode = payload?.code ?: PartoutErrorCode.unhandled
+        userInfo = payload?.userInfo
+
+        // Best effort (should only succeed with import errors though)
+        arguments = userInfo?.let {
+            runCatching {
+                val info = Json.decodeFromJsonElement<ParseErrorInfo>(payload.userInfo)
+                info.arguments
+            }.getOrNull()
+        } ?: emptyList()
     }
 }

--- a/cross/android/io/partout/models/ParseErrorInfo.kt
+++ b/cross/android/io/partout/models/ParseErrorInfo.kt
@@ -23,6 +23,7 @@
 
 package io.partout.models
 
+import io.partout.models.PartoutErrorCode
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
@@ -31,21 +32,28 @@ import kotlinx.serialization.Contextual
 /**
  * 
  *
- * @param name 
- * @param details 
+ * @param arguments
+ * @param errorCode
+ * @param name
+ * @param line
  */
 @Serializable
 
 data class ParseErrorInfo (
 
-    @SerialName(value = "name")
-    val name: kotlin.String,
+    @SerialName(value = "arguments")
+    val arguments: kotlin.collections.List<kotlin.String>,
 
-    @SerialName(value = "details")
-    val details: kotlin.String
+    @Contextual @SerialName(value = "errorCode")
+    val errorCode: PartoutErrorCode? = null,
+
+    @SerialName(value = "name")
+    val name: kotlin.String? = null,
+
+    @SerialName(value = "line")
+    val line: kotlin.String? = null
 
 ) {
 
 
 }
-

--- a/cross/android/io/partout/models/PartoutErrorCode.kt
+++ b/cross/android/io/partout/models/PartoutErrorCode.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.Serializable
 /**
  * 
  *
- * Values: authentication,cached,crypto,decoding,dnsFailure,encoding,exhaustedEndpoints,fdUnavailable,incompatibleModules,incompleteModule,invalidField,invalidValue,ioFailure,keychainAddItem,keychainItemNotFound,linkNotActive,networkChanged,networkUnreachable,noActiveModules,nonFinalModules,notFound,openVPNCompressionMismatch,openVPNConnectionFailure,openVPNNoRouting,openVPNOTPRequired,openVPNPassphraseRequired,openVPNRecoverableAuthentication,openVPNServerShutdown,openVPNTLSFailure,openVPNUnsupportedAlgorithm,openVPNUnsupportedCompression,openVPNUnsupportedOption,operationCancelled,outOfMemory,parsing,passphraseRequired,releasedObject,requiredImplementation,scriptException,socketConfiguration,timeout,tunNotActive,tunNotAvailable,unexpectedModuleType,unhandled,unknownImportedModule,unknownModuleHandler,wireGuardEmptyPeers
+ * Values: authentication,cached,crypto,decoding,dnsFailure,encoding,exhaustedEndpoints,fdUnavailable,incompatibleModules,incompleteModule,invalidField,invalidValue,ioFailure,keychainAddItem,keychainItemNotFound,linkNotActive,networkChanged,networkUnreachable,noActiveModules,nonFinalModules,notFound,openVPNCompressionMismatch,openVPNConnectionFailure,openVPNNoRouting,openVPNOTPRequired,openVPNPassphraseRequired,openVPNRecoverableAuthentication,openVPNServerShutdown,openVPNTLSFailure,openVPNUnsupportedAlgorithm,openVPNUnsupportedCompression,openVPNUnsupportedOption,operationCancelled,outOfMemory,parsing,passphraseRequired,releasedObject,requiredImplementation,scriptException,socketConfiguration,timeout,tunNotActive,tunNotAvailable,unexpectedModuleType,unhandled,unknownImportedModule,unknownModuleHandler,wireGuardEmptyPeers,wireGuardInterfaceHasInvalidAddress,wireGuardInterfaceHasInvalidDNS,wireGuardInterfaceHasInvalidListenPort,wireGuardInterfaceHasInvalidMTU,wireGuardInterfaceHasInvalidPrivateKey,wireGuardInterfaceHasNoPrivateKey,wireGuardInterfaceHasUnrecognizedKey,wireGuardMultipleEntriesForKey,wireGuardMultipleInterfaces,wireGuardMultiplePeersWithSamePublicKey,wireGuardNoInterface,wireGuardPeerHasInvalidAllowedIP,wireGuardPeerHasInvalidEndpoint,wireGuardPeerHasInvalidPersistentKeepAlive,wireGuardPeerHasInvalidPreSharedKey,wireGuardPeerHasInvalidPublicKey,wireGuardPeerHasNoPublicKey,wireGuardPeerHasUnrecognizedKey
  */
 @Serializable
 enum class PartoutErrorCode(val value: kotlin.String) {
@@ -178,7 +178,61 @@ enum class PartoutErrorCode(val value: kotlin.String) {
     unknownModuleHandler("unknownModuleHandler"),
 
     @SerialName(value = "WireGuard.emptyPeers")
-    wireGuardEmptyPeers("WireGuard.emptyPeers");
+    wireGuardEmptyPeers("WireGuard.emptyPeers"),
+
+    @SerialName(value = "WireGuard.interfaceHasInvalidAddress")
+    wireGuardInterfaceHasInvalidAddress("WireGuard.interfaceHasInvalidAddress"),
+
+    @SerialName(value = "WireGuard.interfaceHasInvalidDNS")
+    wireGuardInterfaceHasInvalidDNS("WireGuard.interfaceHasInvalidDNS"),
+
+    @SerialName(value = "WireGuard.interfaceHasInvalidListenPort")
+    wireGuardInterfaceHasInvalidListenPort("WireGuard.interfaceHasInvalidListenPort"),
+
+    @SerialName(value = "WireGuard.interfaceHasInvalidMTU")
+    wireGuardInterfaceHasInvalidMTU("WireGuard.interfaceHasInvalidMTU"),
+
+    @SerialName(value = "WireGuard.interfaceHasInvalidPrivateKey")
+    wireGuardInterfaceHasInvalidPrivateKey("WireGuard.interfaceHasInvalidPrivateKey"),
+
+    @SerialName(value = "WireGuard.interfaceHasNoPrivateKey")
+    wireGuardInterfaceHasNoPrivateKey("WireGuard.interfaceHasNoPrivateKey"),
+
+    @SerialName(value = "WireGuard.interfaceHasUnrecognizedKey")
+    wireGuardInterfaceHasUnrecognizedKey("WireGuard.interfaceHasUnrecognizedKey"),
+
+    @SerialName(value = "WireGuard.multipleEntriesForKey")
+    wireGuardMultipleEntriesForKey("WireGuard.multipleEntriesForKey"),
+
+    @SerialName(value = "WireGuard.multipleInterfaces")
+    wireGuardMultipleInterfaces("WireGuard.multipleInterfaces"),
+
+    @SerialName(value = "WireGuard.multiplePeersWithSamePublicKey")
+    wireGuardMultiplePeersWithSamePublicKey("WireGuard.multiplePeersWithSamePublicKey"),
+
+    @SerialName(value = "WireGuard.noInterface")
+    wireGuardNoInterface("WireGuard.noInterface"),
+
+    @SerialName(value = "WireGuard.peerHasInvalidAllowedIP")
+    wireGuardPeerHasInvalidAllowedIP("WireGuard.peerHasInvalidAllowedIP"),
+
+    @SerialName(value = "WireGuard.peerHasInvalidEndpoint")
+    wireGuardPeerHasInvalidEndpoint("WireGuard.peerHasInvalidEndpoint"),
+
+    @SerialName(value = "WireGuard.peerHasInvalidPersistentKeepAlive")
+    wireGuardPeerHasInvalidPersistentKeepAlive("WireGuard.peerHasInvalidPersistentKeepAlive"),
+
+    @SerialName(value = "WireGuard.peerHasInvalidPreSharedKey")
+    wireGuardPeerHasInvalidPreSharedKey("WireGuard.peerHasInvalidPreSharedKey"),
+
+    @SerialName(value = "WireGuard.peerHasInvalidPublicKey")
+    wireGuardPeerHasInvalidPublicKey("WireGuard.peerHasInvalidPublicKey"),
+
+    @SerialName(value = "WireGuard.peerHasNoPublicKey")
+    wireGuardPeerHasNoPublicKey("WireGuard.peerHasNoPublicKey"),
+
+    @SerialName(value = "WireGuard.peerHasUnrecognizedKey")
+    wireGuardPeerHasUnrecognizedKey("WireGuard.peerHasUnrecognizedKey");
 
     /**
      * Override [toString()] to avoid using the enum variable name as the value, and instead use

--- a/cross/apple/Sources/PartoutCore/OpenAPI/Codegen/ParseErrorInfo.swift
+++ b/cross/apple/Sources/PartoutCore/OpenAPI/Codegen/ParseErrorInfo.swift
@@ -7,12 +7,16 @@
 
 public struct ParseErrorInfo: Sendable, Codable, Hashable {
 
-    public var name: String
-    public var details: String
+    public var errorCode: PartoutErrorCode?
+    public var name: String?
+    public var line: String?
+    public var arguments: [String]
 
-    public init(name: String, details: String) {
+    public init(errorCode: PartoutErrorCode? = nil, name: String? = nil, line: String? = nil, arguments: [String]) {
+        self.errorCode = errorCode
         self.name = name
-        self.details = details
+        self.line = line
+        self.arguments = arguments
     }
 }
 

--- a/cross/apple/Sources/PartoutCore/OpenAPI/Codegen/PartoutErrorCode.swift
+++ b/cross/apple/Sources/PartoutCore/OpenAPI/Codegen/PartoutErrorCode.swift
@@ -102,4 +102,40 @@ public enum PartoutErrorCode: String, Sendable, Codable, CaseIterable {
     case unknownModuleHandler = "unknownModuleHandler"
     /// Configuration has no peers.
     case wireGuardEmptyPeers = "WireGuard.emptyPeers"
+    /// WireGuard interface address is invalid.
+    case wireGuardInterfaceHasInvalidAddress = "WireGuard.interfaceHasInvalidAddress"
+    /// WireGuard interface DNS entry is invalid.
+    case wireGuardInterfaceHasInvalidDNS = "WireGuard.interfaceHasInvalidDNS"
+    /// WireGuard interface listen port is invalid.
+    case wireGuardInterfaceHasInvalidListenPort = "WireGuard.interfaceHasInvalidListenPort"
+    /// WireGuard interface MTU is invalid.
+    case wireGuardInterfaceHasInvalidMTU = "WireGuard.interfaceHasInvalidMTU"
+    /// WireGuard interface private key is invalid.
+    case wireGuardInterfaceHasInvalidPrivateKey = "WireGuard.interfaceHasInvalidPrivateKey"
+    /// WireGuard interface has no private key.
+    case wireGuardInterfaceHasNoPrivateKey = "WireGuard.interfaceHasNoPrivateKey"
+    /// WireGuard interface key is unrecognized.
+    case wireGuardInterfaceHasUnrecognizedKey = "WireGuard.interfaceHasUnrecognizedKey"
+    /// WireGuard key occurs more than once.
+    case wireGuardMultipleEntriesForKey = "WireGuard.multipleEntriesForKey"
+    /// WireGuard configuration has multiple interface sections.
+    case wireGuardMultipleInterfaces = "WireGuard.multipleInterfaces"
+    /// WireGuard configuration has multiple peers with the same public key.
+    case wireGuardMultiplePeersWithSamePublicKey = "WireGuard.multiplePeersWithSamePublicKey"
+    /// WireGuard configuration has no interface section.
+    case wireGuardNoInterface = "WireGuard.noInterface"
+    /// WireGuard peer allowed IP is invalid.
+    case wireGuardPeerHasInvalidAllowedIP = "WireGuard.peerHasInvalidAllowedIP"
+    /// WireGuard peer endpoint is invalid.
+    case wireGuardPeerHasInvalidEndpoint = "WireGuard.peerHasInvalidEndpoint"
+    /// WireGuard peer persistent keepalive is invalid.
+    case wireGuardPeerHasInvalidPersistentKeepAlive = "WireGuard.peerHasInvalidPersistentKeepAlive"
+    /// WireGuard peer pre-shared key is invalid.
+    case wireGuardPeerHasInvalidPreSharedKey = "WireGuard.peerHasInvalidPreSharedKey"
+    /// WireGuard peer public key is invalid.
+    case wireGuardPeerHasInvalidPublicKey = "WireGuard.peerHasInvalidPublicKey"
+    /// WireGuard peer has no public key.
+    case wireGuardPeerHasNoPublicKey = "WireGuard.peerHasNoPublicKey"
+    /// WireGuard peer key is unrecognized.
+    case wireGuardPeerHasUnrecognizedKey = "WireGuard.peerHasUnrecognizedKey"
 }

--- a/cross/apple/Sources/PartoutRuntime/PartoutImporter.swift
+++ b/cross/apple/Sources/PartoutRuntime/PartoutImporter.swift
@@ -6,21 +6,23 @@ public final class PartoutImporter: Sendable {
     public init() {}
 
     public func importModule(from url: URL) throws -> Module? {
+        let encoder = JSONEncoder.shared()
+        let decoder = JSONDecoder.shared()
         let text = try String(contentsOf: url, encoding: .utf8)
         guard let cJSON = partout_import_module(text) else { return nil }
         defer { free(cJSON) }
         let json = String(cString: cJSON)
         guard let jsonData = json.data(using: .utf8) else { return nil }
-        let envelope = try JSONDecoder.shared().decode(ABIEnvelope.self, from: jsonData)
-        let payloadData = try JSONEncoder.shared().encode(envelope.payload)
-        if envelope.code != 0 {
-            let payload = try JSONDecoder.shared().decode(ABIErrorPayload.self, from: payloadData)
+        let envelope = try decoder.decode(ABIEnvelope.self, from: jsonData)
+        let payloadData = try encoder.encode(envelope.payload)
+        guard envelope.code == 0 else {
+            let payload = try decoder.decode(ABIErrorPayload.self, from: payloadData)
             if let userInfo = payload.userInfo {
                 throw PartoutError(payload.code, userInfo)
             }
             throw PartoutError(payload.code)
         }
-        let tagged = try JSONDecoder.shared().decode(TaggedModule.self, from: payloadData)
+        let tagged = try decoder.decode(TaggedModule.self, from: payloadData)
         return tagged.containedModule
     }
 }

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -24,13 +24,18 @@ components:
     ParseErrorInfo:
       additionalProperties: false
       properties:
+        errorCode:
+          $ref: "#/components/schemas/PartoutErrorCode"
         name:
           type: string
-        details:
+        line:
           type: string
+        arguments:
+          items:
+            type: string
+          type: array
       required:
-        - name
-        - details
+        - arguments
       type: object
     Address:
       type: string
@@ -816,6 +821,24 @@ components:
         - unknownImportedModule
         - unknownModuleHandler
         - WireGuard.emptyPeers
+        - WireGuard.interfaceHasInvalidAddress
+        - WireGuard.interfaceHasInvalidDNS
+        - WireGuard.interfaceHasInvalidListenPort
+        - WireGuard.interfaceHasInvalidMTU
+        - WireGuard.interfaceHasInvalidPrivateKey
+        - WireGuard.interfaceHasNoPrivateKey
+        - WireGuard.interfaceHasUnrecognizedKey
+        - WireGuard.multipleEntriesForKey
+        - WireGuard.multipleInterfaces
+        - WireGuard.multiplePeersWithSamePublicKey
+        - WireGuard.noInterface
+        - WireGuard.peerHasInvalidAllowedIP
+        - WireGuard.peerHasInvalidEndpoint
+        - WireGuard.peerHasInvalidPersistentKeepAlive
+        - WireGuard.peerHasInvalidPreSharedKey
+        - WireGuard.peerHasInvalidPublicKey
+        - WireGuard.peerHasNoPublicKey
+        - WireGuard.peerHasUnrecognizedKey
       type: string
       x-enum-varnames:
         - authentication
@@ -866,6 +889,24 @@ components:
         - unknownImportedModule
         - unknownModuleHandler
         - wireGuardEmptyPeers
+        - wireGuardInterfaceHasInvalidAddress
+        - wireGuardInterfaceHasInvalidDNS
+        - wireGuardInterfaceHasInvalidListenPort
+        - wireGuardInterfaceHasInvalidMTU
+        - wireGuardInterfaceHasInvalidPrivateKey
+        - wireGuardInterfaceHasNoPrivateKey
+        - wireGuardInterfaceHasUnrecognizedKey
+        - wireGuardMultipleEntriesForKey
+        - wireGuardMultipleInterfaces
+        - wireGuardMultiplePeersWithSamePublicKey
+        - wireGuardNoInterface
+        - wireGuardPeerHasInvalidAllowedIP
+        - wireGuardPeerHasInvalidEndpoint
+        - wireGuardPeerHasInvalidPersistentKeepAlive
+        - wireGuardPeerHasInvalidPreSharedKey
+        - wireGuardPeerHasInvalidPublicKey
+        - wireGuardPeerHasNoPublicKey
+        - wireGuardPeerHasUnrecognizedKey
       x-enum-descriptions:
         - Authentication failure.
         - Response is cached.
@@ -915,6 +956,24 @@ components:
         - Module content is unknown for the importer.
         - Module handler is unknown.
         - Configuration has no peers.
+        - WireGuard interface address is invalid.
+        - WireGuard interface DNS entry is invalid.
+        - WireGuard interface listen port is invalid.
+        - WireGuard interface MTU is invalid.
+        - WireGuard interface private key is invalid.
+        - WireGuard interface has no private key.
+        - WireGuard interface key is unrecognized.
+        - WireGuard key occurs more than once.
+        - WireGuard configuration has multiple interface sections.
+        - WireGuard configuration has multiple peers with the same public key.
+        - WireGuard configuration has no interface section.
+        - WireGuard peer allowed IP is invalid.
+        - WireGuard peer endpoint is invalid.
+        - WireGuard peer persistent keepalive is invalid.
+        - WireGuard peer pre-shared key is invalid.
+        - WireGuard peer public key is invalid.
+        - WireGuard peer has no public key.
+        - WireGuard peer key is unrecognized.
     Profile:
       additionalProperties: false
       properties:

--- a/src/abi/helpers.zig
+++ b/src/abi/helpers.zig
@@ -143,8 +143,15 @@ fn errorPayloadWithInfoAllocZ(
     parse_error_info: ?*const api.ParseErrorInfo,
 ) ?[*:0]u8 {
     const user_info: ?api.JSONValue = if (parse_error_info) |info| user_info: {
-        if (info.name.len == 0 and info.details.len == 0) break :user_info null;
-        const bytes = util.encodeJsonValue(allocator, info.*) catch break :user_info null;
+        if (info.name == null and info.line == null and info.arguments.len == 0) break :user_info null;
+        // `error_code` is an internal handoff to ABIErrorPayload.code. Do not
+        // duplicate it inside ABIErrorPayload.userInfo.
+        const public_info: api.ParseErrorInfo = .{
+            .name = info.name,
+            .line = info.line,
+            .arguments = info.arguments,
+        };
+        const bytes = util.encodeJsonValue(allocator, public_info) catch break :user_info null;
         break :user_info .{
             .bytes = bytes,
             .owned = true,
@@ -166,7 +173,10 @@ pub fn importErrorPayloadAllocZ(
 ) ?[*:0]u8 {
     const payload = errorPayloadWithInfoAllocZ(
         allocator,
-        importErrorCode(err),
+        if (context.parse_error_info) |error_info|
+            error_info.error_code orelse importErrorCode(err)
+        else
+            importErrorCode(err),
         context.parse_error_info,
     );
     return wrapOwnedImportPayload(

--- a/src/core/api_generated.zig
+++ b/src/core/api_generated.zig
@@ -366,8 +366,10 @@ pub const ABIErrorPayload = struct {
 };
 
 pub const ParseErrorInfo = struct {
-    name: []const u8 = "",
-    details: []const u8 = "",
+    error_code: ?PartoutErrorCode = null,
+    name: ?[]const u8 = null,
+    line: ?[]const u8 = null,
+    arguments: []const []const u8 = &.{},
 
     pub fn parse(allocator: std.mem.Allocator, text: []const u8) DecodeError!ParseErrorInfo {
         return parseWithErrorInfo(allocator, text, null);
@@ -389,8 +391,10 @@ pub const ParseErrorInfo = struct {
         const object = objectValue(value) orelse return error.InvalidModel;
         var result = ParseErrorInfo{};
         errdefer result.deinit(allocator);
-        result.name = try parseJsonField([]const u8, allocator, object, "name", error_info);
-        result.details = try parseJsonField([]const u8, allocator, object, "details", error_info);
+        result.error_code = try parseOptionalJsonField(PartoutErrorCode, allocator, object, "errorCode", error_info);
+        result.name = try parseOptionalJsonField([]const u8, allocator, object, "name", error_info);
+        result.line = try parseOptionalJsonField([]const u8, allocator, object, "line", error_info);
+        result.arguments = try parseJsonField([]const []const u8, allocator, object, "arguments", error_info);
         return result;
     }
 
@@ -401,16 +405,28 @@ pub const ParseErrorInfo = struct {
     }
 
     pub fn deinit(self: *const @This(), allocator: std.mem.Allocator) void {
-        deinitJson([]const u8, allocator, &self.name);
-        deinitJson([]const u8, allocator, &self.details);
+        if (self.error_code) |*value| deinitJson(PartoutErrorCode, allocator, value);
+        if (self.name) |*value| deinitJson([]const u8, allocator, value);
+        if (self.line) |*value| deinitJson([]const u8, allocator, value);
+        deinitJson([]const []const u8, allocator, &self.arguments);
     }
 
     pub fn jsonStringify(self: @This(), jw: anytype) JsonStringifyError!void {
         try jw.beginObject();
-        try jw.objectField("name");
-        try writeJson(jw, self.name);
-        try jw.objectField("details");
-        try writeJson(jw, self.details);
+        if (self.error_code) |value| {
+            try jw.objectField("errorCode");
+            try writeJson(jw, value);
+        }
+        if (self.name) |value| {
+            try jw.objectField("name");
+            try writeJson(jw, value);
+        }
+        if (self.line) |value| {
+            try jw.objectField("line");
+            try writeJson(jw, value);
+        }
+        try jw.objectField("arguments");
+        try writeJson(jw, self.arguments);
         try jw.endObject();
     }
 };
@@ -2430,6 +2446,24 @@ pub const PartoutErrorCode = enum {
     unknownImportedModule,
     unknownModuleHandler,
     wireGuardEmptyPeers,
+    wireGuardInterfaceHasInvalidAddress,
+    wireGuardInterfaceHasInvalidDNS,
+    wireGuardInterfaceHasInvalidListenPort,
+    wireGuardInterfaceHasInvalidMTU,
+    wireGuardInterfaceHasInvalidPrivateKey,
+    wireGuardInterfaceHasNoPrivateKey,
+    wireGuardInterfaceHasUnrecognizedKey,
+    wireGuardMultipleEntriesForKey,
+    wireGuardMultipleInterfaces,
+    wireGuardMultiplePeersWithSamePublicKey,
+    wireGuardNoInterface,
+    wireGuardPeerHasInvalidAllowedIP,
+    wireGuardPeerHasInvalidEndpoint,
+    wireGuardPeerHasInvalidPersistentKeepAlive,
+    wireGuardPeerHasInvalidPreSharedKey,
+    wireGuardPeerHasInvalidPublicKey,
+    wireGuardPeerHasNoPublicKey,
+    wireGuardPeerHasUnrecognizedKey,
 
     pub fn parseValue(_: std.mem.Allocator, value: std.json.Value) DecodeError!@This() {
         const raw_value = stringValue(value) orelse return error.InvalidModel;
@@ -2485,6 +2519,24 @@ pub const PartoutErrorCode = enum {
         if (std.mem.eql(u8, raw_value, "unknownImportedModule")) return .unknownImportedModule;
         if (std.mem.eql(u8, raw_value, "unknownModuleHandler")) return .unknownModuleHandler;
         if (std.mem.eql(u8, raw_value, "WireGuard.emptyPeers")) return .wireGuardEmptyPeers;
+        if (std.mem.eql(u8, raw_value, "WireGuard.interfaceHasInvalidAddress")) return .wireGuardInterfaceHasInvalidAddress;
+        if (std.mem.eql(u8, raw_value, "WireGuard.interfaceHasInvalidDNS")) return .wireGuardInterfaceHasInvalidDNS;
+        if (std.mem.eql(u8, raw_value, "WireGuard.interfaceHasInvalidListenPort")) return .wireGuardInterfaceHasInvalidListenPort;
+        if (std.mem.eql(u8, raw_value, "WireGuard.interfaceHasInvalidMTU")) return .wireGuardInterfaceHasInvalidMTU;
+        if (std.mem.eql(u8, raw_value, "WireGuard.interfaceHasInvalidPrivateKey")) return .wireGuardInterfaceHasInvalidPrivateKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.interfaceHasNoPrivateKey")) return .wireGuardInterfaceHasNoPrivateKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.interfaceHasUnrecognizedKey")) return .wireGuardInterfaceHasUnrecognizedKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.multipleEntriesForKey")) return .wireGuardMultipleEntriesForKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.multipleInterfaces")) return .wireGuardMultipleInterfaces;
+        if (std.mem.eql(u8, raw_value, "WireGuard.multiplePeersWithSamePublicKey")) return .wireGuardMultiplePeersWithSamePublicKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.noInterface")) return .wireGuardNoInterface;
+        if (std.mem.eql(u8, raw_value, "WireGuard.peerHasInvalidAllowedIP")) return .wireGuardPeerHasInvalidAllowedIP;
+        if (std.mem.eql(u8, raw_value, "WireGuard.peerHasInvalidEndpoint")) return .wireGuardPeerHasInvalidEndpoint;
+        if (std.mem.eql(u8, raw_value, "WireGuard.peerHasInvalidPersistentKeepAlive")) return .wireGuardPeerHasInvalidPersistentKeepAlive;
+        if (std.mem.eql(u8, raw_value, "WireGuard.peerHasInvalidPreSharedKey")) return .wireGuardPeerHasInvalidPreSharedKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.peerHasInvalidPublicKey")) return .wireGuardPeerHasInvalidPublicKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.peerHasNoPublicKey")) return .wireGuardPeerHasNoPublicKey;
+        if (std.mem.eql(u8, raw_value, "WireGuard.peerHasUnrecognizedKey")) return .wireGuardPeerHasUnrecognizedKey;
         return null;
     }
 
@@ -2538,6 +2590,24 @@ pub const PartoutErrorCode = enum {
             .unknownImportedModule => "unknownImportedModule",
             .unknownModuleHandler => "unknownModuleHandler",
             .wireGuardEmptyPeers => "WireGuard.emptyPeers",
+            .wireGuardInterfaceHasInvalidAddress => "WireGuard.interfaceHasInvalidAddress",
+            .wireGuardInterfaceHasInvalidDNS => "WireGuard.interfaceHasInvalidDNS",
+            .wireGuardInterfaceHasInvalidListenPort => "WireGuard.interfaceHasInvalidListenPort",
+            .wireGuardInterfaceHasInvalidMTU => "WireGuard.interfaceHasInvalidMTU",
+            .wireGuardInterfaceHasInvalidPrivateKey => "WireGuard.interfaceHasInvalidPrivateKey",
+            .wireGuardInterfaceHasNoPrivateKey => "WireGuard.interfaceHasNoPrivateKey",
+            .wireGuardInterfaceHasUnrecognizedKey => "WireGuard.interfaceHasUnrecognizedKey",
+            .wireGuardMultipleEntriesForKey => "WireGuard.multipleEntriesForKey",
+            .wireGuardMultipleInterfaces => "WireGuard.multipleInterfaces",
+            .wireGuardMultiplePeersWithSamePublicKey => "WireGuard.multiplePeersWithSamePublicKey",
+            .wireGuardNoInterface => "WireGuard.noInterface",
+            .wireGuardPeerHasInvalidAllowedIP => "WireGuard.peerHasInvalidAllowedIP",
+            .wireGuardPeerHasInvalidEndpoint => "WireGuard.peerHasInvalidEndpoint",
+            .wireGuardPeerHasInvalidPersistentKeepAlive => "WireGuard.peerHasInvalidPersistentKeepAlive",
+            .wireGuardPeerHasInvalidPreSharedKey => "WireGuard.peerHasInvalidPreSharedKey",
+            .wireGuardPeerHasInvalidPublicKey => "WireGuard.peerHasInvalidPublicKey",
+            .wireGuardPeerHasNoPublicKey => "WireGuard.peerHasNoPublicKey",
+            .wireGuardPeerHasUnrecognizedKey => "WireGuard.peerHasUnrecognizedKey",
         };
     }
 

--- a/src/core/registry.zig
+++ b/src/core/registry.zig
@@ -205,9 +205,9 @@ pub const Registry = struct {
     /// Imports a tagged module by probing registered importers in order.
     ///
     /// `error.UnknownImportedModule` means an importer declined the input and
-    /// probing should continue. If no importer succeeds, the first concrete
-    /// importer error is returned; if every importer only declined, parsing
-    /// fails with `error.Parsing`.
+    /// probing should continue. Any other error means the importer recognized
+    /// the input, so it is returned immediately. If every importer declines,
+    /// parsing fails with `error.Parsing`.
     pub fn importModule(
         self: Registry,
         allocator: std.mem.Allocator,
@@ -215,23 +215,16 @@ pub const Registry = struct {
         context: ?ImportContext,
     ) ImportError!api.TaggedModule {
         var was_handled = false;
-        var first_error: ?ImportError = null;
 
         for (self.all_implementations) |impl| {
             if (impl.vtable.import_module == null) continue;
             was_handled = true;
             return impl.importModule(allocator, contents, context) catch |err| {
-                switch (err) {
-                    error.UnknownImportedModule => {},
-                    else => if (first_error == null) {
-                        first_error = err;
-                    },
-                }
+                if (err != error.UnknownImportedModule) return err;
                 continue;
             };
         }
 
-        if (first_error) |err| return err;
         if (!was_handled) return error.UnknownImportedModule;
         return error.Parsing;
     }

--- a/src/openvpn/parser.zig
+++ b/src/openvpn/parser.zig
@@ -30,10 +30,12 @@ pub fn importModule(
             error.InvalidFormat => error.UnknownImportedModule,
             error.EmptyPassphrase => {
                 setRecognizedType(context);
+                setImportErrorCode(context, err);
                 return error.PassphraseRequired;
             },
             else => {
                 setRecognizedType(context);
+                setImportErrorCode(context, err);
                 return error.Parsing;
             },
         };
@@ -41,10 +43,12 @@ pub fn importModule(
     setRecognizedType(context);
     if (!isCompleteClientConfiguration(&configuration)) {
         configuration.deinit(allocator);
+        setErrorCode(context, .parsing);
         return error.Parsing;
     }
     const module_id = core.newId() catch {
         configuration.deinit(allocator);
+        setErrorCode(context, .unhandled);
         return error.Parsing;
     };
     const module = api.TaggedModule{ .OpenVPN = .{
@@ -89,18 +93,18 @@ pub const Parser = struct {
             self: Context,
             allocator: std.mem.Allocator,
             name: []const u8,
-            details: []const u8,
+            line: []const u8,
         ) void {
             const info = self.parse_error_info orelse return;
-            if (info.name.len != 0 or info.details.len != 0) return;
-            const owned_name = allocator.dupe(u8, name) catch return;
-            const owned_details = allocator.dupe(u8, details) catch {
-                allocator.free(owned_name);
+            if (info.name != null or info.line != null or info.arguments.len != 0) return;
+            const owned_name = if (name.len > 0) allocator.dupe(u8, name) catch return else null;
+            const owned_line = if (line.len > 0) allocator.dupe(u8, line) catch {
+                if (owned_name) |value| allocator.free(value);
                 return;
-            };
+            } else null;
             info.* = .{
                 .name = owned_name,
-                .details = owned_details,
+                .line = owned_line,
             };
         }
     };
@@ -1163,6 +1167,26 @@ fn importParserContext(context: ?core.ImportContext) Parser.Context {
 fn setRecognizedType(context: ?core.ImportContext) void {
     const import_context = context orelse return;
     import_context.setRecognizedType(.OpenVPN);
+}
+
+fn setErrorCode(context: ?core.ImportContext, code: api.PartoutErrorCode) void {
+    const import_context = context orelse return;
+    const error_info = import_context.parse_error_info orelse return;
+    if (error_info.error_code == null) error_info.error_code = code;
+}
+
+fn setImportErrorCode(context: ?core.ImportContext, err: ParseError) void {
+    const code: api.PartoutErrorCode = switch (err) {
+        error.OutOfMemory => .outOfMemory,
+        error.ContinuationPushReply, error.MalformedOption => .parsing,
+        error.DecrypterRequired => .requiredImplementation,
+        error.EmptyPassphrase => .openVPNPassphraseRequired,
+        error.InvalidFormat => .unknownImportedModule,
+        error.UnableToDecrypt => .crypto,
+        error.UnsupportedCompression => .openVPNUnsupportedCompression,
+        error.UnsupportedConfiguration => .openVPNUnsupportedOption,
+    };
+    setErrorCode(context, code);
 }
 
 const known_openvpn_options = [_][]const u8{

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,2 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
 pub const identifier = "io.partout";
 pub const number = "0.161.5";

--- a/src/wireguard/parser.zig
+++ b/src/wireguard/parser.zig
@@ -22,6 +22,7 @@ pub fn importModule(
             error.InvalidLine => error.UnknownImportedModule,
             else => {
                 setRecognizedType(context);
+                setImportErrorCode(context, err);
                 return error.Parsing;
             },
         };
@@ -29,6 +30,7 @@ pub fn importModule(
     setRecognizedType(context);
     const module_id = core.newId() catch {
         configuration.deinit(allocator);
+        setErrorCode(context, .unhandled);
         return error.Parsing;
     };
     const module = api.TaggedModule{ .WireGuard = .{
@@ -46,18 +48,36 @@ pub const Parser = struct {
             self: Context,
             allocator: std.mem.Allocator,
             name: []const u8,
-            details: []const u8,
+            line: []const u8,
+            arguments: []const []const u8,
         ) void {
             const info = self.parse_error_info orelse return;
-            if (info.name.len != 0 or info.details.len != 0) return;
-            const owned_name = allocator.dupe(u8, name) catch return;
-            const owned_details = allocator.dupe(u8, details) catch {
-                allocator.free(owned_name);
+            if (info.name != null or info.line != null or info.arguments.len != 0) return;
+            const owned_name = if (name.len > 0) allocator.dupe(u8, name) catch return else null;
+            const owned_line = if (line.len > 0) allocator.dupe(u8, line) catch {
+                if (owned_name) |value| allocator.free(value);
+                return;
+            } else null;
+            const owned_arguments = allocator.alloc([]const u8, arguments.len) catch {
+                if (owned_line) |value| allocator.free(value);
+                if (owned_name) |value| allocator.free(value);
                 return;
             };
+            var initialized: usize = 0;
+            for (arguments, 0..) |argument, index| {
+                owned_arguments[index] = allocator.dupe(u8, argument) catch {
+                    for (owned_arguments[0..initialized]) |owned_argument| allocator.free(owned_argument);
+                    allocator.free(owned_arguments);
+                    if (owned_line) |owned| allocator.free(owned);
+                    if (owned_name) |owned| allocator.free(owned);
+                    return;
+                };
+                initialized += 1;
+            }
             info.* = .{
                 .name = owned_name,
-                .details = owned_details,
+                .line = owned_line,
+                .arguments = owned_arguments,
             };
         }
     };
@@ -88,7 +108,13 @@ pub const Parser = struct {
 
         var error_name: []const u8 = "";
         var error_line: []const u8 = "";
-        errdefer context.setParseErrorInfo(allocator, error_name, error_line);
+        var error_argument: ?[]const u8 = null;
+        errdefer context.setParseErrorInfo(
+            allocator,
+            error_name,
+            error_line,
+            if (error_argument) |argument| &.{argument} else &.{},
+        );
 
         var lines = std.mem.splitScalar(u8, contents, '\n');
         while (lines.next()) |raw_line| {
@@ -101,6 +127,7 @@ pub const Parser = struct {
 
             error_name = "";
             error_line = line;
+            error_argument = null;
 
             if (std.ascii.eqlIgnoreCase(line, "[interface]")) {
                 if (section == .peer) {
@@ -129,8 +156,14 @@ pub const Parser = struct {
 
             switch (section) {
                 .none => return error.InvalidLine,
-                .interface => try interface_builder.put(allocator, key, value),
-                .peer => try peer_builder.?.put(allocator, key, value),
+                .interface => interface_builder.put(allocator, key, value) catch |err| {
+                    error_argument = associatedArgument(err, key, value);
+                    return err;
+                },
+                .peer => peer_builder.?.put(allocator, key, value) catch |err| {
+                    error_argument = associatedArgument(err, key, value);
+                    return err;
+                },
             }
         }
 
@@ -162,6 +195,27 @@ pub const Parser = struct {
         try peers.append(allocator, peer);
     }
 };
+
+fn associatedArgument(err: ParseError, key: []const u8, value: []const u8) ?[]const u8 {
+    return switch (err) {
+        error.InterfaceHasUnrecognizedKey,
+        error.PeerHasUnrecognizedKey,
+        error.MultipleEntriesForKey,
+        => key,
+        error.InterfaceHasInvalidPrivateKey,
+        error.InterfaceHasInvalidListenPort,
+        error.InterfaceHasInvalidAddress,
+        error.InterfaceHasInvalidDNS,
+        error.InterfaceHasInvalidMTU,
+        error.PeerHasInvalidPublicKey,
+        error.PeerHasInvalidPreSharedKey,
+        error.PeerHasInvalidAllowedIP,
+        error.PeerHasInvalidEndpoint,
+        error.PeerHasInvalidPersistentKeepAlive,
+        => value,
+        else => null,
+    };
+}
 
 pub const ParseError = std.mem.Allocator.Error || error{
     InvalidLine,
@@ -508,4 +562,37 @@ fn importParserContext(context: ?core.ImportContext) Parser.Context {
 fn setRecognizedType(context: ?core.ImportContext) void {
     const import_context = context orelse return;
     import_context.setRecognizedType(.WireGuard);
+}
+
+fn setErrorCode(context: ?core.ImportContext, code: api.PartoutErrorCode) void {
+    const import_context = context orelse return;
+    const error_info = import_context.parse_error_info orelse return;
+    if (error_info.error_code == null) error_info.error_code = code;
+}
+
+fn setImportErrorCode(context: ?core.ImportContext, err: ParseError) void {
+    const code: api.PartoutErrorCode = switch (err) {
+        error.OutOfMemory => .outOfMemory,
+        error.InvalidLine => .parsing,
+        error.NoInterface => .wireGuardNoInterface,
+        error.MultipleInterfaces => .wireGuardMultipleInterfaces,
+        error.InterfaceHasNoPrivateKey => .wireGuardInterfaceHasNoPrivateKey,
+        error.InterfaceHasInvalidPrivateKey => .wireGuardInterfaceHasInvalidPrivateKey,
+        error.InterfaceHasInvalidListenPort => .wireGuardInterfaceHasInvalidListenPort,
+        error.InterfaceHasInvalidAddress => .wireGuardInterfaceHasInvalidAddress,
+        error.InterfaceHasInvalidDNS => .wireGuardInterfaceHasInvalidDNS,
+        error.InterfaceHasInvalidMTU => .wireGuardInterfaceHasInvalidMTU,
+        error.InterfaceHasUnrecognizedKey => .wireGuardInterfaceHasUnrecognizedKey,
+        error.PeerHasNoPublicKey => .wireGuardPeerHasNoPublicKey,
+        error.PeerHasInvalidPublicKey => .wireGuardPeerHasInvalidPublicKey,
+        error.PeerHasInvalidPreSharedKey => .wireGuardPeerHasInvalidPreSharedKey,
+        error.PeerHasInvalidAllowedIP => .wireGuardPeerHasInvalidAllowedIP,
+        error.PeerHasInvalidEndpoint => .wireGuardPeerHasInvalidEndpoint,
+        error.PeerHasInvalidPersistentKeepAlive => .wireGuardPeerHasInvalidPersistentKeepAlive,
+        error.PeerHasUnrecognizedKey => .wireGuardPeerHasUnrecognizedKey,
+        error.MultiplePeersWithSamePublicKey => .wireGuardMultiplePeersWithSamePublicKey,
+        error.MultipleEntriesForKey => .wireGuardMultipleEntriesForKey,
+        error.IdGeneration => .unhandled,
+    };
+    setErrorCode(context, code);
 }

--- a/tests/abi/helpers.zig
+++ b/tests/abi/helpers.zig
@@ -22,7 +22,8 @@ test "ABI import error payload includes parse error info" {
     const allocator = std.testing.allocator;
     var info: api.ParseErrorInfo = .{
         .name = "PrivateKey",
-        .details = "PrivateKey = nope",
+        .line = "PrivateKey = nope",
+        .arguments = &.{"nope"},
     };
     const context = core.ImportContext.init(&info, null, null);
 
@@ -40,8 +41,36 @@ test "ABI import error payload includes parse error info" {
 
     var parsed_info = try api.ParseErrorInfo.parse(allocator, payload.user_info.?.bytes);
     defer parsed_info.deinit(allocator);
-    try std.testing.expectEqualStrings("PrivateKey", parsed_info.name);
-    try std.testing.expectEqualStrings("PrivateKey = nope", parsed_info.details);
+    try std.testing.expectEqualStrings("PrivateKey", parsed_info.name.?);
+    try std.testing.expectEqualStrings("PrivateKey = nope", parsed_info.line.?);
+    try std.testing.expectEqual(@as(usize, 1), parsed_info.arguments.len);
+    try std.testing.expectEqualStrings("nope", parsed_info.arguments[0]);
+}
+
+test "ABI import error payload moves parse error code to top level" {
+    const allocator = std.testing.allocator;
+    var info: api.ParseErrorInfo = .{
+        .error_code = .wireGuardPeerHasNoPublicKey,
+        .line = "AllowedIPs = 0.0.0.0/0",
+    };
+    const context = core.ImportContext.init(&info, null, null);
+
+    const c_payload = helpers.importErrorPayloadAllocZ(
+        allocator,
+        error.InvalidProfile,
+        context,
+    ) orelse return error.TestUnexpectedResult;
+    const payload_json = std.mem.span(c_payload);
+    defer allocator.free(payload_json);
+
+    var payload = try parseErrorEnvelope(allocator, payload_json);
+    defer payload.deinit(allocator);
+    try std.testing.expectEqual(api.PartoutErrorCode.wireGuardPeerHasNoPublicKey, payload.code);
+
+    var parsed_info = try api.ParseErrorInfo.parse(allocator, payload.user_info.?.bytes);
+    defer parsed_info.deinit(allocator);
+    try std.testing.expect(parsed_info.error_code == null);
+    try std.testing.expect(std.mem.indexOf(u8, payload.user_info.?.bytes, "\"errorCode\"") == null);
 }
 
 test "ABI import errors map to stable public codes" {

--- a/tests/abi/importer.zig
+++ b/tests/abi/importer.zig
@@ -212,6 +212,24 @@ test "ABI importer preserves OpenVPN parse error codes" {
         api.PartoutErrorCode.openVPNUnsupportedCompression,
         profile_info.error_code.?,
     );
+
+    var passphrase_info: api.ParseErrorInfo = .{};
+    defer passphrase_info.deinit(allocator);
+    try std.testing.expectError(
+        error.PassphraseRequired,
+        importer.importModule(
+            allocator,
+            encrypted_openvpn_profile,
+            core.ImportContext.init(&passphrase_info, null, null),
+        ),
+    );
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.openVPNPassphraseRequired,
+        passphrase_info.error_code.?,
+    );
+    try std.testing.expect(passphrase_info.name == null);
+    try std.testing.expect(passphrase_info.line == null);
+    try std.testing.expectEqual(@as(usize, 0), passphrase_info.arguments.len);
 }
 
 test "profile import export returns normalized success and failure payloads" {
@@ -233,6 +251,12 @@ test "profile import export returns normalized success and failure payloads" {
         "code",
         "OpenVPN.unsupportedCompression",
     );
+    try expectImportEnvelope(
+        partout.partout_import_profile(encrypted_openvpn_profile, null),
+        -1,
+        "code",
+        "OpenVPN.passphraseRequired",
+    );
 }
 
 test "module import export returns normalized success and failure payloads" {
@@ -253,6 +277,12 @@ test "module import export returns normalized success and failure payloads" {
         -1,
         "code",
         "OpenVPN.unsupportedCompression",
+    );
+    try expectImportEnvelope(
+        partout.partout_import_module(encrypted_openvpn_profile),
+        -1,
+        "code",
+        "OpenVPN.passphraseRequired",
     );
 }
 
@@ -301,3 +331,14 @@ const invalid_wireguard_profile =
 ;
 
 const invalid_openvpn_profile = "compress lzo";
+
+const encrypted_openvpn_profile =
+    \\client
+    \\<key>
+    \\-----BEGIN PRIVATE KEY-----
+    \\Proc-Type: 4,ENCRYPTED
+    \\DEK-Info: AES-256-CBC,0123456789ABCDEF
+    \\ciphertext
+    \\-----END PRIVATE KEY-----
+    \\</key>
+;

--- a/tests/abi/importer.zig
+++ b/tests/abi/importer.zig
@@ -138,8 +138,14 @@ test "ABI importer reports parse error info for raw modules" {
             core.ImportContext.init(&info, null, null),
         ),
     );
-    try std.testing.expectEqualStrings("PrivateKey", info.name);
-    try std.testing.expectEqualStrings("PrivateKey = nope", info.details);
+    try std.testing.expectEqualStrings("PrivateKey", info.name.?);
+    try std.testing.expectEqualStrings("PrivateKey = nope", info.line.?);
+    try std.testing.expectEqual(@as(usize, 1), info.arguments.len);
+    try std.testing.expectEqualStrings("nope", info.arguments[0]);
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.wireGuardInterfaceHasInvalidPrivateKey,
+        info.error_code.?,
+    );
 }
 
 test "ABI importer reports parse error info for raw profiles" {
@@ -161,8 +167,51 @@ test "ABI importer reports parse error info for raw profiles" {
             core.ImportContext.init(&info, null, null),
         ),
     );
-    try std.testing.expectEqualStrings("PrivateKey", info.name);
-    try std.testing.expectEqualStrings("PrivateKey = nope", info.details);
+    try std.testing.expectEqualStrings("PrivateKey", info.name.?);
+    try std.testing.expectEqualStrings("PrivateKey = nope", info.line.?);
+    try std.testing.expectEqual(@as(usize, 1), info.arguments.len);
+    try std.testing.expectEqualStrings("nope", info.arguments[0]);
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.wireGuardInterfaceHasInvalidPrivateKey,
+        info.error_code.?,
+    );
+}
+
+test "ABI importer preserves OpenVPN parse error codes" {
+    const allocator = std.testing.allocator;
+
+    var importer = try Importer.init(allocator);
+    defer importer.deinit(allocator);
+    var module_info: api.ParseErrorInfo = .{};
+    defer module_info.deinit(allocator);
+    try std.testing.expectError(
+        error.Parsing,
+        importer.importModule(
+            allocator,
+            invalid_openvpn_profile,
+            core.ImportContext.init(&module_info, null, null),
+        ),
+    );
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.openVPNUnsupportedCompression,
+        module_info.error_code.?,
+    );
+
+    var profile_info: api.ParseErrorInfo = .{};
+    defer profile_info.deinit(allocator);
+    try std.testing.expectError(
+        error.InvalidProfile,
+        importer.importProfile(
+            allocator,
+            invalid_openvpn_profile,
+            null,
+            core.ImportContext.init(&profile_info, null, null),
+        ),
+    );
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.openVPNUnsupportedCompression,
+        profile_info.error_code.?,
+    );
 }
 
 test "profile import export returns normalized success and failure payloads" {
@@ -176,7 +225,13 @@ test "profile import export returns normalized success and failure payloads" {
         partout.partout_import_profile(invalid_wireguard_profile, null),
         -1,
         "code",
-        "decoding",
+        "WireGuard.peerHasNoPublicKey",
+    );
+    try expectImportEnvelope(
+        partout.partout_import_profile(invalid_openvpn_profile, null),
+        -1,
+        "code",
+        "OpenVPN.unsupportedCompression",
     );
 }
 
@@ -191,7 +246,13 @@ test "module import export returns normalized success and failure payloads" {
         partout.partout_import_module(invalid_wireguard_profile),
         -1,
         "code",
-        "parsing",
+        "WireGuard.peerHasNoPublicKey",
+    );
+    try expectImportEnvelope(
+        partout.partout_import_module(invalid_openvpn_profile),
+        -1,
+        "code",
+        "OpenVPN.unsupportedCompression",
     );
 }
 
@@ -234,5 +295,9 @@ const valid_wireguard_profile =
 
 const invalid_wireguard_profile =
     \\[Interface]
-    \\PrivateKey = nope
+    \\PrivateKey = 4hBza7JtPKZFKwqtEmDR0iZyru1kqpQta/DRduMbHQw=
+    \\[Peer]
+    \\AllowedIPs = 0.0.0.0/0
 ;
+
+const invalid_openvpn_profile = "compress lzo";

--- a/tests/core/registry.zig
+++ b/tests/core/registry.zig
@@ -328,12 +328,13 @@ test "registry preserves the first importer error" {
     try std.testing.expectError(error.Parsing, registry.importModule(allocator, "contents", null));
 }
 
-test "registry preserves recognized type from first concrete importer error" {
+test "registry stops after a concrete importer error" {
     const allocator = std.testing.allocator;
 
     const Mock = struct {
         module_type: api.ModuleType,
         err: ImportError,
+        called: bool = false,
 
         fn moduleType(ptr: ?*anyopaque) api.ModuleType {
             const self: *@This() = @ptrCast(@alignCast(ptr.?));
@@ -347,6 +348,7 @@ test "registry preserves recognized type from first concrete importer error" {
             context: ?ImportContext,
         ) ImportError!api.TaggedModule {
             const self: *@This() = @ptrCast(@alignCast(ptr.?));
+            self.called = true;
             if (self.err != error.UnknownImportedModule) {
                 if (context) |import_context| import_context.setRecognizedType(self.module_type);
             }
@@ -386,6 +388,8 @@ test "registry preserves recognized type from first concrete importer error" {
         ),
     );
     try std.testing.expectEqual(api.ModuleType.OpenVPN, recognized_type);
+    try std.testing.expect(failed.called);
+    try std.testing.expect(!ignored.called);
 }
 
 test "registry imports tagged profiles directly" {

--- a/tests/openvpn/exports.zig
+++ b/tests/openvpn/exports.zig
@@ -82,7 +82,7 @@ test "OpenVPN module importer requires CA and at least one remote" {
     );
 }
 
-test "OpenVPN module importer reports generic parse error info" {
+test "OpenVPN module importer reports public parse error code and info" {
     const allocator = std.testing.allocator;
 
     const module_implementation = exports.impl.module;
@@ -98,8 +98,36 @@ test "OpenVPN module importer reports generic parse error info" {
         ),
     );
 
-    try std.testing.expectEqualStrings("compress", info.name);
-    try std.testing.expectEqualStrings("compress lzo", info.details);
+    try std.testing.expectEqualStrings("compress", info.name.?);
+    try std.testing.expectEqualStrings("compress lzo", info.line.?);
+    try std.testing.expectEqual(@as(usize, 0), info.arguments.len);
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.openVPNUnsupportedCompression,
+        info.error_code.?,
+    );
+}
+
+test "OpenVPN module importer maps parser errors to public codes" {
+    const allocator = std.testing.allocator;
+    const module_implementation = exports.impl.module;
+    const cases = .{
+        .{ "cipher", api.PartoutErrorCode.parsing },
+        .{ "proto sctp", api.PartoutErrorCode.openVPNUnsupportedOption },
+    };
+
+    inline for (cases) |entry| {
+        var info: api.ParseErrorInfo = .{};
+        defer info.deinit(allocator);
+        try std.testing.expectError(
+            error.Parsing,
+            module_implementation.importModule(
+                allocator,
+                entry[0],
+                core.ImportContext.init(&info, null, null),
+            ),
+        );
+        try std.testing.expectEqual(entry[1], info.error_code.?);
+    }
 }
 
 test "OpenVPN module importer accepts protocol context pointer" {
@@ -136,17 +164,20 @@ test "OpenVPN module importer reports passphrase requirement" {
 
     const module_implementation = exports.impl.module;
     var recognized_type: api.ModuleType = undefined;
+    var info: api.ParseErrorInfo = .{};
+    defer info.deinit(allocator);
 
     try std.testing.expectError(
         error.PassphraseRequired,
         module_implementation.importModule(
             allocator,
             encrypted_key_configuration,
-            core.ImportContext.init(null, &recognized_type, null),
+            core.ImportContext.init(&info, &recognized_type, null),
         ),
     );
 
     try std.testing.expectEqual(api.ModuleType.OpenVPN, recognized_type);
+    try std.testing.expectEqual(api.PartoutErrorCode.openVPNPassphraseRequired, info.error_code.?);
 }
 
 test "OpenVPN module importer decrypts legacy PKCS#1 client keys" {

--- a/tests/openvpn/parser.zig
+++ b/tests/openvpn/parser.zig
@@ -668,7 +668,7 @@ fn expectParseErrorInfo(
     expected_err: anytype,
     contents: []const u8,
     expected_name: []const u8,
-    expected_details: []const u8,
+    expected_line: []const u8,
 ) !void {
     const allocator = std.testing.allocator;
     var info: api.ParseErrorInfo = .{};
@@ -680,8 +680,9 @@ fn expectParseErrorInfo(
             .parse_error_info = &info,
         }),
     );
-    try std.testing.expectEqualStrings(expected_name, info.name);
-    try std.testing.expectEqualStrings(expected_details, info.details);
+    try std.testing.expectEqualStrings(expected_name, info.name.?);
+    try std.testing.expectEqualStrings(expected_line, info.line.?);
+    try std.testing.expectEqual(@as(usize, 0), info.arguments.len);
 }
 
 fn failDecryptKey(

--- a/tests/wireguard/exports.zig
+++ b/tests/wireguard/exports.zig
@@ -48,7 +48,7 @@ test "WireGuard module exports import tagged module" {
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"searchDomains\":[\"example.com\"]") != null);
 }
 
-test "WireGuard module importer reports generic parse error info" {
+test "WireGuard module importer reports public parse error code and info" {
     const allocator = std.testing.allocator;
 
     const module_implementation = exports.impl.module;
@@ -66,6 +66,38 @@ test "WireGuard module importer reports generic parse error info" {
         ),
     );
 
-    try std.testing.expectEqualStrings("PrivateKey", info.name);
-    try std.testing.expectEqualStrings("PrivateKey = nope", info.details);
+    try std.testing.expectEqualStrings("PrivateKey", info.name.?);
+    try std.testing.expectEqualStrings("PrivateKey = nope", info.line.?);
+    try std.testing.expectEqual(@as(usize, 1), info.arguments.len);
+    try std.testing.expectEqualStrings("nope", info.arguments[0]);
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.wireGuardInterfaceHasInvalidPrivateKey,
+        info.error_code.?,
+    );
+}
+
+test "WireGuard module importer preserves PeerHasNoPublicKey" {
+    const allocator = std.testing.allocator;
+
+    const module_implementation = exports.impl.module;
+    var info: api.ParseErrorInfo = .{};
+    defer info.deinit(allocator);
+
+    try std.testing.expectError(
+        error.Parsing,
+        module_implementation.importModule(
+            allocator,
+            \\[Interface]
+            \\PrivateKey = 4hBza7JtPKZFKwqtEmDR0iZyru1kqpQta/DRduMbHQw=
+            \\[Peer]
+            \\AllowedIPs = 0.0.0.0/0
+        ,
+            core.ImportContext.init(&info, null, null),
+        ),
+    );
+
+    try std.testing.expectEqual(
+        api.PartoutErrorCode.wireGuardPeerHasNoPublicKey,
+        info.error_code.?,
+    );
 }

--- a/tests/wireguard/parser.zig
+++ b/tests/wireguard/parser.zig
@@ -42,8 +42,9 @@ test "WireGuardParser reports parse error info" {
     try expectParseErrorInfo(
         error.InvalidLine,
         "this is not wg",
-        "",
+        null,
         "this is not wg",
+        &.{},
     );
     try expectParseErrorInfo(
         error.InterfaceHasInvalidPrivateKey,
@@ -52,6 +53,7 @@ test "WireGuardParser reports parse error info" {
     ,
         "PrivateKey",
         "PrivateKey = nope",
+        &.{"nope"},
     );
     try expectParseErrorInfo(
         error.InterfaceHasInvalidListenPort,
@@ -61,6 +63,7 @@ test "WireGuardParser reports parse error info" {
     ,
         "ListenPort",
         "ListenPort = nope",
+        &.{"nope"},
     );
     try expectParseErrorInfo(
         error.PeerHasInvalidAllowedIP,
@@ -73,6 +76,7 @@ test "WireGuardParser reports parse error info" {
     ,
         "AllowedIPs",
         "AllowedIPs = nope",
+        &.{"nope"},
     );
     try expectParseErrorInfo(
         error.PeerHasUnrecognizedKey,
@@ -85,6 +89,18 @@ test "WireGuardParser reports parse error info" {
     ,
         "Bogus",
         "Bogus = yep",
+        &.{"Bogus"},
+    );
+    try expectParseErrorInfo(
+        error.MultipleEntriesForKey,
+        \\[Interface]
+        \\PrivateKey = 4hBza7JtPKZFKwqtEmDR0iZyru1kqpQta/DRduMbHQw=
+        \\ListenPort = 51820
+        \\ListenPort = 12345
+    ,
+        "ListenPort",
+        "ListenPort = 12345",
+        &.{"ListenPort"},
     );
     try expectParseErrorInfo(
         error.MultipleInterfaces,
@@ -92,8 +108,9 @@ test "WireGuardParser reports parse error info" {
         \\PrivateKey = 4hBza7JtPKZFKwqtEmDR0iZyru1kqpQta/DRduMbHQw=
         \\[Interface]
     ,
-        "",
+        null,
         "[Interface]",
+        &.{},
     );
     try expectParseErrorInfo(
         error.PeerHasNoPublicKey,
@@ -104,6 +121,7 @@ test "WireGuardParser reports parse error info" {
     ,
         "AllowedIPs",
         "AllowedIPs = 0.0.0.0/0",
+        &.{},
     );
 }
 
@@ -218,8 +236,9 @@ test "WireGuardParser matches sections and keys case-insensitively" {
 fn expectParseErrorInfo(
     expected_err: anyerror,
     contents: []const u8,
-    expected_name: []const u8,
-    expected_line: []const u8,
+    expected_name: ?[]const u8,
+    expected_line: ?[]const u8,
+    expected_arguments: []const []const u8,
 ) !void {
     const allocator = std.testing.allocator;
     var info: api.ParseErrorInfo = .{};
@@ -231,6 +250,18 @@ fn expectParseErrorInfo(
             .parse_error_info = &info,
         }),
     );
-    try std.testing.expectEqualStrings(expected_name, info.name);
-    try std.testing.expectEqualStrings(expected_line, info.details);
+    if (expected_name) |expected| {
+        try std.testing.expectEqualStrings(expected, info.name.?);
+    } else {
+        try std.testing.expect(info.name == null);
+    }
+    if (expected_line) |expected| {
+        try std.testing.expectEqualStrings(expected, info.line.?);
+    } else {
+        try std.testing.expect(info.line == null);
+    }
+    try std.testing.expectEqual(expected_arguments.len, info.arguments.len);
+    for (expected_arguments, info.arguments) |expected, actual| {
+        try std.testing.expectEqualStrings(expected, actual);
+    }
 }


### PR DESCRIPTION
- Stop at the first meaningful module error (!= UnknownImportedModule), i.e., if at least one module implementation recognized the format
- Add specific WireGuard parsing error codes
- Attach arguments to ParseErrorInfo (propagate to ABI error userInfo)
- Android: Remodel PartoutException to carry actionable data