### PR TITLE
Android: Add logger context and logcat tag

### DIFF
--- a/cross/android/io/partout/PartoutVpnServiceRuntime.kt
+++ b/cross/android/io/partout/PartoutVpnServiceRuntime.kt
@@ -44,6 +44,7 @@ class PartoutVpnServiceRuntime(
     // Execute actions in serial queue
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
+    private var isPartoutInitialized = false
     private var isRunning = false
     private var activeProfileId: String? = null
 
@@ -126,6 +127,7 @@ class PartoutVpnServiceRuntime(
             stopService()
             return@launchCommand
         }
+        initializePartoutIfNeeded(startOptions.logsPrivateData)
 
         // Observe snapshots during start attempt
         snapshotEmitter.accept(
@@ -145,7 +147,6 @@ class PartoutVpnServiceRuntime(
                 startOptions.controllerOptions
             )
             val code = withContext(Dispatchers.IO) {
-                wrapper.partoutInit(logTag, startOptions.logsPrivateData)
                 wrapper.partoutDaemonStart(
                     profileJSON,
                     service.cacheDir.absolutePath,
@@ -205,6 +206,12 @@ class PartoutVpnServiceRuntime(
 
     private fun decodeProfileId(profileJSON: String): String {
         return json.decodeFromString<TaggedProfile>(profileJSON).id
+    }
+
+    private fun initializePartoutIfNeeded(logsPrivateData: Boolean) {
+        if (isPartoutInitialized) return
+        wrapper.partoutInit(logTag, logsPrivateData)
+        isPartoutInitialized = true
     }
 
     private suspend fun stopTunnel() {

--- a/cross/android/io/partout/PartoutWrapper.kt
+++ b/cross/android/io/partout/PartoutWrapper.kt
@@ -63,7 +63,10 @@ class PartoutWrapper(
     //endregion
 
     //region ABI
-    override external fun partoutInit(tag: String, logsPrivateData: Boolean)
+    override external fun partoutInit(
+        tag: String,
+        logsPrivateData: Boolean
+    )
     override external fun partoutVersion(): String
     override external fun partoutImportProfile(
         text: String,

--- a/cross/android/io/partout/PartoutWrapper.kt
+++ b/cross/android/io/partout/PartoutWrapper.kt
@@ -6,7 +6,6 @@ package io.partout
 
 import io.partout.abi.PartoutResult
 import io.partout.models.ABIEnvelope
-import io.partout.models.CryptoBackend
 import io.partout.models.PartoutErrorCode
 import io.partout.models.TaggedProfile
 import kotlinx.serialization.json.Json

--- a/cross/apple/Demo/Tunnel/PacketTunnelProvider.swift
+++ b/cross/apple/Demo/Tunnel/PacketTunnelProvider.swift
@@ -90,9 +90,11 @@ private extension PacketTunnelProvider {
 }
 
 private nonisolated func logger(
+    _ ctx: UnsafeMutableRawPointer?,
     _ level: Int32,
     _ message: UnsafePointer<CChar>?
 ) {
+    _ = ctx
     guard let level = DebugLog.Level(rawValue: Int(level)),
           let message else { return }
     pp_log_g(.abi, level, String(cString: message))

--- a/cross/apple/Sources/PartoutRuntime/PartoutProviderRuntime.swift
+++ b/cross/apple/Sources/PartoutRuntime/PartoutProviderRuntime.swift
@@ -56,6 +56,7 @@ public final class PartoutProviderRuntime: Sendable {
 
         var init_args = partout_init_args(
             logs_private_data: logsPrivateData,
+            logger_ctx: nil,
             logger: logger
         )
         pp_log(ctx, .runtime, .info, "Initialize Partout library")

--- a/src/core/logging.zig
+++ b/src/core/logging.zig
@@ -20,6 +20,7 @@ pub const Level = enum(c_int) {
 };
 
 const Logger = *const fn (
+    ctx: ?*anyopaque,
     level: c_int,
     message: [*:0]const u8,
 ) callconv(.c) void;
@@ -31,6 +32,7 @@ pub const Callback = ?Logger;
 
 var mutex: concurrency.Mutex = .{};
 var logs_private_data: bool = false;
+var external_logger_ctx: ?*anyopaque = null;
 var external_logger: Callback = null;
 
 /// C ABI entry point used by foreign callers to forward a log message.
@@ -43,8 +45,9 @@ fn partoutLog(
         mutex.unlock();
         return;
     };
+    const logger_ctx = external_logger_ctx;
     mutex.unlock();
-    dispatchCString(logger, level, message);
+    dispatchCString(logger, logger_ctx, level, message);
 }
 
 comptime {
@@ -59,11 +62,13 @@ comptime {
 /// Passing a null `logger` disables logging.
 pub fn init(
     private_data: bool,
+    logger_ctx: ?*anyopaque,
     logger: Callback,
 ) void {
     mutex.lock();
     defer mutex.unlock();
     logs_private_data = private_data;
+    external_logger_ctx = logger_ctx;
     external_logger = logger;
 }
 
@@ -72,6 +77,7 @@ pub fn deinit() void {
     mutex.lock();
     defer mutex.unlock();
     logs_private_data = false;
+    external_logger_ctx = null;
     external_logger = null;
 }
 
@@ -103,8 +109,9 @@ pub fn write(level: Level, message: [:0]const u8) void {
         mutex.unlock();
         return;
     };
+    const logger_ctx = external_logger_ctx;
     mutex.unlock();
-    dispatchSlice(logger, @intFromEnum(level), message);
+    dispatchSlice(logger, logger_ctx, @intFromEnum(level), message);
 }
 
 /// Formats and writes a core log message.
@@ -120,6 +127,7 @@ pub fn writef(level: Level, comptime fmt: []const u8, args: anytype) void {
         mutex.unlock();
         return;
     };
+    const logger_ctx = external_logger_ctx;
     mutex.unlock();
     var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
     defer arena.deinit();
@@ -130,7 +138,7 @@ pub fn writef(level: Level, comptime fmt: []const u8, args: anytype) void {
         private_data,
     ) catch return;
     const message = std.fmt.allocPrintSentinel(allocator, fmt, prepared, 0) catch return;
-    dispatchSlice(logger, @intFromEnum(level), message);
+    dispatchSlice(logger, logger_ctx, @intFromEnum(level), message);
 }
 
 /// Forwards a borrowed C string directly to the configured C logger.
@@ -140,8 +148,9 @@ pub fn writeCString(level: Level, message: [*:0]const u8) void {
         mutex.unlock();
         return;
     };
+    const logger_ctx = external_logger_ctx;
     mutex.unlock();
-    dispatchCString(logger, @intFromEnum(level), message);
+    dispatchCString(logger, logger_ctx, @intFromEnum(level), message);
 }
 
 /// Logs a profile using the structured layout of the legacy Apple runtime.
@@ -193,18 +202,20 @@ pub fn writefAndFailDebug(comptime fmt: []const u8, args: anytype) void {
 
 fn dispatchSlice(
     logger: Logger,
+    logger_ctx: ?*anyopaque,
     level: c_int,
     message: [:0]const u8,
 ) void {
-    dispatchCString(logger, level, message.ptr);
+    dispatchCString(logger, logger_ctx, level, message.ptr);
 }
 
 fn dispatchCString(
     logger: Logger,
+    logger_ctx: ?*anyopaque,
     level: c_int,
     message: [*:0]const u8,
 ) void {
-    logger(level, message);
+    logger(logger_ctx, level, message);
 }
 
 fn writeProfileModule(

--- a/src/partout.h
+++ b/src/partout.h
@@ -26,9 +26,10 @@ typedef enum {
     PartoutLogLevelInfo,
     PartoutLogLevelDebug
 } partout_log_level;
-typedef void (*partout_logger_cb)(int level, const char *message);
+typedef void (*partout_logger_cb)(void *ctx, int level, const char *message);
 typedef struct {
     bool logs_private_data;
+    void *logger_ctx;
     partout_logger_cb logger;
 } partout_init_args;
 void partout_init(const partout_init_args *args);

--- a/src/partout.zig
+++ b/src/partout.zig
@@ -74,7 +74,7 @@ pub export fn partout_version() callconv(.c) [*:0]const u8 {
 
 pub export fn partout_init(args_pointer: ?*const partout_c.partout_init_args) callconv(.c) void {
     const args = args_pointer orelse return;
-    log.init(args.logs_private_data, args.logger);
+    log.init(args.logs_private_data, args.logger_ctx, args.logger);
 }
 
 pub export fn partout_readfile(

--- a/src/partout_jni.c
+++ b/src/partout_jni.c
@@ -16,7 +16,7 @@
 static void daemon_bindings_free(partout_daemon_bindings *b);
 
 static void android_logger(void *ctx, int level, const char *message) {
-    (void)ctx;
+    const char *tag = ctx ? (const char *)ctx : "Partout";
     int android_level = 0;
     switch (level) {
         case PartoutLogLevelDebug:
@@ -35,7 +35,7 @@ static void android_logger(void *ctx, int level, const char *message) {
             android_level = ANDROID_LOG_FATAL;
             break;
     }
-    __android_log_print(android_level, "Partout", "%s", message);
+    __android_log_print(android_level, tag, "%s", message);
 }
 
 JNIEXPORT void JNICALL
@@ -49,9 +49,14 @@ Java_io_partout_PartoutWrapper_partoutInit(
     partout_init_args args = { 0 };
     const char *cTag = (*env)->GetStringUTFChars(env, tag, NULL);
     args.logs_private_data = logs_private_data;
+    args.logger_ctx = (void *)cTag;
     args.logger = android_logger;
     partout_init(&args);
-    (*env)->ReleaseStringUTFChars(env, tag, cTag);
+    // XXX: The tag must outlive the call, so we agree on leaking
+    // this tiny allocation once. It's acceptable compared to
+    // ensuring a more complex lifetime, because there's no clear
+    // partout_deinit() counterpart to deallocate the tag.
+    // (*env)->ReleaseStringUTFChars(env, tag, cTag);
 }
 
 JNIEXPORT jstring JNICALL

--- a/src/partout_jni.c
+++ b/src/partout_jni.c
@@ -47,16 +47,18 @@ Java_io_partout_PartoutWrapper_partoutInit(
 ) {
     (void)thiz;
     partout_init_args args = { 0 };
-    const char *cTag = (*env)->GetStringUTFChars(env, tag, NULL);
+    const char *jni_tag = (*env)->GetStringUTFChars(env, tag, NULL);
+    char *c_tag = jni_tag ? strdup(jni_tag) : NULL;
     args.logs_private_data = logs_private_data;
-    args.logger_ctx = (void *)cTag;
+    args.logger_ctx = (void *)c_tag;
     args.logger = android_logger;
     partout_init(&args);
+    if (jni_tag) (*env)->ReleaseStringUTFChars(env, tag, jni_tag);
     // XXX: The tag must outlive the call, so we agree on leaking
     // this tiny allocation once. It's acceptable compared to
     // ensuring a more complex lifetime, because there's no clear
     // partout_deinit() counterpart to deallocate the tag.
-    // (*env)->ReleaseStringUTFChars(env, tag, cTag);
+    // free(c_tag);
 }
 
 JNIEXPORT jstring JNICALL
@@ -74,15 +76,15 @@ Java_io_partout_PartoutWrapper_partoutImportProfile(
         jstring name
 ) {
     (void)thiz;
-    const char *cText = (*env)->GetStringUTFChars(env, text, NULL);
-    const char *cName = name ? (*env)->GetStringUTFChars(env, name, NULL) : NULL;
-    char *json = partout_import_profile(cText, cName);
-    (*env)->ReleaseStringUTFChars(env, text, cText);
-    if (cName) (*env)->ReleaseStringUTFChars(env, name, cName);
+    const char *jni_text = (*env)->GetStringUTFChars(env, text, NULL);
+    const char *jni_name = name ? (*env)->GetStringUTFChars(env, name, NULL) : NULL;
+    char *json = partout_import_profile(jni_text, jni_name);
+    (*env)->ReleaseStringUTFChars(env, text, jni_text);
+    if (jni_name) (*env)->ReleaseStringUTFChars(env, name, jni_name);
 
-    jstring jJSON = json ? (*env)->NewStringUTF(env, json) : NULL;
+    jstring j_json = json ? (*env)->NewStringUTF(env, json) : NULL;
     free(json);
-    return jJSON;
+    return j_json;
 }
 
 JNIEXPORT jint JNICALL
@@ -96,25 +98,25 @@ Java_io_partout_PartoutWrapper_partoutDaemonStart(
         jint cryptoBackend
 ) {
     (void) thiz;
-    const char *cProfile = (*env)->GetStringUTFChars(env, profile, NULL);
-    const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
+    const char *jni_profile = (*env)->GetStringUTFChars(env, profile, NULL);
+    const char *jni_cache_dir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
     partout_daemon_bindings bindings = {0};
     bindings.controller = (*env)->NewGlobalRef(env, controller);
     bindings.release = daemon_bindings_free;
 
     partout_daemon_start_args args = {0};
-    args.profile = cProfile;
+    args.profile = jni_profile;
     args.options.is_daemon = false;
     args.options.cancels_unrecoverable = true;
-    args.options.cache_dir = cCacheDir;
+    args.options.cache_dir = jni_cache_dir;
     args.options.min_data_count_delta = minDataCountDelta;
     args.options.crypto = cryptoBackend;
     args.bindings = &bindings;
     const jint result = partout_daemon_start(&args);
 
-    (*env)->ReleaseStringUTFChars(env, profile, cProfile);
-    (*env)->ReleaseStringUTFChars(env, cacheDir, cCacheDir);
+    (*env)->ReleaseStringUTFChars(env, profile, jni_profile);
+    (*env)->ReleaseStringUTFChars(env, cacheDir, jni_cache_dir);
     return result;
 }
 

--- a/src/partout_jni.c
+++ b/src/partout_jni.c
@@ -15,7 +15,8 @@
 #define PARTOUT_JNI_CB(e, c) PARTOUT_CB(abi_completion_proxy, abi_handler_create(e, c))
 static void daemon_bindings_free(partout_daemon_bindings *b);
 
-static void android_logger(int level, const char *message) {
+static void android_logger(void *ctx, int level, const char *message) {
+    (void)ctx;
     int android_level = 0;
     switch (level) {
         case PartoutLogLevelDebug:

--- a/tests/abi/helpers.zig
+++ b/tests/abi/helpers.zig
@@ -14,7 +14,8 @@ const InitArgs = partout_c.partout_init_args;
 
 test "ABI structs stay C-sized" {
     try std.testing.expect(@offsetOf(InitArgs, "logs_private_data") == 0);
-    try std.testing.expect(@offsetOf(InitArgs, "logger") == @sizeOf(?*anyopaque));
+    try std.testing.expect(@offsetOf(InitArgs, "logger_ctx") == @sizeOf(?*anyopaque));
+    try std.testing.expect(@offsetOf(InitArgs, "logger") == 2 * @sizeOf(?*anyopaque));
     try std.testing.expect(@sizeOf(CompletionCode) == @sizeOf(c_int));
 }
 

--- a/tests/core/api.zig
+++ b/tests/core/api.zig
@@ -18,7 +18,7 @@ const CapturingLogger = struct {
     var message: [256]u8 = undefined;
     var message_len: usize = 0;
 
-    fn log(new_level: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+    fn log(_: ?*anyopaque, new_level: c_int, raw_message: [*:0]const u8) callconv(.c) void {
         const value = std.mem.span(raw_message);
         level = new_level;
         message_len = @min(value.len, message.len);
@@ -76,7 +76,7 @@ test "unavailable crypto backend logs and falls back to default" {
     const fallback = api.defaultCryptoBackend();
     const expected = try api.cryptoFunctionTable(fallback);
 
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     defer logging.deinit();
     const actual = try api.cryptoFunctionTable(requested);
 

--- a/tests/core/logging.zig
+++ b/tests/core/logging.zig
@@ -15,7 +15,7 @@ const CapturingLogger = struct {
         message_len = 0;
     }
 
-    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+    fn log(_: ?*anyopaque, _: c_int, raw_message: [*:0]const u8) callconv(.c) void {
         const value = std.mem.span(raw_message);
         message_len = @min(value.len, message.len);
         @memcpy(message[0..message_len], value[0..message_len]);
@@ -33,7 +33,7 @@ const ReplacementLogger = struct {
         called = false;
     }
 
-    fn log(_: c_int, _: [*:0]const u8) callconv(.c) void {
+    fn log(_: ?*anyopaque, _: c_int, _: [*:0]const u8) callconv(.c) void {
         called = true;
     }
 };
@@ -53,7 +53,7 @@ const ProfileLogger = struct {
         saw_active_on_demand = false;
     }
 
-    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+    fn log(_: ?*anyopaque, _: c_int, raw_message: [*:0]const u8) callconv(.c) void {
         const message = std.mem.span(raw_message);
         saw_id = saw_id or std.mem.eql(
             u8,
@@ -80,50 +80,54 @@ const ReconfiguringValue = struct {
         allocator: std.mem.Allocator,
         _: ReconfiguringValue,
     ) ![]const u8 {
-        logging.init(false, ReplacementLogger.log);
+        logging.init(false, null, ReplacementLogger.log);
         return allocator.dupe(u8, "secret");
     }
 };
 
 test "private data flag round-trips" {
-    logging.init(true, null);
+    logging.init(true, null, null);
     defer logging.deinit();
     try std.testing.expect(logging.logsPrivateData());
 }
 
 test "logging is disabled without callback" {
-    logging.init(false, null);
+    logging.init(false, null, null);
     defer logging.deinit();
     try std.testing.expect(!logging.hasLogger());
     logging.write(.notice, "ignored");
 }
 
-test "external logger callback receives log messages" {
+test "external logger callback receives context and log messages" {
     const TestLogger = struct {
         var called = false;
         var saw_level = false;
         var saw_message = false;
 
-        fn log(level: c_int, message: [*:0]const u8) callconv(.c) void {
+        fn log(ctx: ?*anyopaque, level: c_int, message: [*:0]const u8) callconv(.c) void {
             called = true;
+            const saw_context: *bool = @ptrCast(@alignCast(ctx.?));
+            saw_context.* = true;
             saw_level = level == @intFromEnum(logging.Level.notice);
             saw_message = std.mem.eql(u8, std.mem.span(message), "hello");
         }
     };
 
-    logging.init(false, TestLogger.log);
+    var saw_context = false;
+    logging.init(false, &saw_context, TestLogger.log);
     defer logging.deinit();
 
     logging.write(.notice, "hello");
 
     try std.testing.expect(TestLogger.called);
+    try std.testing.expect(saw_context);
     try std.testing.expect(TestLogger.saw_level);
     try std.testing.expect(TestLogger.saw_message);
 }
 
 test "profile modules log active and inactive prefixes" {
     ProfileLogger.reset();
-    logging.init(false, ProfileLogger.log);
+    logging.init(false, null, ProfileLogger.log);
     defer logging.deinit();
 
     const wireguard_id = api.UUID{
@@ -162,13 +166,13 @@ test "sentinel log messages cross the C callback without copying" {
     const TestLogger = struct {
         var message_address: usize = 0;
 
-        fn log(_: c_int, message: [*:0]const u8) callconv(.c) void {
+        fn log(_: ?*anyopaque, _: c_int, message: [*:0]const u8) callconv(.c) void {
             message_address = @intFromPtr(message);
         }
     };
 
     const message: [:0]const u8 = "borrowed";
-    logging.init(false, TestLogger.log);
+    logging.init(false, null, TestLogger.log);
     defer logging.deinit();
 
     logging.write(.notice, message);
@@ -180,13 +184,13 @@ test "C log messages are forwarded without scanning or copying" {
     const TestLogger = struct {
         var message_address: usize = 0;
 
-        fn log(_: c_int, message: [*:0]const u8) callconv(.c) void {
+        fn log(_: ?*anyopaque, _: c_int, message: [*:0]const u8) callconv(.c) void {
             message_address = @intFromPtr(message);
         }
     };
 
     const message: [:0]const u8 = "borrowed";
-    logging.init(false, TestLogger.log);
+    logging.init(false, null, TestLogger.log);
     defer logging.deinit();
 
     logging.writeCString(.notice, message.ptr);
@@ -196,7 +200,7 @@ test "C log messages are forwarded without scanning or copying" {
 
 test "duration helpers log compact time representations" {
     CapturingLogger.reset();
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     defer logging.deinit();
 
     logging.logTimeSeconds(.debug, "Elapsed: ", 3661);
@@ -214,7 +218,7 @@ test "duration helpers log compact time representations" {
 
 test "writef automatically redacts registered argument types" {
     CapturingLogger.reset();
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     defer logging.deinit();
 
     const endpoint = api.Endpoint{
@@ -253,7 +257,7 @@ test "writef automatically redacts registered argument types" {
         CapturingLogger.lastMessage(),
     );
 
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     logging.writef(.notice, "Public: {d}, endpoint: {s}", .{
         42,
         endpoint,
@@ -282,11 +286,11 @@ test "writef automatically redacts registered argument types" {
 
 test "sensitive values use the policy captured by writef" {
     CapturingLogger.reset();
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     defer logging.deinit();
 
     const marked_while_private = logging.sensitive("example.com");
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     logging.writef(.debug, "DNS resolved {s}", .{marked_while_private});
     try std.testing.expectEqualStrings(
         "DNS resolved <redacted>",
@@ -294,7 +298,7 @@ test "sensitive values use the policy captured by writef" {
     );
 
     const marked_while_redacted = logging.sensitive("example.com");
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     logging.writef(.debug, "DNS resolved {s}", .{marked_while_redacted});
     try std.testing.expectEqualStrings(
         "DNS resolved example.com",
@@ -305,7 +309,7 @@ test "sensitive values use the policy captured by writef" {
 test "writef dispatches with the same state used to prepare arguments" {
     CapturingLogger.reset();
     ReplacementLogger.reset();
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     defer logging.deinit();
 
     logging.writef(.debug, "{s}", .{ReconfiguringValue{}});
@@ -319,7 +323,7 @@ test "writef dispatches with the same state used to prepare arguments" {
 
 test "writef infers array and dictionary debug representations" {
     CapturingLogger.reset();
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     defer logging.deinit();
 
     const endpoints = [_]api.Endpoint{
@@ -351,7 +355,7 @@ test "writef infers array and dictionary debug representations" {
         CapturingLogger.lastMessage(),
     );
 
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     logging.writef(.notice, "Array: {s}", .{&endpoints});
     try std.testing.expectEqualStrings(
         "Array: <redacted>",
@@ -361,7 +365,7 @@ test "writef infers array and dictionary debug representations" {
 
 test "writef recognizes generated sensitive models without generated methods" {
     CapturingLogger.reset();
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     defer logging.deinit();
 
     const subnets = [_]api.Subnet{api.Subnet.parseRaw("10.0.0.2/24").?};
@@ -372,7 +376,7 @@ test "writef recognizes generated sensitive models without generated methods" {
         CapturingLogger.lastMessage(),
     );
 
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     logging.writef(.notice, "Settings: {s}", .{settings});
     try std.testing.expectEqualStrings(
         "Settings: <redacted>",
@@ -390,7 +394,7 @@ test "writef recognizes generated sensitive models without generated methods" {
         CapturingLogger.lastMessage(),
     );
 
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     logging.writef(.notice, "Credentials: {s}", .{credentials});
     try std.testing.expect(std.mem.indexOf(
         u8,

--- a/tests/net/platform_dns.zig
+++ b/tests/net/platform_dns.zig
@@ -15,7 +15,7 @@ const CapturingLogger = struct {
     var message: [256]u8 = undefined;
     var message_len: usize = 0;
 
-    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+    fn log(_: ?*anyopaque, _: c_int, raw_message: [*:0]const u8) callconv(.c) void {
         const value = std.mem.span(raw_message);
         message_len = @min(value.len, message.len);
         @memcpy(message[0..message_len], value[0..message_len]);
@@ -44,7 +44,7 @@ test "DNS resolver times out and caps abandoned queries" {
     const allocator = std.testing.allocator;
     const max_pending_queries = platform_dns.testing.maxPendingQueries;
     var dns = PlatformDNS.init();
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     defer logging.deinit();
     HangingResolver.release.store(false, .release);
     defer {

--- a/tests/openvpn/internal/logging.zig
+++ b/tests/openvpn/internal/logging.zig
@@ -13,7 +13,7 @@ const CapturingLogger = struct {
     var message: [512]u8 = undefined;
     var message_len: usize = 0;
 
-    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+    fn log(_: ?*anyopaque, _: c_int, raw_message: [*:0]const u8) callconv(.c) void {
         const value = std.mem.span(raw_message);
         message_len = @min(value.len, message.len);
         @memcpy(message[0..message_len], value[0..message_len]);
@@ -27,7 +27,7 @@ const CapturingLogger = struct {
 test "pushReplyString redacts auth tokens unless private logging is enabled" {
     const allocator = std.testing.allocator;
     const message = "PUSH_REPLY,ping 10,auth-token somethingsecret,cipher AES-256-GCM";
-    logging.init(false, null);
+    logging.init(false, null, null);
     defer logging.deinit();
 
     const loggable = try openvpn_logging.pushReplyString(allocator, message);
@@ -37,7 +37,7 @@ test "pushReplyString redacts auth tokens unless private logging is enabled" {
         loggable,
     );
 
-    logging.init(true, null);
+    logging.init(true, null, null);
     const private_loggable = try openvpn_logging.pushReplyString(allocator, message);
     defer allocator.free(private_loggable);
     try std.testing.expectEqualStrings(message, private_loggable);
@@ -50,7 +50,7 @@ test "logConfiguration accepts empty sensitive strings" {
         .dns_domain = "",
         .proxy_auto_configuration_url = "",
     };
-    logging.init(false, null);
+    logging.init(false, null, null);
     defer logging.deinit();
 
     openvpn_logging.logConfiguration(&configuration, true);
@@ -61,7 +61,7 @@ test "logConfiguration formats route collections as strings" {
         .{ .destination = api.Subnet.parseRaw("10.0.0.0/24").? },
     };
     const configuration = api.OpenVPNConfiguration{ .routes4 = &routes };
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     defer logging.deinit();
 
     openvpn_logging.logConfiguration(&configuration, false);
@@ -70,7 +70,7 @@ test "logConfiguration formats route collections as strings" {
         CapturingLogger.lastMessage(),
     );
 
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     openvpn_logging.logConfiguration(&configuration, false);
     try std.testing.expectEqualStrings(
         "\tRoutes (IPv4): [{\"destination\":\"10.0.0.0/24\"}]",

--- a/tests/openvpn/internal/push.zig
+++ b/tests/openvpn/internal/push.zig
@@ -13,7 +13,7 @@ const CapturingLogger = struct {
     var message: [512]u8 = undefined;
     var message_len: usize = 0;
 
-    fn log(_: c_int, raw_message: [*:0]const u8) callconv(.c) void {
+    fn log(_: ?*anyopaque, _: c_int, raw_message: [*:0]const u8) callconv(.c) void {
         const value = std.mem.span(raw_message);
         message_len = @min(value.len, message.len);
         @memcpy(message[0..message_len], value[0..message_len]);
@@ -238,7 +238,7 @@ test "writef formats PUSH_REPLY according to the private logging policy" {
         "PUSH_REPLY,ping 10,auth-token somethingsecret,cipher AES-256-GCM",
     )).?;
     defer reply.deinit(allocator);
-    logging.init(true, CapturingLogger.log);
+    logging.init(true, null, CapturingLogger.log);
     defer logging.deinit();
 
     logging.writef(.info, "{s}", .{reply});
@@ -248,7 +248,7 @@ test "writef formats PUSH_REPLY according to the private logging policy" {
         CapturingLogger.lastMessage(),
     );
 
-    logging.init(false, CapturingLogger.log);
+    logging.init(false, null, CapturingLogger.log);
     logging.writef(.info, "{s}", .{reply});
     try std.testing.expectEqualStrings(
         "<redacted>",


### PR DESCRIPTION
Also, initialize Partout at most once per service because the log tag is intentionally leaked for simplicity.